### PR TITLE
swap to generating label edge types based on message passing edge types

### DIFF
--- a/python/gigl/types/graph.py
+++ b/python/gigl/types/graph.py
@@ -22,6 +22,7 @@ DEFAULT_HOMOGENEOUS_EDGE_TYPE = EdgeType(
 _POSITIVE_LABEL_TAG = "gigl_positive"
 _NEGATIVE_LABEL_TAG = "gigl_negative"
 
+_EdgeType = TypeVar("_EdgeType", EdgeType, tuple[str, str, str])
 # TODO(kmonte, mkolodner): Move SerializedGraphMetadata and maybe convert_pb_to_serialized_graph_metadata here.
 
 
@@ -146,7 +147,9 @@ class LoadedGraphTensors:
         self.negative_label = None
 
 
-def message_passing_to_positive_label(message_passing_edge_type: EdgeType) -> EdgeType:
+def message_passing_to_positive_label(
+    message_passing_edge_type: _EdgeType,
+) -> _EdgeType:
     """Convert a message passing edge type to a positive label edge type.
 
     Args:
@@ -155,16 +158,22 @@ def message_passing_to_positive_label(message_passing_edge_type: EdgeType) -> Ed
     Returns:
         EdgeType: The positive label edge type.
     """
-    return EdgeType(
-        src_node_type=message_passing_edge_type.src_node_type,
-        relation=Relation(
-            f"{message_passing_edge_type.relation}_{_POSITIVE_LABEL_TAG}"
-        ),
-        dst_node_type=message_passing_edge_type.dst_node_type,
+    edge_type = (
+        str(message_passing_edge_type[0]),
+        f"{message_passing_edge_type[1]}_{_POSITIVE_LABEL_TAG}",
+        str(message_passing_edge_type[2]),
     )
+    if isinstance(message_passing_edge_type, EdgeType):
+        return EdgeType(
+            NodeType(edge_type[0]), Relation(edge_type[1]), NodeType(edge_type[2])
+        )
+    else:
+        return edge_type
 
 
-def message_passing_to_negative_label(message_passing_edge_type: EdgeType) -> EdgeType:
+def message_passing_to_negative_label(
+    message_passing_edge_type: _EdgeType,
+) -> _EdgeType:
     """Convert a message passing edge type to a negative label edge type.
 
     Args:
@@ -173,18 +182,22 @@ def message_passing_to_negative_label(message_passing_edge_type: EdgeType) -> Ed
     Returns:
         EdgeType: The negative label edge type.
     """
-    return EdgeType(
-        src_node_type=message_passing_edge_type.src_node_type,
-        relation=Relation(
-            f"{message_passing_edge_type.relation}_{_NEGATIVE_LABEL_TAG}"
-        ),
-        dst_node_type=message_passing_edge_type.dst_node_type,
+    edge_type = (
+        str(message_passing_edge_type[0]),
+        f"{message_passing_edge_type[1]}_{_NEGATIVE_LABEL_TAG}",
+        str(message_passing_edge_type[2]),
     )
+    if isinstance(message_passing_edge_type, EdgeType):
+        return EdgeType(
+            NodeType(edge_type[0]), Relation(edge_type[1]), NodeType(edge_type[2])
+        )
+    else:
+        return edge_type
 
 
 def select_label_edge_types(
-    message_passing_edge_type: EdgeType, edge_entities: abc.Iterable[EdgeType]
-) -> tuple[EdgeType, Optional[EdgeType]]:
+    message_passing_edge_type: _EdgeType, edge_entities: abc.Iterable[_EdgeType]
+) -> tuple[_EdgeType, Optional[_EdgeType]]:
     """Select label edge types for a given message passing edge type.
 
     Args:

--- a/python/gigl/types/graph.py
+++ b/python/gigl/types/graph.py
@@ -22,7 +22,11 @@ DEFAULT_HOMOGENEOUS_EDGE_TYPE = EdgeType(
 _POSITIVE_LABEL_TAG = "gigl_positive"
 _NEGATIVE_LABEL_TAG = "gigl_negative"
 
+# We really should support PyG EdgeType natively but since we type ignore it that's not ideal atm...
+# We can use this TypeVar to try and stem the bleeding (hopefully).
 _EdgeType = TypeVar("_EdgeType", EdgeType, tuple[str, str, str])
+
+
 # TODO(kmonte, mkolodner): Move SerializedGraphMetadata and maybe convert_pb_to_serialized_graph_metadata here.
 
 

--- a/python/gigl/types/graph.py
+++ b/python/gigl/types/graph.py
@@ -10,6 +10,8 @@ from gigl.common.logger import Logger
 # TODO(kmonte) - we should move gigl.src.common.types.graph_data to this file.
 from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
 
+logger = Logger()
+
 DEFAULT_HOMOGENEOUS_NODE_TYPE = NodeType("default_homogeneous_node_type")
 DEFAULT_HOMOGENEOUS_EDGE_TYPE = EdgeType(
     src_node_type=DEFAULT_HOMOGENEOUS_NODE_TYPE,
@@ -17,8 +19,8 @@ DEFAULT_HOMOGENEOUS_EDGE_TYPE = EdgeType(
     dst_node_type=DEFAULT_HOMOGENEOUS_NODE_TYPE,
 )
 
-POSITIVE_LABEL_RELATION = Relation("positive_label")
-NEGATIVE_LABEL_RELATION = Relation("negative_label")
+_POSITIVE_LABEL_TAG = "gigl_positive"
+_NEGATIVE_LABEL_TAG = "gigl_negative"
 
 # TODO(kmonte, mkolodner): Move SerializedGraphMetadata and maybe convert_pb_to_serialized_graph_metadata here.
 
@@ -82,9 +84,6 @@ class PartitionOutput:
     ]
 
 
-logger = Logger()
-
-
 # This dataclass should not be frozen, as we are expected to delete its members once they have been registered inside of the partitioner
 # in order to save memory.
 @dataclass
@@ -131,17 +130,9 @@ class LoadedGraphTensors:
         logger.info(
             f"Basing positive and negative labels on edge types on main label edge type: {main_edge_type}."
         )
-        positive_label_edge_type = EdgeType(
-            main_edge_type.src_node_type,
-            POSITIVE_LABEL_RELATION,
-            main_edge_type.dst_node_type,
-        )
+        positive_label_edge_type = message_passing_to_positive_label(main_edge_type)
         edge_index_with_labels[positive_label_edge_type] = self.positive_label
-        negative_label_edge_type = EdgeType(
-            main_edge_type.src_node_type,
-            NEGATIVE_LABEL_RELATION,
-            main_edge_type.dst_node_type,
-        )
+        negative_label_edge_type = message_passing_to_negative_label(main_edge_type)
         edge_index_with_labels[negative_label_edge_type] = self.negative_label
         logger.info(
             f"Treating positive labels as edge type {positive_label_edge_type} and negative labels as edge type {negative_label_edge_type}."
@@ -153,6 +144,68 @@ class LoadedGraphTensors:
         self.edge_features = to_heterogeneous_edge(self.edge_features)
         self.positive_label = None
         self.negative_label = None
+
+
+def message_passing_to_positive_label(message_passing_edge_type: EdgeType) -> EdgeType:
+    """Convert a message passing edge type to a positive label edge type.
+
+    Args:
+        message_passing_edge_type (EdgeType): The message passing edge type.
+
+    Returns:
+        EdgeType: The positive label edge type.
+    """
+    return EdgeType(
+        src_node_type=message_passing_edge_type.src_node_type,
+        relation=Relation(
+            f"{message_passing_edge_type.relation}_{_POSITIVE_LABEL_TAG}"
+        ),
+        dst_node_type=message_passing_edge_type.dst_node_type,
+    )
+
+
+def message_passing_to_negative_label(message_passing_edge_type: EdgeType) -> EdgeType:
+    """Convert a message passing edge type to a negative label edge type.
+
+    Args:
+        message_passing_edge_type (EdgeType): The message passing edge type.
+
+    Returns:
+        EdgeType: The negative label edge type.
+    """
+    return EdgeType(
+        src_node_type=message_passing_edge_type.src_node_type,
+        relation=Relation(
+            f"{message_passing_edge_type.relation}_{_NEGATIVE_LABEL_TAG}"
+        ),
+        dst_node_type=message_passing_edge_type.dst_node_type,
+    )
+
+
+def select_label_edge_types(
+    message_passing_edge_type: EdgeType, edge_entities: abc.Iterable[EdgeType]
+) -> tuple[EdgeType, Optional[EdgeType]]:
+    """Select label edge types for a given message passing edge type.
+
+    Args:
+        message_passing_edge_type (EdgeType): The message passing edge type.
+        edge_entities (abc.Iterable[EdgeType]): The edge entities to select from.
+
+    Returns:
+        tuple[EdgeType, Optional[EdgeType]]: A tuple containing the positive label edge type and optionally the negative label edge type.
+    """
+    positive_label_type = None
+    negative_label_type = None
+    for edge_type in edge_entities:
+        if message_passing_to_positive_label(message_passing_edge_type) == edge_type:
+            positive_label_type = edge_type
+        if message_passing_to_negative_label(message_passing_edge_type) == edge_type:
+            negative_label_type = edge_type
+    if positive_label_type is None:
+        raise ValueError(
+            f"Could not find positive label edge type for message passing edge type {message_passing_edge_type} from edge entities {edge_entities}."
+        )
+    return positive_label_type, negative_label_type
 
 
 _T = TypeVar("_T")
@@ -171,6 +224,18 @@ def to_heterogeneous_node(x: Union[_T, dict[NodeType, _T]]) -> dict[NodeType, _T
 def to_heterogeneous_node(
     x: Optional[Union[_T, dict[NodeType, _T]]]
 ) -> Optional[dict[NodeType, _T]]:
+    """Convert a value to a heterogeneous node representation.
+
+    If the input is None, return None.
+    If the input is a dictionary, return it as is.
+    If the input is a single value, return it as a dictionary with the default homogeneous node type as the key.
+
+    Args:
+        x (Optional[Union[_T, dict[NodeType, _T]]]): The input value to convert.
+
+    Returns:
+        Optional[dict[NodeType, _T]]: The converted heterogeneous node representation.
+    """
     if x is None:
         return None
     if isinstance(x, dict):
@@ -191,6 +256,18 @@ def to_heterogeneous_edge(x: Union[_T, dict[EdgeType, _T]]) -> dict[EdgeType, _T
 def to_heterogeneous_edge(
     x: Optional[Union[_T, dict[EdgeType, _T]]]
 ) -> Optional[dict[EdgeType, _T]]:
+    """Convert a value to a heterogeneous edge representation.
+
+    If the input is None, return None.
+    If the input is a dictionary, return it as is.
+    If the input is a single value, return it as a dictionary with the default homogeneous edge type as the key.
+
+    Args:
+        x (Optional[Union[_T, dict[EdgeType, _T]]]): The input value to convert.
+
+    Returns:
+        Optional[dict[EdgeType, _T]]: The converted heterogeneous edge representation.
+    """
     if x is None:
         return None
     if isinstance(x, dict):
@@ -211,6 +288,18 @@ def to_homogeneous(x: Union[_T, dict[Union[NodeType, EdgeType], _T]]) -> _T:
 def to_homogeneous(
     x: Optional[Union[_T, dict[Union[NodeType, EdgeType], _T]]]
 ) -> Optional[_T]:
+    """Convert a value to a homogeneous representation.
+
+    If the input is None, return None.
+    If the input is a dictionary, return the single value in the dictionary.
+    If the input is a single value, return it as is.
+
+    Args:
+        x (Optional[Union[_T, dict[Union[NodeType, EdgeType], _T]]]): The input value to convert.
+
+    Returns:
+        Optional[_T]: The converted homogeneous representation.
+    """
     if x is None:
         return None
     if isinstance(x, dict):

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -11,7 +11,7 @@ from torch_geometric.data import Data, HeteroData
 from gigl.distributed.dist_context import DistributedContext
 from gigl.distributed.dist_link_prediction_dataset import DistLinkPredictionDataset
 from gigl.distributed.distributed_neighborloader import DistNeighborLoader
-from gigl.src.common.types.graph_data import EdgeType, NodeType
+from gigl.src.common.types.graph_data import NodeType
 from gigl.src.mocking.mocking_assets.mocked_datasets_for_pipeline_tests import (
     CORA_NODE_ANCHOR_MOCKED_DATASET_INFO,
     DBLP_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
@@ -19,10 +19,10 @@ from gigl.src.mocking.mocking_assets.mocked_datasets_for_pipeline_tests import (
 from gigl.types.graph import (
     DEFAULT_HOMOGENEOUS_EDGE_TYPE,
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
-    NEGATIVE_LABEL_RELATION,
-    POSITIVE_LABEL_RELATION,
     GraphPartitionData,
     PartitionOutput,
+    message_passing_to_negative_label,
+    message_passing_to_positive_label,
     to_heterogeneous_node,
 )
 from tests.test_assets.distributed.run_distributed_dataset import (
@@ -78,8 +78,12 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
 
     def test_distributed_neighbor_loader_batched(self):
         node_type = DEFAULT_HOMOGENEOUS_NODE_TYPE
-        positive_edge_type = EdgeType(node_type, POSITIVE_LABEL_RELATION, node_type)
-        negative_edge_type = EdgeType(node_type, NEGATIVE_LABEL_RELATION, node_type)
+        positive_edge_type = message_passing_to_positive_label(
+            DEFAULT_HOMOGENEOUS_EDGE_TYPE
+        )
+        negative_edge_type = message_passing_to_negative_label(
+            DEFAULT_HOMOGENEOUS_EDGE_TYPE
+        )
         edge_index = {
             DEFAULT_HOMOGENEOUS_EDGE_TYPE: torch.tensor(
                 [

--- a/python/tests/unit/types_tests/graph_test.py
+++ b/python/tests/unit/types_tests/graph_test.py
@@ -7,9 +7,10 @@ from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
 from gigl.types.graph import (
     DEFAULT_HOMOGENEOUS_EDGE_TYPE,
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
-    NEGATIVE_LABEL_RELATION,
-    POSITIVE_LABEL_RELATION,
     LoadedGraphTensors,
+    message_passing_to_negative_label,
+    message_passing_to_positive_label,
+    select_label_edge_types,
     to_heterogeneous_edge,
     to_heterogeneous_node,
     to_homogeneous,
@@ -91,15 +92,11 @@ class GraphTypesTyest(unittest.TestCase):
                 negative_label=torch.tensor([[1, 0]]),
                 expected_edge_index={
                     DEFAULT_HOMOGENEOUS_EDGE_TYPE: torch.tensor([[0, 1], [1, 2]]),
-                    EdgeType(
-                        DEFAULT_HOMOGENEOUS_NODE_TYPE,
-                        POSITIVE_LABEL_RELATION,
-                        DEFAULT_HOMOGENEOUS_NODE_TYPE,
+                    message_passing_to_positive_label(
+                        DEFAULT_HOMOGENEOUS_EDGE_TYPE
                     ): torch.tensor([[0, 2]]),
-                    EdgeType(
-                        DEFAULT_HOMOGENEOUS_NODE_TYPE,
-                        NEGATIVE_LABEL_RELATION,
-                        DEFAULT_HOMOGENEOUS_NODE_TYPE,
+                    message_passing_to_negative_label(
+                        DEFAULT_HOMOGENEOUS_EDGE_TYPE
                     ): torch.tensor([[1, 0]]),
                 },
             ),
@@ -185,6 +182,28 @@ class GraphTypesTyest(unittest.TestCase):
 
         with self.assertRaises(raises):
             graph_tensors.treat_labels_as_edges()
+
+    def test_select_label_edge_types(self):
+        message_passing_edge_type = DEFAULT_HOMOGENEOUS_EDGE_TYPE
+        edge_types = [
+            message_passing_edge_type,
+            message_passing_to_positive_label(message_passing_edge_type),
+            message_passing_to_negative_label(message_passing_edge_type),
+            EdgeType(NodeType("foo"), Relation("bar"), NodeType("baz")),
+            EdgeType(
+                DEFAULT_HOMOGENEOUS_NODE_TYPE,
+                Relation("bar"),
+                DEFAULT_HOMOGENEOUS_NODE_TYPE,
+            ),
+        ]
+
+        self.assertEqual(
+            (
+                message_passing_to_positive_label(message_passing_edge_type),
+                message_passing_to_negative_label(message_passing_edge_type),
+            ),
+            select_label_edge_types(message_passing_edge_type, edge_types),
+        )
 
 
 if __name__ == "__main__":

--- a/python/tests/unit/types_tests/graph_test.py
+++ b/python/tests/unit/types_tests/graph_test.py
@@ -205,6 +205,24 @@ class GraphTypesTyest(unittest.TestCase):
             select_label_edge_types(message_passing_edge_type, edge_types),
         )
 
+    def test_select_label_edge_types_pyg(self):
+        message_passing_edge_type = ("node", "to", "node")
+        edge_types = [
+            message_passing_edge_type,
+            message_passing_to_positive_label(message_passing_edge_type),
+            message_passing_to_negative_label(message_passing_edge_type),
+            ("other", "to", "node"),
+            ("other", "to", "other"),
+        ]
+
+        self.assertEqual(
+            (
+                message_passing_to_positive_label(message_passing_edge_type),
+                message_passing_to_negative_label(message_passing_edge_type),
+            ),
+            select_label_edge_types(message_passing_edge_type, edge_types),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As you've mentioned prior, we should do this eventually - I think this will make our supervised HeteroData -> Data conversion easier.