### PR TITLE
Improve Range Based Partitioning

### DIFF
--- a/python/gigl/common/data/load_torch_tensors.py
+++ b/python/gigl/common/data/load_torch_tensors.py
@@ -291,11 +291,10 @@ def load_torch_tensors_from_tf_record(
     else:
         # In this setting, we start and join each process one-at-a-time in order to achieve sequential tensor loading
         logger.info("Loading Serialized TFRecord Data in Sequence ...")
-        # Sequentially launch node, edge, and label loading processes to
-        # reduce the peak memory usage. Here we launch edge loading process
-        # first since edge data is larger than node data, so launching edge
-        # before launching node reduces peak memosry usage compared with
-        # first launching node loading and then launching edge loading.
+        # Here we launch edge loading process first since experimentally
+        # we have found that, since edge data is larger than node data,
+        # launching edge before launching node reduces peak memory usage
+        # compared with first launching node loading and then launching edge loading.
         edge_data_loading_process.start()
         edge_data_loading_process.join()
         node_data_loading_process.start()

--- a/python/gigl/common/data/load_torch_tensors.py
+++ b/python/gigl/common/data/load_torch_tensors.py
@@ -291,6 +291,11 @@ def load_torch_tensors_from_tf_record(
     else:
         # In this setting, we start and join each process one-at-a-time in order to achieve sequential tensor loading
         logger.info("Loading Serialized TFRecord Data in Sequence ...")
+        # Sequentially launch node, edge, and label loading processes to
+        # reduce the peak memory usage. Here we launch edge loading process
+        # first since edge data is larger than node data, so launching edge
+        # before launching node reduces peak memosry usage compared with
+        # first launching node loading and then launching edge loading.
         edge_data_loading_process.start()
         edge_data_loading_process.join()
         node_data_loading_process.start()
@@ -330,6 +335,11 @@ def load_torch_tensors_from_tf_record(
             f"Rank {rank} has finished loading data in {time.time() - start_time:.2f} seconds. Wait for other ranks to finish loading data from tfrecords"
         )
         barrier()
+
+    # Shutdown manager process to remove dependencies on large tensors,
+    # so that when we delete them in partitioner they will be garbage
+    # collected. Note that just deleting or clearing these output dicts here is not
+    # enough, and we have to shutdown the manager process.
 
     del node_output_dict, edge_output_dict, error_dict
 

--- a/python/gigl/common/data/load_torch_tensors.py
+++ b/python/gigl/common/data/load_torch_tensors.py
@@ -1,4 +1,3 @@
-import gc
 import time
 import traceback
 from dataclasses import dataclass
@@ -334,17 +333,6 @@ def load_torch_tensors_from_tf_record(
             f"Rank {rank} has finished loading data in {time.time() - start_time:.2f} seconds. Wait for other ranks to finish loading data from tfrecords"
         )
         barrier()
-
-    # Shutdown manager process to remove dependencies on large tensors,
-    # so that when we delete them in partitioner they will be garbage
-    # collected. Note that just deleting or clearing these output dicts here is not
-    # enough, and we have to shutdown the manager process.
-
-    del node_output_dict, edge_output_dict, error_dict
-
-    manager.shutdown()
-
-    gc.collect()
 
     logger.info(
         f"All ranks have finished loading data from tfrecords, rank {rank} finished in {time.time() - start_time:.2f} seconds"

--- a/python/gigl/common/data/load_torch_tensors.py
+++ b/python/gigl/common/data/load_torch_tensors.py
@@ -174,7 +174,8 @@ def load_torch_tensors_from_tf_record(
     serialized_graph_metadata: SerializedGraphMetadata,
     should_load_tensors_in_parallel: bool,
     rank: int = 0,
-    tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
+    node_tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
+    edge_tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
 ) -> LoadedGraphTensors:
     """
     Loads all torch tensors from a SerializedGraphMetadata object for all entity [node, edge, positive_label, negative_label] and edge / node types.
@@ -188,7 +189,8 @@ def load_torch_tensors_from_tf_record(
         serialized_graph_metadata (SerializedGraphMetadata): Serialized graph metadata contained serialized information for loading tfrecords across node and edge types
         should_load_tensors_in_parallel (bool): Whether tensors should be loaded from serialized information in parallel or in sequence across the [node, edge, pos_label, neg_label] entity types.
         rank (int): Rank on current machine
-        tf_dataset_options (TFDatasetOptions): The options to use when building the dataset.
+        node_tf_dataset_options (TFDatasetOptions): The options to use for nodes when building the dataset.
+        edge_tf_dataset_options (TFDatasetOptions): The options to use for edges when building the dataset.
     Returns:
         loaded_graph_tensors (LoadedGraphTensors): Unpartitioned Graph Tensors
     """
@@ -222,7 +224,7 @@ def load_torch_tensors_from_tf_record(
             "entity_type": _NODE_KEY,
             "serialized_tf_record_info": serialized_graph_metadata.node_entity_info,
             "rank": rank,
-            "tf_dataset_options": tf_dataset_options,
+            "tf_dataset_options": node_tf_dataset_options,
         },
     )
 
@@ -235,7 +237,7 @@ def load_torch_tensors_from_tf_record(
             "entity_type": _EDGE_KEY,
             "serialized_tf_record_info": serialized_graph_metadata.edge_entity_info,
             "rank": rank,
-            "tf_dataset_options": tf_dataset_options,
+            "tf_dataset_options": edge_tf_dataset_options,
         },
     )
 
@@ -249,7 +251,6 @@ def load_torch_tensors_from_tf_record(
                 "entity_type": _POSITIVE_LABEL_KEY,
                 "serialized_tf_record_info": serialized_graph_metadata.positive_label_entity_info,
                 "rank": rank,
-                "tf_dataset_options": tf_dataset_options,
             },
         )
     else:
