### PR TITLE
Support batching input in our neighbor loader

### DIFF
--- a/python/gigl/distributed/distributed_neighborloader.py
+++ b/python/gigl/distributed/distributed_neighborloader.py
@@ -58,6 +58,8 @@ class DistNeighborLoader(DistLoader):
         channel_size: str = "4GB",
         process_start_gap_seconds: int = 60,
         num_cpu_threads: Optional[int] = None,
+        shuffle: bool = False,
+        drop_last: bool = False,
         _main_inference_port: int = DEFAULT_MASTER_INFERENCE_PORT,
         _main_sampling_port: int = DEFAULT_MASTER_SAMPLING_PORT,
     ):
@@ -105,6 +107,8 @@ class DistNeighborLoader(DistLoader):
             num_cpu_threads (Optional[int]): Number of cpu threads PyTorch should use for CPU training/inference
                 neighbor loading; on top of the per process parallelism.
                 Defaults to `2` if set to `None` when using cpu training/inference.
+            shuffle (bool): Whether to shuffle the input nodes. (default: ``False``).
+            drop_last (bool): Whether to drop the last incomplete batch. (default: ``False``).
             _main_inference_port (int): WARNING: You don't need to configure this unless port conflict issues. Slotted for refactor.
                 The port number to use for inference processes.
                 In future, the port will be automatically assigned based on availability.
@@ -200,8 +204,8 @@ class DistNeighborLoader(DistLoader):
             sampling_type=SamplingType.NODE,
             num_neighbors=num_neighbors,
             batch_size=batch_size,
-            shuffle=False,
-            drop_last=False,
+            shuffle=shuffle,
+            drop_last=drop_last,
             with_edge=True,
             collect_features=True,
             with_neg=False,

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -6,15 +6,25 @@ import graphlearn_torch as glt
 import torch
 import torch.distributed.rpc
 from torch.multiprocessing import Manager
+from torch.testing import assert_close
 from torch_geometric.data import Data, HeteroData
 
 from gigl.distributed.dist_context import DistributedContext
 from gigl.distributed.dist_link_prediction_dataset import DistLinkPredictionDataset
 from gigl.distributed.distributed_neighborloader import DistNeighborLoader
-from gigl.src.common.types.graph_data import NodeType
+from gigl.src.common.types.graph_data import EdgeType, NodeType
 from gigl.src.mocking.mocking_assets.mocked_datasets_for_pipeline_tests import (
     CORA_NODE_ANCHOR_MOCKED_DATASET_INFO,
     DBLP_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
+)
+from gigl.types.graph import (
+    DEFAULT_HOMOGENEOUS_EDGE_TYPE,
+    DEFAULT_HOMOGENEOUS_NODE_TYPE,
+    NEGATIVE_LABEL_RELATION,
+    POSITIVE_LABEL_RELATION,
+    GraphPartitionData,
+    PartitionOutput,
+    to_heterogeneous_node,
 )
 from tests.test_assets.distributed.run_distributed_dataset import (
     run_distributed_dataset,
@@ -65,6 +75,56 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
         # Cora has 2708 nodes, make sure we go over all of them.
         # https://paperswithcode.com/dataset/cora
         self.assertEqual(count, 2708)
+
+    def test_distributed_neighbor_loader_batched(self):
+        nt = DEFAULT_HOMOGENEOUS_NODE_TYPE
+        positive_edge = EdgeType(nt, POSITIVE_LABEL_RELATION, nt)
+        negative_edge = EdgeType(nt, NEGATIVE_LABEL_RELATION, nt)
+        edge_index = {
+            DEFAULT_HOMOGENEOUS_EDGE_TYPE: torch.tensor(
+                [
+                    [10, 10, 11, 11, 12, 12, 13, 13],
+                    [11, 12, 12, 13, 14, 11, 14, 11],
+                ]
+            ),
+        }
+        po = PartitionOutput(
+            node_partition_book=to_heterogeneous_node(torch.zeros(14)),
+            edge_partition_book={
+                DEFAULT_HOMOGENEOUS_EDGE_TYPE: torch.zeros(6),
+                positive_edge: torch.zeros(3),
+                negative_edge: torch.zeros(3),
+            },
+            partitioned_edge_index={
+                etype: GraphPartitionData(
+                    edge_index=idx, edge_ids=torch.arange(idx.size(1))
+                )
+                for etype, idx in edge_index.items()
+            },
+            partitioned_edge_features=None,
+            partitioned_node_features=None,
+            partitioned_negative_labels=None,
+            partitioned_positive_labels=None,
+        )
+        dataset = DistLinkPredictionDataset(rank=0, world_size=1, edge_dir="out")
+        dataset.build(partition_output=po)
+
+        loader = DistNeighborLoader(
+            dataset=dataset,
+            num_neighbors=[2],
+            input_nodes=(nt, torch.tensor([[10, 12]])),
+            context=self._context,
+            local_process_rank=0,
+            local_process_world_size=1,
+        )
+        count = 0
+        for datum in loader:
+            self.assertIsInstance(datum, HeteroData)
+            count += 1
+
+        self.assertEqual(count, 1)
+        assert_close(datum[nt].node.msort(), torch.tensor([10, 11, 12, 14]))
+        assert_close(datum[nt].batch.msort(), torch.tensor([10, 12]))
 
     # TODO: (svij) - Figure out why this test is failing on Google Cloud Build
     @unittest.skip("Failing on Google Cloud Build - skiping for now")

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -88,7 +88,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
                 ]
             ),
         }
-        po = PartitionOutput(
+        partition_output = PartitionOutput(
             node_partition_book=to_heterogeneous_node(torch.zeros(14)),
             edge_partition_book={
                 DEFAULT_HOMOGENEOUS_EDGE_TYPE: torch.zeros(6),
@@ -107,7 +107,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             partitioned_positive_labels=None,
         )
         dataset = DistLinkPredictionDataset(rank=0, world_size=1, edge_dir="out")
-        dataset.build(partition_output=po)
+        dataset.build(partition_output=partition_output)
 
         loader = DistNeighborLoader(
             dataset=dataset,


### PR DESCRIPTION
This allows us to sample against multiple nodes in the same "batch".

Moving over http:://go/internal-gigl-pull/496