### PR TITLE
Update Connect Worker Pool

### DIFF
--- a/python/gigl/common/utils/vertex_ai_context.py
+++ b/python/gigl/common/utils/vertex_ai_context.py
@@ -2,13 +2,12 @@
 
 import os
 import subprocess
-import time
+from typing import List, Optional
 
-from gigl.common import GcsUri
+import torch.distributed as dist
+
 from gigl.common.logger import Logger
-from gigl.common.services.vertex_ai import LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY
-from gigl.common.utils.gcs import GcsUtils
-from gigl.distributed import DistributedContext
+from gigl.distributed.dist_context import DistributedContext
 
 logger = Logger()
 
@@ -110,69 +109,27 @@ def connect_worker_pool() -> DistributedContext:
     to get the leader worker's internal IP address and to ensure that the workers
     can all communicate with the leader worker.
     """
-
     global_rank = get_rank()
     global_world_size = get_world_size()
+    # Uses the VAI-set environment variables for `RANK`, `WORLD_SIZE`, `MASTER_IP_ADDRESS`, and `MASTER_PORT` for setting up the process group
+    dist.init_process_group(backend="gloo")
 
     is_leader_worker = global_rank == 0
-    ip_file_uri = GcsUri(_get_leader_worker_internal_ip_file_path())
-    gcs_utils = GcsUtils()
-    host_ip: str
+    broadcast_list: List[Optional[str]]
     if is_leader_worker:
-        logger.info("Wait 180 seconds for the leader machine to settle down.")
-        time.sleep(180)
         host_ip = subprocess.check_output(["hostname", "-i"]).decode().strip()
-        logger.info(f"Writing host IP address ({host_ip}) to {ip_file_uri}")
-        gcs_utils.upload_from_string(gcs_path=ip_file_uri, content=host_ip)
+        broadcast_list = [host_ip]
     else:
-        max_retries = 60
-        interval_s = 30
-        for attempt_num in range(1, max_retries + 1):
-            logger.info(
-                f"Checking if {ip_file_uri} exists and reading HOST_IP (attempt {attempt_num})..."
-            )
-            try:
-                host_ip = gcs_utils.read_from_gcs(ip_file_uri)
-                logger.info(f"Pinging host ip ({host_ip}) ...")
-                if _ping_host_ip(host_ip):
-                    logger.info(f"Ping to host ip ({host_ip}) was successful.")
-                    break
-            except Exception as e:
-                logger.info(e)
-            logger.info(
-                f"Retrieving host information and/or ping failed, retrying in {interval_s} seconds..."
-            )
-            time.sleep(interval_s)
-        if attempt_num >= max_retries:
-            logger.info(
-                f"Failed to ping HOST_IP after {max_retries} attempts. Exiting."
-            )
-            raise Exception(f"Failed to ping HOST_IP after {max_retries} attempts.")
+        broadcast_list = [None]
 
+    dist.broadcast_object_list(object_list=broadcast_list, src=0)
+    main_worker_ip_address = broadcast_list[0]
+    assert main_worker_ip_address is not None
+
+    # Tears down the process group, since we no longer need it for establishing communication between machines
+    dist.destroy_process_group()
     return DistributedContext(
-        main_worker_ip_address=host_ip,
+        main_worker_ip_address=main_worker_ip_address,
         global_rank=global_rank,
         global_world_size=global_world_size,
     )
-
-
-def _get_leader_worker_internal_ip_file_path() -> str:
-    """
-    Get the file path to the leader worker's internal IP address.
-    """
-    assert is_currently_running_in_vertex_ai_job(), "Not running in Vertex AI job."
-    internal_ip_file_path = os.getenv(LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY)
-    assert internal_ip_file_path is not None, (
-        f"Internal IP file path ({LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY}) "
-        + f"not found in environment variables. {os.environ}"
-    )
-
-    return internal_ip_file_path
-
-
-def _ping_host_ip(host_ip: str) -> bool:
-    try:
-        subprocess.check_output(["ping", "-c", "1", host_ip])
-        return True
-    except subprocess.CalledProcessError:
-        return False

--- a/python/tests/unit/common/utils/vertex_ai_context_test.py
+++ b/python/tests/unit/common/utils/vertex_ai_context_test.py
@@ -1,9 +1,7 @@
 import os
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import patch
 
-from gigl.common import GcsUri
-from gigl.common.services.vertex_ai import LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY
 from gigl.common.utils.vertex_ai_context import (
     DistributedContext,
     connect_worker_pool,
@@ -63,55 +61,58 @@ class TestVertexAIContext(unittest.TestCase):
         with self.assertRaises(Exception):
             get_rank()
 
+    @patch("torch.distributed.init_process_group")
+    @patch("torch.distributed.broadcast_object_list")
     @patch("subprocess.check_output", return_value=b"127.0.0.1")
     @patch("time.sleep", return_value=None)
-    @patch("gigl.common.utils.gcs.GcsUtils.upload_from_string")
     @patch.dict(
         os.environ,
         {
             "RANK": "0",
             "WORLD_SIZE": "2",
-            LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY: "gs://FAKE BUCKET DNE/some-file.txt",
             "CLOUD_ML_JOB_ID": "test_job_id",
         },
     )
-    def test_connect_worker_pool_leader(self, mock_upload, mock_sleep, mock_subprocess):
+    def test_connect_worker_pool_leader(
+        self,
+        mock_sleep,
+        mock_check_output,
+        mock_broadcast_object_list,
+        mock_init_process_group,
+    ):
         distributed_context: DistributedContext = connect_worker_pool()
         self.assertEqual(distributed_context.main_worker_ip_address, "127.0.0.1")
         self.assertEqual(distributed_context.global_rank, 0)
         self.assertEqual(distributed_context.global_world_size, 2)
-        mock_upload.assert_called_once_with(
-            gcs_path=GcsUri("gs://FAKE BUCKET DNE/some-file.txt"), content="127.0.0.1"
-        )
 
-    @patch("gigl.common.utils.vertex_ai_context._ping_host_ip")
+    @patch("torch.distributed.init_process_group")
+    @patch("torch.distributed.broadcast_object_list")
     @patch("subprocess.check_output", return_value=b"127.0.0.1")
     @patch("time.sleep", return_value=None)
-    @patch("gigl.common.utils.gcs.GcsUtils.read_from_gcs", return_value="127.0.0.1")
-    @patch("gigl.common.utils.gcs.GcsUtils.upload_from_string")
     @patch.dict(
         os.environ,
         {
             "RANK": "1",
             "WORLD_SIZE": "2",
-            LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY: "gs://FAKE BUCKET DNE/some-file.txt",
             "CLOUD_ML_JOB_ID": "test_job_id",
         },
     )
     def test_connect_worker_pool_worker(
-        self, mock_upload, mock_read, mock_sleep, mock_subprocess, mock_ping_host
+        self,
+        mock_sleep,
+        mock_check_output,
+        mock_broadcast_object_list,
+        mock_init_process_group,
     ):
-        mock_ping_host.side_effect = [False, True]
+        def _mock_broadcast_object_list(object_list, src):
+            # Simulate broadcasting
+            object_list[0] = "127.0.0.1"
+
+        mock_broadcast_object_list.side_effect = _mock_broadcast_object_list
         distributed_context: DistributedContext = connect_worker_pool()
         self.assertEqual(distributed_context.main_worker_ip_address, "127.0.0.1")
         self.assertEqual(distributed_context.global_rank, 1)
         self.assertEqual(distributed_context.global_world_size, 2)
-        mock_read.assert_has_calls(
-            [
-                call(GcsUri("gs://FAKE BUCKET DNE/some-file.txt")),
-                call(GcsUri("gs://FAKE BUCKET DNE/some-file.txt")),
-            ]
-        )
 
 
 if __name__ == "__main__":

--- a/python/tests/unit/common/utils/vertex_ai_context_test.py
+++ b/python/tests/unit/common/utils/vertex_ai_context_test.py
@@ -63,6 +63,7 @@ class TestVertexAIContext(unittest.TestCase):
 
     @patch("torch.distributed.init_process_group")
     @patch("torch.distributed.broadcast_object_list")
+    @patch("torch.distributed.destroy_process_group")
     @patch("subprocess.check_output", return_value=b"127.0.0.1")
     @patch("time.sleep", return_value=None)
     @patch.dict(
@@ -77,6 +78,7 @@ class TestVertexAIContext(unittest.TestCase):
         self,
         mock_sleep,
         mock_check_output,
+        mock_destroy_process_group,
         mock_broadcast_object_list,
         mock_init_process_group,
     ):
@@ -87,6 +89,7 @@ class TestVertexAIContext(unittest.TestCase):
 
     @patch("torch.distributed.init_process_group")
     @patch("torch.distributed.broadcast_object_list")
+    @patch("torch.distributed.destroy_process_group")
     @patch("subprocess.check_output", return_value=b"127.0.0.1")
     @patch("time.sleep", return_value=None)
     @patch.dict(
@@ -101,6 +104,7 @@ class TestVertexAIContext(unittest.TestCase):
         self,
         mock_sleep,
         mock_check_output,
+        mock_destroy_process_group,
         mock_broadcast_object_list,
         mock_init_process_group,
     ):


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- Updates `connect_worker_pool` so that we are using `torch.distributed.init_process_group` to communicate the main_worker_ip_address across the machines, rather than writing the IP address to GCP and using `ping`
- Decrease time for `connect_worker_pool` from 3 minutes to ~5 seconds

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write  a test plan?
[VAI Inference Job
](https://console.cloud.google.com/vertex-ai/locations/us-central1/training/848264029599170560)<img width="1247" alt="Screenshot 2025-05-19 at 6 04 37 PM" src="https://github.com/user-attachments/assets/ef5ead6d-611e-494d-beb8-26f78f9c4a4f" />


***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
