### PR TITLE
Update `load_embeddings_from_bigquery` to run asynchronously

### DIFF
--- a/python/gigl/common/data/export.py
+++ b/python/gigl/common/data/export.py
@@ -215,7 +215,11 @@ class EmbeddingExporter:
 
 # TODO(kmonte): We should migrate this over to `BqUtils.load_files_to_bq` once that is implemented.
 def load_embeddings_to_bigquery(
-    gcs_folder: GcsUri, project_id: str, dataset_id: str, table_id: str
+    gcs_folder: GcsUri,
+    project_id: str,
+    dataset_id: str,
+    table_id: str,
+    should_run_async: bool = False,
 ) -> LoadJob:
     """
     Loads multiple Avro files containing GNN embeddings from GCS into BigQuery.
@@ -233,6 +237,7 @@ def load_embeddings_to_bigquery(
         project_id (str): The GCP project ID.
         dataset_id (str): The BigQuery dataset ID.
         table_id (str): The BigQuery table ID.
+        should_run_async (bool): Whether loading to bigquery step should happen asynchronously. Defaults to False.
 
     Returns:
         LoadJob: A BigQuery LoadJob object representing the load operation, which allows
@@ -260,9 +265,14 @@ def load_embeddings_to_bigquery(
         job_config=job_config,
     )
 
-    load_job.result()  # Wait for the job to complete.
-    logger.info(
-        f"Loading {load_job.output_rows:,} rows into {dataset_id}:{table_id} in {time.perf_counter() - start:.2f} seconds."
-    )
+    if should_run_async:
+        logger.info(
+            f"Started loading process for {dataset_id}:{table_id}, running asynchronously"
+        )
+    else:
+        load_job.result()  # Wait for the job to complete.
+        logger.info(
+            f"Loading {load_job.output_rows:,} rows into {dataset_id}:{table_id} in {time.perf_counter() - start:.2f} seconds."
+        )
 
     return load_job

--- a/python/gigl/common/data/export.py
+++ b/python/gigl/common/data/export.py
@@ -241,7 +241,7 @@ def load_embeddings_to_bigquery(
 
     Returns:
         LoadJob: A BigQuery LoadJob object representing the load operation, which allows
-        user to monitor and retrieve details about the job status and result. The return job will be done if
+        user to monitor and retrieve details about the job status and result. The returned job will be done if
         `should_run_async=False` and will be returned immediately after creation (not necessarily complete) if
         `should_run_asnyc=True`.
     """
@@ -269,7 +269,7 @@ def load_embeddings_to_bigquery(
 
     if should_run_async:
         logger.info(
-            f"Started loading process for {dataset_id}:{table_id}, running asynchronously"
+            f"Started loading process for {dataset_id}:{table_id} with job id {load_job.job_id}, running asynchronously"
         )
     else:
         load_job.result()  # Wait for the job to complete.

--- a/python/gigl/common/data/export.py
+++ b/python/gigl/common/data/export.py
@@ -241,7 +241,9 @@ def load_embeddings_to_bigquery(
 
     Returns:
         LoadJob: A BigQuery LoadJob object representing the load operation, which allows
-        user to monitor and retrieve details about the job status and result.
+        user to monitor and retrieve details about the job status and result. The return job will be done if
+        `should_run_async=False` and will be returned immediately after creation (not necessarily complete) if
+        `should_run_asnyc=True`.
     """
     start = time.perf_counter()
     logger.info(f"Loading embeddings from {gcs_folder} to BigQuery.")

--- a/python/tests/unit/common/data/export_test.py
+++ b/python/tests/unit/common/data/export_test.py
@@ -1,6 +1,5 @@
 import io
 import tempfile
-import time
 import unittest
 from pathlib import Path
 from typing import List, Optional
@@ -369,12 +368,6 @@ class TestEmbeddingExporter(unittest.TestCase):
             table_id,
             should_run_async=should_run_async,
         )
-
-        if should_run_async:
-            # Waiting for load job to finish without relying on `load_job.result()`. This way, we ensure that job was able to start and finish
-            # asynchronously.
-            while not load_job.done():
-                time.sleep(1)
 
         # Assertions
         mock_bigquery_client.assert_called_once_with(project=project_id)

--- a/python/tests/unit/common/data/export_test.py
+++ b/python/tests/unit/common/data/export_test.py
@@ -1,5 +1,6 @@
 import io
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from typing import List, Optional
@@ -333,8 +334,22 @@ class TestEmbeddingExporter(unittest.TestCase):
         exporter = EmbeddingExporter(export_dir=gcs_base_uri)
         exporter.flush_embeddings()
 
+    @parameterized.expand(
+        [
+            param(
+                "Test if we can load embeddings synchronously",
+                should_run_async=False,
+            ),
+            param(
+                "Test if we can load embeddings asynchronously",
+                should_run_async=True,
+            ),
+        ]
+    )
     @patch("gigl.common.data.export.bigquery.Client")
-    def test_load_embedding_to_bigquery(self, mock_bigquery_client):
+    def test_load_embedding_to_bigquery(
+        self, _, mock_bigquery_client, should_run_async: bool
+    ):
         # Mock inputs
         gcs_folder = GcsUri("gs://test-bucket/test-folder")
         project_id = "test-project"
@@ -348,8 +363,18 @@ class TestEmbeddingExporter(unittest.TestCase):
 
         # Call the function
         load_job = load_embeddings_to_bigquery(
-            gcs_folder, project_id, dataset_id, table_id
+            gcs_folder,
+            project_id,
+            dataset_id,
+            table_id,
+            should_run_async=should_run_async,
         )
+
+        if should_run_async:
+            # Waiting for load job to finish without relying on `laod_job.result()`. This way, we ensure that job was able to start and finish
+            # asynchronously.
+            while not load_job.done():
+                time.sleep(1)
 
         # Assertions
         mock_bigquery_client.assert_called_once_with(project=project_id)

--- a/python/tests/unit/common/data/export_test.py
+++ b/python/tests/unit/common/data/export_test.py
@@ -371,7 +371,7 @@ class TestEmbeddingExporter(unittest.TestCase):
         )
 
         if should_run_async:
-            # Waiting for load job to finish without relying on `laod_job.result()`. This way, we ensure that job was able to start and finish
+            # Waiting for load job to finish without relying on `load_job.result()`. This way, we ensure that job was able to start and finish
             # asynchronously.
             while not load_job.done():
                 time.sleep(1)


### PR DESCRIPTION
**Scope of work done**
- Updates `load_embeddings_from_bigquery` to have asynchronous support so that we aren't blocking on BQ finishing

We want this for heterogeneous inference so that we can begin the inference process for the next node type without requiring this step to be finished for the previous inference node type. See [here](https://github.com/Snapchat/GiGL/pull/20#discussion_r2082618610) for more context.

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
