### PR TITLE
Return BigQuery load job object

### DIFF
--- a/examples/distributed/homogeneous_inference.py
+++ b/examples/distributed/homogeneous_inference.py
@@ -407,6 +407,9 @@ def _run_example_inference(
         logger.info("--- Machine 0 triggers loading embeddings from GCS to BigQuery")
         load_embedding_start_time = time.time()
 
+        # The `load_embeddings_to_bigquery` API returns a BigQuery LoadJob object
+        # representing the load operation, which allows user to monitor and retrieve
+        # details about the job status and result.
         _ = load_embeddings_to_bigquery(
             gcs_folder=embedding_output_gcs_folder,
             project_id=bq_project_id,

--- a/examples/distributed/homogeneous_inference.py
+++ b/examples/distributed/homogeneous_inference.py
@@ -407,7 +407,7 @@ def _run_example_inference(
         logger.info("--- Machine 0 triggers loading embeddings from GCS to BigQuery")
         load_embedding_start_time = time.time()
 
-        load_embeddings_to_bigquery(
+        _ = load_embeddings_to_bigquery(
             gcs_folder=embedding_output_gcs_folder,
             project_id=bq_project_id,
             dataset_id=bq_dataset_id,

--- a/python/gigl/common/data/export.py
+++ b/python/gigl/common/data/export.py
@@ -233,6 +233,10 @@ def load_embeddings_to_bigquery(
         project_id (str): The GCP project ID.
         dataset_id (str): The BigQuery dataset ID.
         table_id (str): The BigQuery table ID.
+
+    Returns:
+        LoadJob: A BigQuery LoadJob object representing the load operation, which allows
+        user to monitor and retrieve details about the job status and result.
     """
     start = time.perf_counter()
     logger.info(f"Loading embeddings from {gcs_folder} to BigQuery.")

--- a/python/gigl/common/data/export.py
+++ b/python/gigl/common/data/export.py
@@ -16,6 +16,7 @@ import fastavro.types
 import requests
 import torch
 from google.cloud import bigquery
+from google.cloud.bigquery.job import LoadJob
 from google.cloud.exceptions import GoogleCloudError
 from typing_extensions import Self
 
@@ -215,7 +216,7 @@ class EmbeddingExporter:
 # TODO(kmonte): We should migrate this over to `BqUtils.load_files_to_bq` once that is implemented.
 def load_embeddings_to_bigquery(
     gcs_folder: GcsUri, project_id: str, dataset_id: str, table_id: str
-) -> None:
+) -> LoadJob:
     """
     Loads multiple Avro files containing GNN embeddings from GCS into BigQuery.
 
@@ -259,3 +260,5 @@ def load_embeddings_to_bigquery(
     logger.info(
         f"Loading {load_job.output_rows:,} rows into {dataset_id}:{table_id} in {time.perf_counter() - start:.2f} seconds."
     )
+
+    return load_job

--- a/python/tests/integration/common/data/export_test.py
+++ b/python/tests/integration/common/data/export_test.py
@@ -68,7 +68,7 @@ class EmbeddingExportIntergrationTest(unittest.TestCase):
         logger.info(
             f"Will try exporting to {self.embedding_output_dir} to BQ: {bq_export_table_path}"
         )
-        load_embeddings_to_bigquery(
+        load_job = load_embeddings_to_bigquery(
             gcs_folder=self.embedding_output_dir,
             project_id=self.embedding_output_bq_project,
             dataset_id=self.embedding_output_bq_dataset,
@@ -76,6 +76,10 @@ class EmbeddingExportIntergrationTest(unittest.TestCase):
         )
 
         # Check that data in BQ is as expected...
+        self.assertEqual(
+            load_job.output_rows,
+            num_nodes * 2,
+        )
         self.assertEqual(
             bq_client.count_number_of_rows_in_bq_table(bq_export_table_path),
             num_nodes * 2,

--- a/python/tests/unit/common/data/export_test.py
+++ b/python/tests/unit/common/data/export_test.py
@@ -347,7 +347,9 @@ class TestEmbeddingExporter(unittest.TestCase):
         mock_bigquery_client.return_value = mock_client
 
         # Call the function
-        load_embeddings_to_bigquery(gcs_folder, project_id, dataset_id, table_id)
+        load_job = load_embeddings_to_bigquery(
+            gcs_folder, project_id, dataset_id, table_id
+        )
 
         # Assertions
         mock_bigquery_client.assert_called_once_with(project=project_id)
@@ -356,6 +358,7 @@ class TestEmbeddingExporter(unittest.TestCase):
             destination=mock_client.dataset.return_value.table.return_value,
             job_config=ANY,
         )
+        self.assertEqual(load_job.output_rows, 1000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Features
When loading embeddings into BigQuery, return the load job info so that user could add check on it. For example, user could check whether the number of embeddings being loaded is expected.

### Testing

- Unit tested
- Integration tested