### PR TITLE
Create workflow for releasing documentation

### DIFF
--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -1,11 +1,13 @@
 name: Release Documentation
+# Workflow used for building and deploying GiGL documentation to GitHub Pages:
+# https://snapchat.github.io/GiGL/
 
 on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
 
-  # In case we need to run manually.
+  # In case we need to run manually for testing, or if push to main fails deploying documentation.
   workflow_dispatch:
 
 permissions:
@@ -28,6 +30,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      # autodoc analyses the code and docstrings by introspection after importing the modules.
+      # For importing to work, we have to make sure that your modules can be found by Sphinx and
+      # that dependencies can be resolved.
       - name: Setup Machine for releasing documentation
         uses: snapchat/gigl/.github/actions/setup-python-tools@main
         with:
@@ -36,6 +41,7 @@ jobs:
             gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
             workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
             gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+      # We also make gigl available w/ editable install `-e` so that autodoc can find it.
       - name: Install necessary doc dependencies
         run: |
           pip install -e "./python[docs]"

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -3,12 +3,11 @@ name: Release Documentation
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main", "svij/migrate-docs"] # svij/migrate-docs for testing
+    branches: ["main"]
 
-  # Allows you to run this workflow manually from the Actions tab
+  # In case we need to run manually.
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
@@ -21,7 +20,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -49,7 +47,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload the output folder which contains all static assets for gh-pages
+          # Upload the output folder which contains all static assets
           path: 'gh_pages_build/html/'
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload the output folder which contains all static assets for gh-pages
-          path: 'gh_pages_build/'
+          path: 'gh_pages_build/html/'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -1,0 +1,56 @@
+name: Release Documentation
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "svij/migrate-docs"] # svij/migrate-docs for testing
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Machine for releasing documentation
+        uses: snapchat/gigl/.github/actions/setup-python-tools@main
+        with:
+            install_dev_deps: "true"
+            setup_gcloud: "true"
+            gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+            workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+            gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+      - name: Install necessary doc dependencies
+        run: |
+          pip install -e "./python[docs]"
+      - name: Sphinx build
+        run: |
+          make build_docs
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload the output folder which contains all static assets for gh-pages
+          path: 'gh_pages_build/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

Introducing new workflow that will allow us to deploy our docs to github pages.
I have already [merged it to snap-research/GiGL](https://github.com/snap-research/GiGL/actions/runs/14806387587/workflow?pr=21).
You can see the successful results of [deployment](https://github.com/snap-research/GiGL/actions/runs/14806387587/job/41575241673?pr=21) using the rule here: https://snap-research.github.io/GiGL/

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
