### PR TITLE
swap to use type alias instead of new type for NodeId, NodeType, Relation

### DIFF
--- a/python/gigl/src/common/types/graph_data.py
+++ b/python/gigl/src/common/types/graph_data.py
@@ -7,9 +7,9 @@ from typing import NamedTuple, NewType, Tuple
 from gigl.common.utils.func_tools import lru_cache
 
 # Unique identifier for the node for a specific NodeType
-NodeId = NewType("NodeId", int)
-NodeType = NewType("NodeType", str)
-Relation = NewType("Relation", str)
+NodeId = int
+NodeType = str
+Relation = str
 
 
 class EdgeUsageType(str, Enum):

--- a/python/gigl/types/graph.py
+++ b/python/gigl/types/graph.py
@@ -8,17 +8,17 @@ from graphlearn_torch.partition import PartitionBook
 from gigl.common.logger import Logger
 
 # TODO(kmonte) - we should move gigl.src.common.types.graph_data to this file.
-from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
+from gigl.src.common.types.graph_data import EdgeType, NodeType
 
-DEFAULT_HOMOGENEOUS_NODE_TYPE = NodeType("default_homogeneous_node_type")
+DEFAULT_HOMOGENEOUS_NODE_TYPE = "default_homogeneous_node_type"
 DEFAULT_HOMOGENEOUS_EDGE_TYPE = EdgeType(
     src_node_type=DEFAULT_HOMOGENEOUS_NODE_TYPE,
-    relation=Relation("to"),
+    relation="to",
     dst_node_type=DEFAULT_HOMOGENEOUS_NODE_TYPE,
 )
 
-POSITIVE_LABEL_RELATION = Relation("positive_label")
-NEGATIVE_LABEL_RELATION = Relation("negative_label")
+POSITIVE_LABEL_RELATION = "positive_label"
+NEGATIVE_LABEL_RELATION = "negative_label"
 
 # TODO(kmonte, mkolodner): Move SerializedGraphMetadata and maybe convert_pb_to_serialized_graph_metadata here.
 

--- a/python/tests/unit/types_tests/graph_test.py
+++ b/python/tests/unit/types_tests/graph_test.py
@@ -3,7 +3,7 @@ import unittest
 import torch
 from parameterized import param, parameterized
 
-from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
+from gigl.src.common.types.graph_data import EdgeType
 from gigl.types.graph import (
     DEFAULT_HOMOGENEOUS_EDGE_TYPE,
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
@@ -38,8 +38,8 @@ class GraphTypesTyest(unittest.TestCase):
             param("none_input", None, None),
             param(
                 "custom_edge_type",
-                {EdgeType(NodeType("src"), Relation("rel"), NodeType("dst")): "value"},
-                {EdgeType(NodeType("src"), Relation("rel"), NodeType("dst")): "value"},
+                {EdgeType("src", "rel", "dst"): "value"},
+                {EdgeType("src", "rel", "dst"): "value"},
             ),
             param(
                 "default_edge_type", "value", {DEFAULT_HOMOGENEOUS_EDGE_TYPE: "value"}
@@ -54,7 +54,7 @@ class GraphTypesTyest(unittest.TestCase):
             param("none_input", None, None),
             param(
                 "single_value_input",
-                {EdgeType(NodeType("src"), Relation("rel"), NodeType("dst")): "value"},
+                {EdgeType("src", "rel", "dst"): "value"},
                 "value",
             ),
             param("direct_value_input", "value", "value"),
@@ -67,7 +67,7 @@ class GraphTypesTyest(unittest.TestCase):
         [
             param(
                 "multiple_keys_input",
-                {NodeType("src"): "src_value", NodeType("dst"): "dst_value"},
+                {"src": "src_value", "dst": "dst_value"},
             ),
             param(
                 "empty_dict_input",
@@ -149,12 +149,10 @@ class GraphTypesTyest(unittest.TestCase):
             ),
             param(
                 "heterogeneous_inputs",
-                node_ids={NodeType("type1"): torch.tensor([0, 1])},
+                node_ids={"type1": torch.tensor([0, 1])},
                 node_features=None,
                 edge_index={
-                    EdgeType(
-                        NodeType("node1"), Relation("relation"), NodeType("node2")
-                    ): torch.tensor([[0, 1]])
+                    EdgeType("node1", "relation", "node2"): torch.tensor([[0, 1]])
                 },
                 edge_features=None,
                 positive_label=torch.tensor([[0, 2]]),


### PR DESCRIPTION
This is part of the migration to making our APIs more conformation to PyG. 

The impact of this change is that we don't need to write `NodeType("foo_type")` anymore, we can just write `"foo_type"` (see the changes in the test file). 

Ideally I'd change EdgeType too but since we overloaded `__repr__` stringify edgetype into bq table names etc that change is not safe to make. 