### PR TITLE
Lock pip version to fix broken pip-compiles. 

### DIFF
--- a/.github/actions/setup-python-tools/action.yml
+++ b/.github/actions/setup-python-tools/action.yml
@@ -46,9 +46,16 @@ runs:
           python-version: '3.9.13' 
 
       # Step 2: Install pip-tools, which is used to generate hashed requirements.
+      # Note: pip 25.1 has a bug that causes pip-tools to fail with the following error:
+      # File ".../python3.9/site-packages/piptools/repositories/pypi.py", line 452, in allow_all_wheels
+      #   self.finder.find_all_candidates.cache_clear()
+      #   AttributeError: 'function' object has no attribute 'cache_clear'
+      # Thus, we fix the pip version to 25.0.1.
       - name: Install pip-tools
         shell: bash
-        run: pip install pip-tools
+        run: |
+          python -m pip install "pip==25.0.1"
+          pip install pip-tools
 
       # Step 3: Set up Gcloud AUTH using Workload Identity Federation
       # See following for context: https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ include dep_vars.env
 SHELL := /bin/bash
 CONDA_ENV_NAME=gnn
 PYTHON_VERSION=3.9
+PIP_VERSION=25.0.1
 DATE:=$(shell /bin/date "+%Y%m%d-%H%M")
 
 # GIT HASH, or empty string if not in a git repo.
@@ -37,7 +38,7 @@ get_ver_hash:
 	$(eval GIT_COMMIT=$(shell git log -1 --pretty=format:"%H"))
 
 initialize_environment:
-	conda create -y -c conda-forge --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION} pip-tools
+	conda create -y -c conda-forge --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION} pip=${PIP_VERSION} pip-tools
 	@echo "If conda environment was successfully installed, ensure to activate it and run \`make install_dev_deps\` or \`make install_deps\` to complete setup"
 
 clean_environment:

--- a/containers/Dockerfile.builder
+++ b/containers/Dockerfile.builder
@@ -40,7 +40,7 @@ RUN echo 'export PATH="/tools/google-cloud-sdk/bin:/usr/lib/jvm/java-1.11.0-open
 RUN echo 'export JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"' >> /root/.bashrc
 
 # Create the environment:
-# TODO: (svij) Build env using single entrypoing for better maintainability `make initialize_environment` 
+# TODO: (svij) Build env using single entrypoint `make initialize_environment` for better maintainability
 RUN conda create -y --name gigl python=3.9 pip
 
 # Update path so any call for python executables in the built image defaults to using the gnn conda environment

--- a/containers/Dockerfile.builder
+++ b/containers/Dockerfile.builder
@@ -40,6 +40,7 @@ RUN echo 'export PATH="/tools/google-cloud-sdk/bin:/usr/lib/jvm/java-1.11.0-open
 RUN echo 'export JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"' >> /root/.bashrc
 
 # Create the environment:
+# TODO: (svij) Build env using single entrypoing for better maintainability `make initialize_environment` 
 RUN conda create -y --name gigl python=3.9 pip
 
 # Update path so any call for python executables in the built image defaults to using the gnn conda environment

--- a/containers/Dockerfile.cpu.base
+++ b/containers/Dockerfile.cpu.base
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Create the environment:
+# TODO: (svij) Build env using single entrypoing for better maintainability `make initialize_environment` 
 RUN conda create -y --name gnn python=3.9 pip
 
 # Update path so any call for python executables in the built image defaults to using the gnn conda environment

--- a/containers/Dockerfile.cpu.base
+++ b/containers/Dockerfile.cpu.base
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Create the environment:
-# TODO: (svij) Build env using single entrypoing for better maintainability `make initialize_environment` 
+# TODO: (svij) Build env using single entrypoint `make initialize_environment` for better maintainability
 RUN conda create -y --name gnn python=3.9 pip
 
 # Update path so any call for python executables in the built image defaults to using the gnn conda environment

--- a/containers/Dockerfile.cuda.base
+++ b/containers/Dockerfile.cuda.base
@@ -20,7 +20,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
 ENV PATH $CONDA_DIR/bin:$PATH
 
 # Create the conda env environment:
-# TODO: (svij) Build env using single entrypoing for better maintainability `make initialize_environment` 
+# TODO: (svij) Build env using single entrypoint `make initialize_environment` for better maintainability
 RUN conda create -y --name gnn python=3.9 pip
 
 # Update path so any call for python executables in the built image defaults to using the gnn conda environment

--- a/containers/Dockerfile.cuda.base
+++ b/containers/Dockerfile.cuda.base
@@ -20,6 +20,7 @@ RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86
 ENV PATH $CONDA_DIR/bin:$PATH
 
 # Create the conda env environment:
+# TODO: (svij) Build env using single entrypoing for better maintainability `make initialize_environment` 
 RUN conda create -y --name gnn python=3.9 pip
 
 # Update path so any call for python executables in the built image defaults to using the gnn conda environment


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
New `pip` [version](https://pypi.org/project/pip/25.1/) `25.1` seems to have introduced a regression where `pip-compile` is failing.
Example: https://github.com/Snapchat/GiGL/actions/runs/14714954906/job/41296087148

Locking the pip version allows `pip-compile` to continue to work i.e. https://github.com/Snapchat/GiGL/actions/runs/14714954906/job/41296087498


This is change is currently blocking https://github.com/Snapchat/GiGL/pull/5


<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
