### PR TITLE
Address Partitioner Tech Debt

### DIFF
--- a/python/gigl/distributed/__init__.py
+++ b/python/gigl/distributed/__init__.py
@@ -7,10 +7,10 @@ from gigl.distributed.dataset_factory import (
     build_dataset_from_task_config_uri,
 )
 from gigl.distributed.dist_context import DistributedContext
-from gigl.distributed.dist_link_prediction_data_partitioner import (
-    DistLinkPredictionDataPartitioner,
-)
 from gigl.distributed.dist_link_prediction_dataset import DistLinkPredictionDataset
+from gigl.distributed.dist_link_prediction_partitioner import (
+    DistLinkPredictionPartitioner,
+)
 from gigl.distributed.dist_link_prediction_range_partitioner import (
     DistLinkPredictionRangePartitioner,
 )

--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -29,10 +29,10 @@ from gigl.common.logger import Logger
 from gigl.common.utils.decorator import tf_on_cpu
 from gigl.distributed.constants import DEFAULT_MASTER_DATA_BUILDING_PORT
 from gigl.distributed.dist_context import DistributedContext
-from gigl.distributed.dist_link_prediction_data_partitioner import (
-    DistLinkPredictionDataPartitioner,
-)
 from gigl.distributed.dist_link_prediction_dataset import DistLinkPredictionDataset
+from gigl.distributed.dist_link_prediction_partitioner import (
+    DistLinkPredictionPartitioner,
+)
 from gigl.distributed.dist_link_prediction_range_partitioner import (
     DistLinkPredictionRangePartitioner,
 )
