### PR TITLE
Retry on connection errors

### DIFF
--- a/python/gigl/common/data/export.py
+++ b/python/gigl/common/data/export.py
@@ -13,6 +13,7 @@ from typing import Final, Optional, Sequence
 
 import fastavro
 import fastavro.types
+import requests
 import torch
 from google.cloud import bigquery
 from google.cloud.exceptions import GoogleCloudError
@@ -146,7 +147,11 @@ class EmbeddingExporter:
             )
             self.flush_embeddings()
 
-    @retry(exception_to_check=GoogleCloudError, tries=5, max_delay_s=60)
+    @retry(
+        exception_to_check=(GoogleCloudError, requests.exceptions.RequestException),
+        tries=5,
+        max_delay_s=60,
+    )
     def _flush(self):
         """Flushes the in-memory buffer to GCS, retrying on failure."""
         logger.info(

--- a/python/gigl/common/utils/retry.py
+++ b/python/gigl/common/utils/retry.py
@@ -1,6 +1,6 @@
 import time
 from functools import wraps
-from typing import Callable, Optional, Tuple, Type, TypeVar
+from typing import Callable, Optional, Tuple, Type, TypeVar, Union
 from xmlrpc.client import Boolean
 
 from gigl.common.logger import Logger
@@ -21,7 +21,7 @@ class __RetriableTimeoutException(Exception):
 
 
 def retry(
-    exception_to_check: Type = Exception,
+    exception_to_check: Union[Type, Tuple[Type, ...]] = Exception,
     tries: int = 5,
     delay_s: int = 3,
     backoff: int = 2,
@@ -34,7 +34,7 @@ def retry(
     Decorator that can be added around a function to retry incase it fails i.e. throws some exceptions
 
     Args:
-        exception_to_check (Optional[Type]): the exception to check. may be a tuple of
+        exception_to_check (Union[Type, Tuple[Type, ...]]): the exception to check. Could also be a tuple of
         exceptions to check. Defaults to Exception. i.e. catches everything
         tries (Optional[int]): [description]. number of times to try (not retry) before giving up. Defaults to 5.
         delay_s (Optional[int]): [description]. initial delay between retries in seconds. Defaults to 3.

--- a/python/tests/unit/common/data/export_test.py
+++ b/python/tests/unit/common/data/export_test.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 from unittest.mock import ANY, MagicMock, patch
 
 import fastavro
+import requests
 import torch
 from google.cloud.exceptions import GoogleCloudError
 from parameterized import param, parameterized
@@ -243,7 +244,9 @@ class TestEmbeddingExporter(unittest.TestCase):
                 # We want to ensure that the buffer gets reset on retry.
                 buffer.read()
                 self._mock_call_count += 1
-                raise GoogleCloudError("GCS upload failed")
+                google_cloud_error = GoogleCloudError("GCS upload failed")
+                google_cloud_error.code = 503  # Service Unavailable
+                raise google_cloud_error
             elif self._mock_call_count == 1:
                 with test_file.open("wb") as f:
                     f.write(buffer.read())
@@ -271,7 +274,7 @@ class TestEmbeddingExporter(unittest.TestCase):
 
     @patch("time.sleep")
     @patch("gigl.common.data.export.GcsUtils")
-    def test_write_embeddings_to_gcs_upload_retries_and_fails(
+    def test_write_embeddings_to_gcs_upload_retries_on_google_cloud_error_and_fails(
         self, mock_gcs_utils_class, mock_sleep
     ):
         # Mock inputs
@@ -281,15 +284,39 @@ class TestEmbeddingExporter(unittest.TestCase):
         embedding_type = "test_type"
 
         mock_gcs_utils = MagicMock()
-        mock_gcs_utils.upload_from_filelike.side_effect = GoogleCloudError(
-            "GCS upload failed"
-        )
+        google_cloud_error = GoogleCloudError("GCS upload failed")
+        google_cloud_error.code = 503  # Service Unavailable
+        mock_gcs_utils.upload_from_filelike.side_effect = google_cloud_error
         mock_gcs_utils_class.return_value = mock_gcs_utils
         exporter = EmbeddingExporter(export_dir=gcs_base_uri)
         exporter.add_embedding(id_batch, embedding_batch, embedding_type)
 
         # Assertions
         with self.assertRaisesRegex(RetriesFailedException, "GCS upload failed"):
+            exporter.flush_embeddings()
+        self.assertEqual(mock_gcs_utils.upload_from_filelike.call_count, 6)
+
+    @patch("time.sleep")
+    @patch("gigl.common.data.export.GcsUtils")
+    def test_write_embeddings_to_gcs_upload_retries_on_request_exception_and_fails(
+        self, mock_gcs_utils_class, mock_sleep
+    ):
+        # Mock inputs
+        gcs_base_uri = GcsUri("gs://test-bucket/test-folder")
+        id_batch = torch.tensor([1])
+        embedding_batch = torch.tensor([[1, 11]])
+        embedding_type = "test_type"
+
+        mock_gcs_utils = MagicMock()
+        mock_gcs_utils.upload_from_filelike.side_effect = (
+            requests.exceptions.RequestException("Connection aborted")
+        )
+        mock_gcs_utils_class.return_value = mock_gcs_utils
+        exporter = EmbeddingExporter(export_dir=gcs_base_uri)
+        exporter.add_embedding(id_batch, embedding_batch, embedding_type)
+
+        # Assertions
+        with self.assertRaisesRegex(RetriesFailedException, "Connection aborted"):
             exporter.flush_embeddings()
         self.assertEqual(mock_gcs_utils.upload_from_filelike.call_count, 6)
 


### PR DESCRIPTION
### Features
When uploading embeddings to GCS, retry on both GCP errors (e.g., ServiceUnavailable) and connection related errors (e.g., connection aborted).

### Testing
Unit tested.