### PR TITLE
Update mypy ini file to fix type check locally

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -141,3 +141,9 @@ ignore_missing_imports = True
 
 [mypy-graphlearn_torch.*]
 ignore_missing_imports = True
+
+[mypy-traitlets.*]
+ignore_missing_imports = True
+
+[mypy-pymongo.*]
+ignore_missing_imports = True


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
Updates mypy file to ignore two libraries which throw type stub error when running `make type_check` from local machine with `gnn` conda environment. To reproduce this,
1. Run `make initialize_environment` from GiGL
2. Run `conda activate gnn`
3. Run `make install_dev_deps`
4. Run `make type_check`
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