@@ -56,7 +56,7 @@ def _load_and_build_partitioned_dataset(
     serialized_graph_metadata: SerializedGraphMetadata,
     should_load_tensors_in_parallel: bool,
     edge_dir: Literal["in", "out"],
-    partitioner_class: Optional[Type[DistLinkPredictionDataPartitioner]],
+    partitioner_class: Optional[Type[DistLinkPredictionPartitioner]],
     tf_dataset_options: TFDatasetOptions,
     splitter: Optional[NodeAnchorLinkSplitter] = None,
     _ssl_positive_label_percentage: Optional[float] = None,
@@ -69,8 +69,8 @@ def _load_and_build_partitioned_dataset(
         serialized_graph_metadata (SerializedGraphMetadata): Serialized Graph Metadata contains serialized information for loading TFRecords across node and edge types
         should_load_tensors_in_parallel (bool): Whether tensors should be loaded from serialized information in parallel or in sequence across the [node, edge, pos_label, neg_label] entity types.
         edge_dir (Literal["in", "out"]): Edge direction of the provided graph
-        partitioner_class (Optional[Type[DistLinkPredictionDataPartitioner]]): Partitioner class to partition the graph inputs. If provided, this must be a
-            DistLinkPredictionDataPartitioner or subclass of it. If not provided, will initialize use the DistLinkPredictionDataPartitioner class.
+        partitioner_class (Optional[Type[DistLinkPredictionPartitioner]]): Partitioner class to partition the graph inputs. If provided, this must be a
+            DistLinkPredictionPartitioner or subclass of it. If not provided, will initialize use the DistLinkPredictionPartitioner class.
         tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized data is read.
         splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets. If not provided (None), no splitting will be performed.
         _ssl_positive_label_percentage (Optional[float]): Percentage of edges to select as self-supervised labels. Must be None if supervised edge labels are provided in advance.
@@ -101,7 +101,7 @@ def _load_and_build_partitioned_dataset(
     should_assign_edges_by_src_node: bool = False if edge_dir == "in" else True
 
     if partitioner_class is None:
-        partitioner_class = DistLinkPredictionDataPartitioner
+        partitioner_class = DistLinkPredictionPartitioner
 
     if should_assign_edges_by_src_node:
         logger.info(
@@ -203,7 +203,7 @@ def _build_dataset_process(
     dataset_building_port: int,
     sample_edge_direction: Literal["in", "out"],
     should_load_tensors_in_parallel: bool,
-    partitioner_class: Optional[Type[DistLinkPredictionDataPartitioner]],
+    partitioner_class: Optional[Type[DistLinkPredictionPartitioner]],
     tf_dataset_options: TFDatasetOptions,
     splitter: Optional[NodeAnchorLinkSplitter] = None,
     _ssl_positive_label_percentage: Optional[float] = None,
@@ -234,8 +234,8 @@ def _build_dataset_process(
         dataset_building_port (int): RPC port to use to build the dataset
         sample_edge_direction (Literal["in", "out"]): Whether edges in the graph are directed inward or outward
         should_load_tensors_in_parallel (bool): Whether tensors should be loaded from serialized information in parallel or in sequence across the [node, edge, pos_label, neg_label] entity types.
-        partitioner_class (Optional[Type[DistLinkPredictionDataPartitioner]]): Partitioner class to partition the graph inputs. If provided, this must be a
-            DistLinkPredictionDataPartitioner or subclass of it. If not provided, will initialize use the DistLinkPredictionDataPartitioner class.
+        partitioner_class (Optional[Type[DistLinkPredictionPartitioner]]): Partitioner class to partition the graph inputs. If provided, this must be a
+            DistLinkPredictionPartitioner or subclass of it. If not provided, will initialize use the DistLinkPredictionPartitioner class.
         tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized data is read.
         splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets. If not provided (None), no splitting will be performed.
         _ssl_positive_label_percentage (Optional[float]): Percentage of edges to select as self-supervised labels. Must be None if supervised edge labels are provided in advance.
@@ -278,7 +278,7 @@ def build_dataset(
     distributed_context: DistributedContext,
     sample_edge_direction: Union[Literal["in", "out"], str],
     should_load_tensors_in_parallel: bool = True,
-    partitioner_class: Optional[Type[DistLinkPredictionDataPartitioner]] = None,
+    partitioner_class: Optional[Type[DistLinkPredictionPartitioner]] = None,
     tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
     splitter: Optional[NodeAnchorLinkSplitter] = None,
     _ssl_positive_label_percentage: Optional[float] = None,
@@ -292,8 +292,8 @@ def build_dataset(
         sample_edge_direction (Union[Literal["in", "out"], str]): Whether edges in the graph are directed inward or outward. Note that this is
             listed as a possible string to satisfy type check, but in practice must be a Literal["in", "out"].
         should_load_tensors_in_parallel (bool): Whether tensors should be loaded from serialized information in parallel or in sequence across the [node, edge, pos_label, neg_label] entity types.
-        partitioner_class (Optional[Type[DistLinkPredictionDataPartitioner]]): Partitioner class to partition the graph inputs. If provided, this must be a
-            DistLinkPredictionDataPartitioner or subclass of it. If not provided, will initialize use the DistLinkPredictionDataPartitioner class.
+        partitioner_class (Optional[Type[DistLinkPredictionPartitioner]]): Partitioner class to partition the graph inputs. If provided, this must be a
+            DistLinkPredictionPartitioner or subclass of it. If not provided, will initialize use the DistLinkPredictionPartitioner class.
         tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized data is read.
         splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets. If not provided (None), no splitting will be performed.
         _ssl_positive_label_percentage (Optional[float]): Percentage of edges to select as self-supervised labels. Must be None if supervised edge labels are provided in advance.
@@ -408,7 +408,7 @@ def build_dataset_from_task_config_uri(
     )
 
     if should_use_range_partitioning:
-        partitioner_class = DistLinkPredictionDataPartitioner
+        partitioner_class = DistLinkPredictionPartitioner
     else:
         partitioner_class = DistLinkPredictionRangePartitioner
 

--- a/python/gigl/distributed/dist_link_prediction_partitioner.py
+++ b/python/gigl/distributed/dist_link_prediction_partitioner.py
@@ -77,7 +77,7 @@ class _DistLinkPredicitonPartitionManager(DistPartitionManager):
                 self.partition_book = None
 
 
-class DistLinkPredictionDataPartitioner:
+class DistLinkPredictionPartitioner:
     """
     This class is based on GLT's DistRandomPartitioner class (https://github.com/alibaba/graphlearn-for-pytorch/blob/main/graphlearn_torch/python/distributed/dist_random_partitioner.py)
     and has been optimized for better flexibility and memory management. We assume that init_rpc() and init_worker_group have been called to initialize the rpc and context,
@@ -97,10 +97,10 @@ class DistLinkPredictionDataPartitioner:
     Option 1: User wants to Partition just the nodes of a graph
 
     ```
-    partitioner = DistLinkPredictionDataPartitioner()
+    partitioner = DistLinkPredictionPartitioner()
     # Customer doesn't have to pass in excessive amounts of parameters to the constructor to partition only nodes
     partitioner.register_nodes(node_ids)
-    del node_ids # Del reference to node_ids outside of DistLinkPredictionDataPartitioner to allow memory cleanup within the class
+    del node_ids # Del reference to node_ids outside of DistLinkPredictionPartitioner to allow memory cleanup within the class
     partitioner.partition_nodes()
     # We may optionally want to call gc.collect() to ensure that any lingering memory is cleaned up, which may happen in cases where only a subset of inputs are partitioned (i.e no feats or labels)
     gc.collect()
@@ -109,7 +109,7 @@ class DistLinkPredictionDataPartitioner:
     Option 2: User wants to partition all parts of a graph together and in sequence
 
     ```
-    partitioner = DistLinkPredictionDataPartitioner(node_ids, edge_index, node_features, edge_features, pos_labels, neg_labels)
+    partitioner = DistLinkPredictionPartitioner(node_ids, edge_index, node_features, edge_features, pos_labels, neg_labels)
     # Register is called in the __init__ functions and doesn't need to be called at all outside the class.
     del (
         node_ids,
@@ -118,7 +118,7 @@ class DistLinkPredictionDataPartitioner:
         edge_features,
         pos_labels,
         neg_labels
-    ) # Del reference to tensors outside of DistLinkPredictionDataPartitioner to allow memory cleanup within the class
+    ) # Del reference to tensors outside of DistLinkPredictionPartitioner to allow memory cleanup within the class
     partitioner.partition()
     # We may optionally want to call gc.collect() to ensure that any lingering memory is cleaned up, which may happen in cases where only a subset of inputs are partitioned (i.e no feats or labels)
     gc.collect()

--- a/python/gigl/distributed/dist_link_prediction_range_partitioner.py
+++ b/python/gigl/distributed/dist_link_prediction_range_partitioner.py
@@ -8,8 +8,8 @@ from graphlearn_torch.partition import PartitionBook, RangePartitionBook
 from graphlearn_torch.utils import convert_to_tensor
 
 from gigl.common.logger import Logger
-from gigl.distributed.dist_link_prediction_data_partitioner import (
-    DistLinkPredictionDataPartitioner,
+from gigl.distributed.dist_link_prediction_partitioner import (
+    DistLinkPredictionPartitioner,
 )
 from gigl.distributed.utils.partition_book import get_ids_on_rank
 from gigl.src.common.types.graph_data import EdgeType, NodeType
@@ -18,7 +18,7 @@ from gigl.types.graph import FeaturePartitionData, GraphPartitionData, to_homoge
 logger = Logger()
 
 
-class DistLinkPredictionRangePartitioner(DistLinkPredictionDataPartitioner):
+class DistLinkPredictionRangePartitioner(DistLinkPredictionPartitioner):
     """
     This class is responsible for implementing range-based partitioning. Rather than using a tensor-based partition
     book, this approach stores the upper bound of ids for each rank. For example, a range partition book [4, 8, 12]

--- a/python/gigl/utils/share_memory.py
+++ b/python/gigl/utils/share_memory.py
@@ -24,18 +24,20 @@ def share_memory(
     Calling `share_memory_()` on an empty tensor may cause processes to hang, although the root cause of this is currently unknown. As a result,
     we opt to not move empty tensors to shared memory if they are provided.
 
+    When calling `share_memory` on a RangePartitionBook, we don't need to move the partition bounds to shared memory, since GLT doesn't natively
+    provide a ForkingPickler registration method for the `RangePartitionBook`, and the cost of not moving this to shared memory is minimal,
+    since the size of this tensor is very small, being equal in length to the number of machines.
+
     Args:
-        entity (Optional[Union[torch.Tensor, Dict[_KeyType, torch.Tensor]]]):
+        entity (Optional[Union[torch.Tensor, PartitionBook, Dict[_KeyType, torch.Tensor], Dict[_KeyType, PartitionBook]]]):
             Homogeneous or heterogeneous entity of tensors which is being moved to shared memory
     """
 
-    if entity is None:
+    if entity is None or isinstance(entity, RangePartitionBook):
         return None
     elif isinstance(entity, abc.Mapping):
         for entity_tensor in entity.values():
             share_memory(entity_tensor)
-    elif isinstance(entity, RangePartitionBook):
-        share_memory(entity.partition_bounds)
     else:
         # If the tensor has a dimension which is 0, it is an empty tensor. As a result, we don't move this
         # to shared_memory, since share_memory_() is unsafe on empty tensors, which may cause processes to hang.

--- a/python/tests/test_assets/distributed/run_distributed_dataset.py
+++ b/python/tests/test_assets/distributed/run_distributed_dataset.py
@@ -2,10 +2,10 @@ from typing import Literal, MutableMapping, Optional, Type
 
 from gigl.common.utils.vertex_ai_context import DistributedContext
 from gigl.distributed.dataset_factory import build_dataset
-from gigl.distributed.dist_link_prediction_data_partitioner import (
-    DistLinkPredictionDataPartitioner,
-)
 from gigl.distributed.dist_link_prediction_dataset import DistLinkPredictionDataset
+from gigl.distributed.dist_link_prediction_partitioner import (
+    DistLinkPredictionPartitioner,
+)
 from gigl.distributed.utils.serialized_graph_metadata_translator import (
     convert_pb_to_serialized_graph_metadata,
 )
@@ -26,7 +26,7 @@ def run_distributed_dataset(
     should_load_tensors_in_parallel: bool,
     master_ip_address: str,
     master_port: int,
-    partitioner_class: Optional[Type[DistLinkPredictionDataPartitioner]] = None,
+    partitioner_class: Optional[Type[DistLinkPredictionPartitioner]] = None,
     splitter: Optional[NodeAnchorLinkSplitter] = None,
 ) -> DistLinkPredictionDataset:
     """
@@ -39,7 +39,7 @@ def run_distributed_dataset(
         should_load_tensors_in_parallel (bool): Whether tensors should be loaded from serialized information in parallel or in sequence across the [node, edge, pos_label, neg_label] entity types.
         master_ip_address (str): Master IP Address for performing distributed operations.
         master_port (int) Master Port for performing distributed operations
-        partitioner_class (Optional[Type[DistLinkPredictionDataPartitioner]]): Optional partitioner class to pass into `build_dataset`
+        partitioner_class (Optional[Type[DistLinkPredictionPartitioner]]): Optional partitioner class to pass into `build_dataset`
         splitter (Optional[NodeAnchorLinkSplitter]): Provided splitter for testing
     """
     mocked_dataset_artifact_metadata: MockedDatasetArtifactMetadata = (

--- a/python/tests/test_assets/distributed/run_distributed_partitioner.py
+++ b/python/tests/test_assets/distributed/run_distributed_partitioner.py
@@ -4,7 +4,7 @@ from typing import Dict, Type, Union
 import torch
 from graphlearn_torch.distributed import init_rpc, init_worker_group
 
-from gigl.distributed import DistLinkPredictionDataPartitioner
+from gigl.distributed import DistLinkPredictionPartitioner
 from gigl.src.common.types.graph_data import EdgeType, NodeType
 from gigl.types.graph import PartitionOutput
 from tests.test_assets.distributed.constants import (
@@ -30,7 +30,7 @@ def run_distributed_partitioner(
     master_addr: str,
     master_port: int,
     input_data_strategy: InputDataStrategy,
-    partitioner_class: Type[DistLinkPredictionDataPartitioner],
+    partitioner_class: Type[DistLinkPredictionPartitioner],
 ) -> None:
     """
     Runs the distributed partitioner on a specific rank.
@@ -43,7 +43,7 @@ def run_distributed_partitioner(
         master_addr (str): Master address for initializing rpc for partitioning
         master_port (int): Master port for initializing rpc for partitioning
         input_data_strategy (InputDataStrategy): Strategy for registering inputs to the partitioner
-        partitioner_class (Type[DistLinkPredictionDataPartitioner]): The class to use for partitioning
+        partitioner_class (Type[DistLinkPredictionPartitioner]): The class to use for partitioning
     """
 
     input_graph = rank_to_input_graph[rank]
@@ -72,7 +72,7 @@ def run_distributed_partitioner(
 
     init_worker_group(world_size=MOCKED_NUM_PARTITIONS, rank=rank)
     init_rpc(master_addr=master_addr, master_port=master_port, num_rpc_threads=4)
-    dist_partitioner: DistLinkPredictionDataPartitioner
+    dist_partitioner: DistLinkPredictionPartitioner
 
     if input_data_strategy == InputDataStrategy.REGISTER_ALL_ENTITIES_SEPARATELY:
         dist_partitioner = partitioner_class(

--- a/python/tests/unit/distributed/distributed_dataset_test.py
+++ b/python/tests/unit/distributed/distributed_dataset_test.py
@@ -9,8 +9,8 @@ from torch.multiprocessing import Manager
 from torch.testing import assert_close
 
 from gigl.distributed import (
-    DistLinkPredictionDataPartitioner,
     DistLinkPredictionDataset,
+    DistLinkPredictionPartitioner,
     DistLinkPredictionRangePartitioner,
 )
 from gigl.src.common.types.graph_data import EdgeType, NodeType
@@ -65,7 +65,7 @@ class DistributedDatasetTestCase(unittest.TestCase):
         [
             param(
                 "Test Building Dataset for tensor-based partitioning",
-                partitioner_class=DistLinkPredictionDataPartitioner,
+                partitioner_class=DistLinkPredictionPartitioner,
             ),
             param(
                 "Test Building Dataset for range-based partitioning",
@@ -74,7 +74,7 @@ class DistributedDatasetTestCase(unittest.TestCase):
         ]
     )
     def test_build_dataset(
-        self, _, partitioner_class: Type[DistLinkPredictionDataPartitioner]
+        self, _, partitioner_class: Type[DistLinkPredictionPartitioner]
     ):
         master_port = glt.utils.get_free_port(self._master_ip_address)
         manager = Manager()

--- a/python/tests/unit/distributed/distributed_partitioner_test.py
+++ b/python/tests/unit/distributed/distributed_partitioner_test.py
@@ -13,7 +13,7 @@ from parameterized import param, parameterized
 from torch.multiprocessing import Manager
 
 from gigl.distributed import (
-    DistLinkPredictionDataPartitioner,
+    DistLinkPredictionPartitioner,
     DistLinkPredictionRangePartitioner,
 )
 from gigl.distributed.utils import get_process_group_name
@@ -548,7 +548,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
                 is_heterogeneous=False,
                 input_data_strategy=InputDataStrategy.REGISTER_ALL_ENTITIES_TOGETHER,
                 should_assign_edges_by_src_node=True,
-                partitioner_class=DistLinkPredictionDataPartitioner,
+                partitioner_class=DistLinkPredictionPartitioner,
                 expected_pb_dtype=torch.uint8,
             ),
             param(
@@ -556,7 +556,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
                 is_heterogeneous=True,
                 input_data_strategy=InputDataStrategy.REGISTER_ALL_ENTITIES_TOGETHER,
                 should_assign_edges_by_src_node=True,
-                partitioner_class=DistLinkPredictionDataPartitioner,
+                partitioner_class=DistLinkPredictionPartitioner,
                 expected_pb_dtype=torch.uint8,
             ),
             param(
@@ -564,7 +564,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
                 is_heterogeneous=False,
                 input_data_strategy=InputDataStrategy.REGISTER_ALL_ENTITIES_TOGETHER,
                 should_assign_edges_by_src_node=False,
-                partitioner_class=DistLinkPredictionDataPartitioner,
+                partitioner_class=DistLinkPredictionPartitioner,
                 expected_pb_dtype=torch.uint8,
             ),
             param(
@@ -572,7 +572,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
                 is_heterogeneous=True,
                 input_data_strategy=InputDataStrategy.REGISTER_ALL_ENTITIES_TOGETHER,
                 should_assign_edges_by_src_node=False,
-                partitioner_class=DistLinkPredictionDataPartitioner,
+                partitioner_class=DistLinkPredictionPartitioner,
                 expected_pb_dtype=torch.uint8,
             ),
             param(
@@ -580,7 +580,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
                 is_heterogeneous=False,
                 input_data_strategy=InputDataStrategy.REGISTER_ALL_ENTITIES_SEPARATELY,
                 should_assign_edges_by_src_node=True,
-                partitioner_class=DistLinkPredictionDataPartitioner,
+                partitioner_class=DistLinkPredictionPartitioner,
                 expected_pb_dtype=torch.uint8,
             ),
             param(
@@ -588,7 +588,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
                 is_heterogeneous=False,
                 input_data_strategy=InputDataStrategy.REGISTER_MINIMAL_ENTITIES_SEPARATELY,
                 should_assign_edges_by_src_node=True,
-                partitioner_class=DistLinkPredictionDataPartitioner,
+                partitioner_class=DistLinkPredictionPartitioner,
                 expected_pb_dtype=torch.uint8,
             ),
             param(
@@ -615,7 +615,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
         is_heterogeneous: bool,
         input_data_strategy: InputDataStrategy,
         should_assign_edges_by_src_node: bool,
-        partitioner_class: Type[DistLinkPredictionDataPartitioner],
+        partitioner_class: Type[DistLinkPredictionPartitioner],
         expected_pb_dtype: torch.dtype,
     ) -> None:
         """
@@ -624,7 +624,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
             is_heterogeneous (bool): Whether homogeneous or heterogeneous inputs should be used
             input_data_strategy (InputDataStrategy): Strategy for registering inputs to the partitioner
             should_assign_edges_by_src_node (bool): Whether to partion edges according to the partition book of the source node or destination node
-            partitioner_class (Type[DistLinkPredictionDataPartitioner]): The class to use for partitioning
+            partitioner_class (Type[DistLinkPredictionPartitioner]): The class to use for partitioning
             expected_pb_dtype (torch.dtype): The expected datatype when indexing into a partition book. For range-base partitioning, this will be an torch.int64.
                 Otherwise, it will be a torch.uint8.
         """
@@ -888,7 +888,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
             num_rpc_threads=4,
         )
 
-        partitioner = DistLinkPredictionDataPartitioner(
+        partitioner = DistLinkPredictionPartitioner(
             should_assign_edges_by_src_node=True,
         )
 
@@ -919,7 +919,7 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
             ):
                 partitioner.partition_node()
 
-        partitioner = DistLinkPredictionDataPartitioner(
+        partitioner = DistLinkPredictionPartitioner(
             should_assign_edges_by_src_node=True,
         )
         empty_node_ids = torch.empty(0)

--- a/python/tests/unit/utils/share_memory_test.py
+++ b/python/tests/unit/utils/share_memory_test.py
@@ -47,7 +47,7 @@ class ShareMemoryTest(unittest.TestCase):
         if isinstance(entity, torch.Tensor):
             self.assertTrue(entity.is_shared())
         elif isinstance(entity, RangePartitionBook):
-            self.assertTrue(entity.partition_bounds.is_shared())
+            self.assertFalse(entity.partition_bounds.is_shared())
         elif isinstance(entity, abc.Mapping):
             for entity_tensor in entity.values():
                 self.assertTrue(entity_tensor.is_shared())


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- Rename partitioner `DistLinkPredictionDataPartitioner` -> `DistLinkPredictionPartitioner` for easier readability and better conformity to GLT's naming
- Make calling `share_memory` on a `RangePartitionBook` a no-op, since moving the `partition_bounds` to shared memory doesn't actually work in practice, as GLT's native `RangePartitionBook` has no `ForkingPickler` method.
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