@@ -265,7 +266,6 @@ def load_torch_tensors_from_tf_record(
                 "entity_type": _NEGATIVE_LABEL_KEY,
                 "serialized_tf_record_info": serialized_graph_metadata.negative_label_entity_info,
                 "rank": rank,
-                "tf_dataset_options": tf_dataset_options,
             },
         )
     else:

--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -53,7 +53,8 @@ def _load_and_build_partitioned_dataset(
     should_load_tensors_in_parallel: bool,
     edge_dir: Literal["in", "out"],
     partitioner_class: Optional[Type[DistPartitioner]],
-    tf_dataset_options: TFDatasetOptions,
+    node_tf_dataset_options: TFDatasetOptions,
+    edge_tf_dataset_options: TFDatasetOptions,
     splitter: Optional[NodeAnchorLinkSplitter] = None,
     _ssl_positive_label_percentage: Optional[float] = None,
 ) -> DistLinkPredictionDataset:
@@ -67,7 +68,8 @@ def _load_and_build_partitioned_dataset(
         edge_dir (Literal["in", "out"]): Edge direction of the provided graph
         partitioner_class (Optional[Type[DistPartitioner]]): Partitioner class to partition the graph inputs. If provided, this must be a
             DistPartitioner or subclass of it. If not provided, will initialize use the DistPartitioner class.
-        tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized data is read.
+        node_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized node data is read.
+        edge_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized edge data is read.
         splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets. If not provided (None), no splitting will be performed.
         _ssl_positive_label_percentage (Optional[float]): Percentage of edges to select as self-supervised labels. Must be None if supervised edge labels are provided in advance.
             Slotted for refactor once this functionality is available in the transductive `splitter` directly
@@ -91,7 +93,8 @@ def _load_and_build_partitioned_dataset(
         serialized_graph_metadata=serialized_graph_metadata,
         should_load_tensors_in_parallel=should_load_tensors_in_parallel,
         rank=rank,
-        tf_dataset_options=tf_dataset_options,
+        node_tf_dataset_options=node_tf_dataset_options,
+        edge_tf_dataset_options=edge_tf_dataset_options,
     )
 
     should_assign_edges_by_src_node: bool = False if edge_dir == "in" else True
@@ -200,7 +203,8 @@ def _build_dataset_process(
     sample_edge_direction: Literal["in", "out"],
     should_load_tensors_in_parallel: bool,
     partitioner_class: Optional[Type[DistPartitioner]],
-    tf_dataset_options: TFDatasetOptions,
+    node_tf_dataset_options: TFDatasetOptions,
+    edge_tf_dataset_options: TFDatasetOptions,
     splitter: Optional[NodeAnchorLinkSplitter] = None,
     _ssl_positive_label_percentage: Optional[float] = None,
 ) -> None:
@@ -232,7 +236,8 @@ def _build_dataset_process(
         should_load_tensors_in_parallel (bool): Whether tensors should be loaded from serialized information in parallel or in sequence across the [node, edge, pos_label, neg_label] entity types.
         partitioner_class (Optional[Type[DistPartitioner]]): Partitioner class to partition the graph inputs. If provided, this must be a
             DistPartitioner or subclass of it. If not provided, will initialize use the DistPartitioner class.
-        tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized data is read.
+        node_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized node data is read.
+        edge_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized edge data is read.
         splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets. If not provided (None), no splitting will be performed.
         _ssl_positive_label_percentage (Optional[float]): Percentage of edges to select as self-supervised labels. Must be None if supervised edge labels are provided in advance.
             Slotted for refactor once this functionality is available in the transductive `splitter` directly
@@ -256,7 +261,8 @@ def _build_dataset_process(
         should_load_tensors_in_parallel=should_load_tensors_in_parallel,
         edge_dir=sample_edge_direction,
         partitioner_class=partitioner_class,
-        tf_dataset_options=tf_dataset_options,
+        node_tf_dataset_options=node_tf_dataset_options,
+        edge_tf_dataset_options=edge_tf_dataset_options,
         splitter=splitter,
         _ssl_positive_label_percentage=_ssl_positive_label_percentage,
     )
@@ -275,7 +281,8 @@ def build_dataset(
     sample_edge_direction: Union[Literal["in", "out"], str],
     should_load_tensors_in_parallel: bool = True,
     partitioner_class: Optional[Type[DistPartitioner]] = None,
-    tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
+    node_tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
+    edge_tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
     splitter: Optional[NodeAnchorLinkSplitter] = None,
     _ssl_positive_label_percentage: Optional[float] = None,
     _dataset_building_port: int = DEFAULT_MASTER_DATA_BUILDING_PORT,
@@ -290,7 +297,8 @@ def build_dataset(
         should_load_tensors_in_parallel (bool): Whether tensors should be loaded from serialized information in parallel or in sequence across the [node, edge, pos_label, neg_label] entity types.
         partitioner_class (Optional[Type[DistPartitioner]]): Partitioner class to partition the graph inputs. If provided, this must be a
             DistPartitioner or subclass of it. If not provided, will initialize use the DistPartitioner class.
-        tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized data is read.
+        node_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized node data is read.
+        edge_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized edge data is read.
         splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets. If not provided (None), no splitting will be performed.
         _ssl_positive_label_percentage (Optional[float]): Percentage of edges to select as self-supervised labels. Must be None if supervised edge labels are provided in advance.
             Slotted for refactor once this functionality is available in the transductive `splitter` directly
@@ -323,7 +331,8 @@ def build_dataset(
             sample_edge_direction,
             should_load_tensors_in_parallel,
             partitioner_class,
-            tf_dataset_options,
+            node_tf_dataset_options,
+            edge_tf_dataset_options,
             splitter,
             _ssl_positive_label_percentage,
         ),

--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -331,6 +331,10 @@ def build_dataset(
 
     output_dataset: DistLinkPredictionDataset = output_dict["dataset"]
 
+    del output_dict
+
+    manager.shutdown()
+
     logger.info(
         f"--- Dataset Building finished on rank {distributed_context.global_rank}, which took {time.time()-dataset_building_start_time:.2f} seconds"
     )

--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -331,10 +331,6 @@ def build_dataset(
 
     output_dataset: DistLinkPredictionDataset = output_dict["dataset"]
 
-    del output_dict
-
-    manager.shutdown()
-
     logger.info(
         f"--- Dataset Building finished on rank {distributed_context.global_rank}, which took {time.time()-dataset_building_start_time:.2f} seconds"
     )

--- a/python/gigl/distributed/dist_partitioner.py
+++ b/python/gigl/distributed/dist_partitioner.py
@@ -582,6 +582,9 @@ class DistPartitioner:
                 of each item in the chunk.
             chunk_start_pos (int): The starting position of the current chunk being partitioned
             chunk_end_pos (int): The ending position of the current chunk being partitioned
+            generate_pb (bool): Whether a partition book should be generated. If set to False, will not send the indexed `rank_indices`
+                for the current rank to the partition manager to make the rpc communication easier
+
         """
         # chunk_res is a list where index `i` corresponds to Tuple[input_data_on_i, rank_indices_on_i]
         chunk_res: List[

--- a/python/gigl/distributed/dist_partitioner.py
+++ b/python/gigl/distributed/dist_partitioner.py
@@ -587,12 +587,12 @@ class DistPartitioner:
         chunk_length = chunk_end_pos - chunk_start_pos
         chunk_rank = partition_function(rank_indices, (chunk_start_pos, chunk_end_pos))
 
+        input_indices = torch.arange(chunk_length, dtype=torch.int64)
+
         for rank in range(self._world_size):
             # Filtering for items in chunk which are on the current partition `rank`
             current_rank_mask = chunk_rank == rank
-            per_rank_indices = torch.masked_select(
-                torch.arange(chunk_length, dtype=torch.long), current_rank_mask
-            )
+            per_rank_indices = torch.masked_select(input_indices, current_rank_mask)
             chunk_res.append(
                 (
                     index_select(input_data, per_rank_indices),

--- a/python/gigl/distributed/dist_partitioner.py
+++ b/python/gigl/distributed/dist_partitioner.py
@@ -33,7 +33,7 @@ class _DistLinkPredicitonPartitionManager(DistPartitionManager):
     """
 
     def __init__(
-        self, world_size: int, total_val_size: int = 1, generate_pb: bool = True
+        self, world_size: int, total_val_size: int = 0, generate_pb: bool = False
     ):
         """
         Initializes the partition manager.

--- a/python/gigl/distributed/dist_partitioner.py
+++ b/python/gigl/distributed/dist_partitioner.py
@@ -623,7 +623,7 @@ class DistPartitioner:
                 the specified indices in the chunk range while the second argument is the chunk start and end values. It returns a tuple indicating the rank
                 of each item in the chunk.
             total_val_size (int): The size of the partition book. Defaults to 0 in the case where there should be no partition book generated.
-            generate_pb (bool): Whether a partition book should be generated, defaults to False. This should only be set to true if partitioning nodes or edges for,
+            generate_pb (bool): Whether a partition book should be generated, defaults to False. This should only be set to true if partitioning nodes or edges for
                 tensor-based partitioning and should be false if partitioning node features or edge features or if doing range-based partitioning.
         Return:
             List[Tuple[torch.Tensor, ...]]: Partitioned results of the input generic data type

--- a/python/gigl/distributed/dist_partitioner.py
+++ b/python/gigl/distributed/dist_partitioner.py
@@ -620,8 +620,8 @@ class DistPartitioner:
                 the specified indices in the chunk range while the second argument is the chunk start and end values. It returns a tuple indicating the rank
                 of each item in the chunk.
             total_val_size (int): The size of the partition book. Defaults to 0 in the case where there should be no partition book generated.
-            generate_pb (bool): Whether a partition book should be generated, defaults to True. This should only be set to true if partitioning nodes or edges,
-                and should be false if partitioning node features or edge features.
+            generate_pb (bool): Whether a partition book should be generated, defaults to False. This should only be set to true if partitioning nodes or edges for,
+                tensor-based partitioning and should be false if partitioning node features or edge features or if doing range-based partitioning.
         Return:
             List[Tuple[torch.Tensor, ...]]: Partitioned results of the input generic data type
             Optional[torch.Tensor]: Torch Tensor if `generate_pb` is True, returns None if `generate_pb` is False

--- a/python/gigl/distributed/dist_range_partitioner.py
+++ b/python/gigl/distributed/dist_range_partitioner.py
@@ -228,9 +228,8 @@ class DistRangePartitioner(DistPartitioner):
 
         # Generating edge partition book
 
-        num_of_edges_on_current_rank = partitioned_edge_index.size(1)
         num_edges_on_each_rank: list[tuple[int, int]] = sorted(
-            all_gather((self._rank, num_of_edges_on_current_rank)).values(),
+            all_gather((self._rank, partitioned_edge_index.size(1))).values(),
             key=lambda x: x[0],
         )
 

--- a/python/gigl/distributed/dist_range_partitioner.py
+++ b/python/gigl/distributed/dist_range_partitioner.py
@@ -191,7 +191,7 @@ class DistRangePartitioner(DistPartitioner):
             partition_function=edge_partition_fn,
         )
 
-        del edge_index, target_indices, edge_feat
+        del input_data, edge_index, target_indices, edge_feat
         del self._edge_index[edge_type]
         if self._edge_feat is not None and edge_type in self._edge_feat:
             del self._edge_feat[edge_type]
@@ -215,6 +215,16 @@ class DistRangePartitioner(DistPartitioner):
                 ),
                 dim=0,
             )
+
+        if edge_feat_dim is not None:
+            if len(res_list) == 0:
+                partitioned_edge_features = torch.empty(0, edge_feat_dim)
+            else:
+                partitioned_edge_features = torch.cat([r[2] for r in res_list])
+
+        res_list.clear()
+
+        gc.collect()
 
         # Generating edge partition book
 
@@ -246,18 +256,9 @@ class DistRangePartitioner(DistPartitioner):
         if edge_feat_dim is None:
             current_feat_part = None
         else:
-            if len(res_list) == 0:
-                partitioned_edge_features = torch.empty(0, edge_feat_dim)
-            else:
-                partitioned_edge_features = torch.cat([r[2] for r in res_list])
-            # We don't need to store the partitioned edge feature ids for range-based partitioning, since this is available from the edge partition book
             current_feat_part = FeaturePartitionData(
                 feats=partitioned_edge_features, ids=None
             )
-
-        res_list.clear()
-
-        gc.collect()
 
         logger.info(
             f"Got edge range-based partition book for edge type {edge_type} on rank {self._rank} with partition bounds: {edge_partition_book.partition_bounds}"

--- a/python/gigl/distributed/distributed_neighborloader.py
+++ b/python/gigl/distributed/distributed_neighborloader.py
@@ -56,7 +56,7 @@ class DistNeighborLoader(DistLoader):
         pin_memory_device: Optional[torch.device] = None,
         worker_concurrency: int = 4,
         channel_size: str = "4GB",
-        process_start_gap_seconds: int = 60,
+        process_start_gap_seconds: float = 60.0,
         num_cpu_threads: Optional[int] = None,
         shuffle: bool = False,
         drop_last: bool = False,


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
Changes to improve the performance of range-based partitioning and TFRecord Dataloading
- Restructure `_partition_by_single_chunk` in partitioner so that the rank indices are only sent to RPC if we are generating a partition book, reducing RPC communication load
- Slight restructure of range-based partitioning to make cleanup happen earlier
- Delete reference to `input_data` so that its assets are cleaned up as well through reduced reference count
- Change `process_start_gap_seconds` in the neighbor loader to be float instead of int type, conforming better to params for `init_neighbor_loader_worker`
- Change dataset factory to pass `node_tf_dataset_options` and `edge_tf_dataset_options`, rather than just one singular `tf_dataset_options`. This is important to tune separately during load testing.
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
