### PR TITLE
Add local world size to Distributed Context

### DIFF
--- a/examples/distributed/homogeneous_inference.py
+++ b/examples/distributed/homogeneous_inference.py
@@ -115,7 +115,6 @@ def _inference_process(
     # When spawning processes, each process will be assigned a rank ranging
     # from [0, num_processes).
     process_number_on_current_machine: int,
-    num_inference_processes_per_machine: int,
     distributed_context: DistributedContext,
     embedding_gcs_path: GcsUri,
     model_state_dict_uri: GcsUri,
@@ -134,7 +133,6 @@ def _inference_process(
 
     Args:
         process_number_on_current_machine (int): Process number on the current machine
-        num_inference_processes_per_machine (int): Number of inference processes spawned by each machine
         distributed_context (DistributedContext): Distributed context containing information for master_ip_address, rank, and world size
         embedding_gcs_path (GcsUri): GCS path to load embeddings from
         model_state_dict_uri (GcsUri): GCS path to load model from
@@ -181,7 +179,6 @@ def _inference_process(
         num_neighbors=num_neighbors,
         context=distributed_context,
         local_process_rank=process_number_on_current_machine,
-        local_process_world_size=num_inference_processes_per_machine,
         input_nodes=None,  # Since homogeneous, `None` defaults to using all nodes for inference loop
         num_workers=sampling_workers_per_inference_process,
         batch_size=inference_batch_size,
@@ -319,7 +316,8 @@ def _run_example_inference(
     # All machines run this logic to connect together, and return a distributed context with:
     # - the (GCP) internal IP address of the rank 0 machine, which will be used by GLT for building RPC connections.
     # - the current machine rank
-    # - the total number of machines (world size)
+    # - the total number of machines (global world size)
+    # - the number of inference processes per machine (local world size)
 
     program_start_time = time.time()
 
@@ -371,10 +369,6 @@ def _run_example_inference(
 
     inference_batch_size = gbml_config_pb_wrapper.inferencer_config.inference_batch_size
 
-    num_inference_processes_per_machine = int(
-        inferencer_args.get("num_inference_processes_per_machine", "4")
-    )  # Current large-scale setting sets this value to 4
-
     ## Inference Start
 
     inference_start_time = time.time()
@@ -383,7 +377,6 @@ def _run_example_inference(
     mp.spawn(
         fn=_inference_process,
         args=(
-            num_inference_processes_per_machine,
             distributed_context,
             embedding_output_gcs_folder,
             model_uri,
@@ -394,7 +387,7 @@ def _run_example_inference(
             node_feature_dim,
             edge_feature_dim,
         ),
-        nprocs=num_inference_processes_per_machine,
+        nprocs=distributed_context.local_world_size,
         join=True,
     )
 

--- a/python/gigl/common/utils/vertex_ai_context.py
+++ b/python/gigl/common/utils/vertex_ai_context.py
@@ -124,7 +124,7 @@ def connect_worker_pool() -> DistributedContext:
 
     global_rank = get_rank()
     global_world_size = get_world_size()
-    local_world_Size = get_local_world_size()
+    local_world_size = get_local_world_size()
 
     is_leader_worker = global_rank == 0
     ip_file_uri = GcsUri(_get_leader_worker_internal_ip_file_path())
@@ -165,7 +165,7 @@ def connect_worker_pool() -> DistributedContext:
         main_worker_ip_address=host_ip,
         global_rank=global_rank,
         global_world_size=global_world_size,
-        local_world_Size=local_world_Size,
+        local_world_size=local_world_size,
     )
 
 

--- a/python/gigl/common/utils/vertex_ai_context.py
+++ b/python/gigl/common/utils/vertex_ai_context.py
@@ -73,6 +73,17 @@ def get_leader_port() -> int:
     return int(os.environ.get("MASTER_PORT", 29500))
 
 
+def get_local_world_size() -> int:
+    """
+    The total number of processes spun up on each VAI Machine. This is currently is manually set upon launching a VAI job manually for GLT processes.
+    We should deprecate this in the future if we migrate VAI jobs to be spun up with torchrun instead.
+    Throws if not on Vertex AI.
+    """
+    if not is_currently_running_in_vertex_ai_job():
+        raise _VAI_EXCEPTION
+    return int(os.environ.get("LOCAL_WORLD_SIZE", 1))
+
+
 def get_world_size() -> int:
     """
     The total number of processes that VAI creates. Note that VAI only creates one process per machine.
@@ -111,6 +122,7 @@ def connect_worker_pool() -> DistributedContext:
     """
     global_rank = get_rank()
     global_world_size = get_world_size()
+    local_world_size = get_local_world_size()
     # Uses the VAI-set environment variables for `RANK`, `WORLD_SIZE`, `MASTER_IP_ADDRESS`, and `MASTER_PORT` for setting up the process group
     dist.init_process_group(backend="gloo")
 
@@ -132,4 +144,5 @@ def connect_worker_pool() -> DistributedContext:
         main_worker_ip_address=main_worker_ip_address,
         global_rank=global_rank,
         global_world_size=global_world_size,
+        local_world_size=local_world_size,
     )

--- a/python/gigl/common/utils/vertex_ai_context.py
+++ b/python/gigl/common/utils/vertex_ai_context.py
@@ -2,13 +2,12 @@
 
 import os
 import subprocess
-import time
+from typing import List, Optional
 
-from gigl.common import GcsUri
+import torch.distributed as dist
+
 from gigl.common.logger import Logger
-from gigl.common.services.vertex_ai import LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY
-from gigl.common.utils.gcs import GcsUtils
-from gigl.distributed import DistributedContext
+from gigl.distributed.dist_context import DistributedContext
 
 logger = Logger()
 
@@ -110,69 +109,27 @@ def connect_worker_pool() -> DistributedContext:
     to get the leader worker's internal IP address and to ensure that the workers
     can all communicate with the leader worker.
     """
-
     global_rank = get_rank()
     global_world_size = get_world_size()
+    # Uses the VAI-set environment variables for `RANK`, `WORLD_SIZE`, `MASTER_IP_ADDRESS`, and `MASTER_PORT` for setting up the process group
+    dist.init_process_group(backend="gloo")
 
     is_leader_worker = global_rank == 0
-    ip_file_uri = GcsUri(_get_leader_worker_internal_ip_file_path())
-    gcs_utils = GcsUtils()
-    host_ip: str
+    broadcast_list: List[Optional[str]]
     if is_leader_worker:
-        logger.info("Wait 180 seconds for the leader machine to settle down.")
-        time.sleep(180)
         host_ip = subprocess.check_output(["hostname", "-i"]).decode().strip()
-        logger.info(f"Writing host IP address ({host_ip}) to {ip_file_uri}")
-        gcs_utils.upload_from_string(gcs_path=ip_file_uri, content=host_ip)
+        broadcast_list = [host_ip]
     else:
-        max_retries = 60
-        interval_s = 30
-        for attempt_num in range(1, max_retries + 1):
-            logger.info(
-                f"Checking if {ip_file_uri} exists and reading HOST_IP (attempt {attempt_num})..."
-            )
-            try:
-                host_ip = gcs_utils.read_from_gcs(ip_file_uri)
-                logger.info(f"Pinging host ip ({host_ip}) ...")
-                if _ping_host_ip(host_ip):
-                    logger.info(f"Ping to host ip ({host_ip}) was successful.")
-                    break
-            except Exception as e:
-                logger.info(e)
-            logger.info(
-                f"Retrieving host information and/or ping failed, retrying in {interval_s} seconds..."
-            )
-            time.sleep(interval_s)
-        if attempt_num >= max_retries:
-            logger.info(
-                f"Failed to ping HOST_IP after {max_retries} attempts. Exiting."
-            )
-            raise Exception(f"Failed to ping HOST_IP after {max_retries} attempts.")
+        broadcast_list = [None]
 
+    dist.broadcast_object_list(object_list=broadcast_list, src=0)
+    main_worker_ip_address = broadcast_list[0]
+    assert main_worker_ip_address is not None
+
+    # Tears down the process group, since we no longer need it for establishing communication between machines
+    dist.destroy_process_group()
     return DistributedContext(
-        main_worker_ip_address=host_ip,
+        main_worker_ip_address=main_worker_ip_address,
         global_rank=global_rank,
         global_world_size=global_world_size,
     )
-
-
-def _get_leader_worker_internal_ip_file_path() -> str:
-    """
-    Get the file path to the leader worker's internal IP address.
-    """
-    assert is_currently_running_in_vertex_ai_job(), "Not running in Vertex AI job."
-    internal_ip_file_path = os.getenv(LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY)
-    assert internal_ip_file_path is not None, (
-        f"Internal IP file path ({LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY}) "
-        + f"not found in environment variables. {os.environ}"
-    )
-
-    return internal_ip_file_path
-
-
-def _ping_host_ip(host_ip: str) -> bool:
-    try:
-        subprocess.check_output(["ping", "-c", "1", host_ip])
-        return True
-    except subprocess.CalledProcessError:
-        return False

--- a/python/gigl/distributed/dist_context.py
+++ b/python/gigl/distributed/dist_context.py
@@ -17,3 +17,6 @@ class DistributedContext:
 
     # Total number of machines
     global_world_size: int
+
+    # Total number of training / inference processes to launch per machine
+    local_world_size: int

--- a/python/gigl/distributed/distributed_neighborloader.py
+++ b/python/gigl/distributed/distributed_neighborloader.py
@@ -232,11 +232,8 @@ class DistNeighborLoader(DistLoader):
             )
             num_cpu_threads = DEFAULT_NUM_CPU_THREADS
         gigl.distributed.utils.init_neighbor_loader_worker(
-            master_ip_address=context.main_worker_ip_address,
+            distributed_context=context,
             local_process_rank=local_process_rank,
-            local_process_world_size=context.local_world_size,
-            rank=context.global_rank,
-            world_size=context.global_world_size,
             master_worker_port=_main_inference_port,
             device=device,
             should_use_cpu_workers=should_use_cpu_workers,

--- a/python/gigl/distributed/utils/init_neighbor_loader_worker.py
+++ b/python/gigl/distributed/utils/init_neighbor_loader_worker.py
@@ -7,6 +7,7 @@ import torch
 from graphlearn_torch.distributed import init_rpc, init_worker_group
 
 from gigl.common.logger import Logger
+from gigl.distributed.dist_context import DistributedContext
 
 logger = Logger()
 
@@ -28,11 +29,8 @@ def get_process_group_name(process_rank: int) -> str:
 # That way the "side-effects" of the call are only executed once.
 @lru_cache(maxsize=1)
 def init_neighbor_loader_worker(
-    master_ip_address: str,
+    distributed_context: DistributedContext,
     local_process_rank: int,
-    local_process_world_size: int,
-    rank: int,
-    world_size: int,
     master_worker_port: int,
     device: torch.device,
     should_use_cpu_workers: bool = False,
@@ -43,11 +41,8 @@ def init_neighbor_loader_worker(
     Sets up processes and torch device for initializing the GLT DistNeighborLoader, setting up RPC and worker groups to minimize
     the memory overhead and CPU contention. Returns the torch device which current worker is assigned to.
     Args:
-        master_ip_address (str): Master IP Address to manage processes
+        distributed_context (DistributedContext): Distributed context for the current process
         local_process_rank (int): Process number on the current machine
-        local_process_world_size (int): Total number of processes on the current machine
-        rank (int): Rank of current machine
-        world_size (int): Total number of machines
         master_worker_port (int): Master port to use for communicating between workers during training or inference
         device (torch.device): The device where you want to load the data onto - i.e. where is your model?
         should_use_cpu_workers (bool): Whether we should do CPU training or inference.
@@ -66,10 +61,12 @@ def init_neighbor_loader_worker(
     # usage will add up and cause CPU memory OOM. Hence, we initiate the data loaders group by group
     # to smooth the memory usage. The definition of group is discussed below.
     logger.info(
-        f"---Machine {rank} local process number {local_process_rank} preparing to sleep for {process_start_gap_seconds * local_process_rank} seconds"
+        f"---Machine {distributed_context.global_rank} local process number {local_process_rank} preparing to sleep for {process_start_gap_seconds * local_process_rank} seconds"
     )
     time.sleep(process_start_gap_seconds * local_process_rank)
-    logger.info(f"---Machine {rank} local process number {local_process_rank} started")
+    logger.info(
+        f"---Machine {distributed_context.global_rank} local process number {local_process_rank} started"
+    )
     if not should_use_cpu_workers:
         assert (
             torch.cuda.device_count() > 0
@@ -85,11 +82,13 @@ def init_neighbor_loader_worker(
 
         # Compute the range of physical cores the process should run on.
         total_physical_cores = psutil.cpu_count(logical=False)
-        physical_cores_per_process = total_physical_cores // local_process_world_size
+        physical_cores_per_process = (
+            total_physical_cores // distributed_context.local_world_size
+        )
         start_physical_core = local_process_rank * physical_cores_per_process
         end_physical_core = (
             total_physical_cores
-            if local_process_rank == local_process_world_size - 1
+            if local_process_rank == distributed_context.local_world_size - 1
             else start_physical_core + physical_cores_per_process
         )
 
@@ -130,7 +129,7 @@ def init_neighbor_loader_worker(
         torch.cuda.set_device(device)
         torch.cuda.empty_cache()
         logger.info(
-            f"Machine {rank} local rank {local_process_rank} uses device {torch.cuda.current_device()} by default"
+            f"Machine {distributed_context.global_rank} local rank {local_process_rank} uses device {torch.cuda.current_device()} by default"
         )
 
     # Group of workers. Each process is a worker. Each
@@ -147,11 +146,11 @@ def init_neighbor_loader_worker(
 
     group_name = get_process_group_name(local_process_rank)
     logger.info(
-        f"Init worker group with: world_size={world_size}, rank={rank}, group_name={group_name}, "
+        f"Init worker group with: world_size={distributed_context.global_world_size}, rank={distributed_context.global_rank}, group_name={group_name}, "
     )
     init_worker_group(
-        world_size=world_size,
-        rank=rank,
+        world_size=distributed_context.global_world_size,
+        rank=distributed_context.global_rank,
         group_name=group_name,
     )
 
@@ -164,10 +163,10 @@ def init_neighbor_loader_worker(
     # Note that different process groups are independent of each other. Therefore,
     # they have to use different master ports.
     logger.info(
-        f"Initing worker group with: world_size={world_size}, rank={rank}, group_name={group_name}, "
+        f"Initing worker group with: world_size={distributed_context.global_world_size}, rank={distributed_context.global_rank}, group_name={group_name}, "
     )
     init_rpc(
-        master_addr=master_ip_address,
+        master_addr=distributed_context.main_worker_ip_address,
         master_port=master_worker_port + local_process_rank,
         rpc_timeout=600,
     )

--- a/python/gigl/src/inference/v2/glt_inferencer.py
+++ b/python/gigl/src/inference/v2/glt_inferencer.py
@@ -71,6 +71,9 @@ class GLTInferencer:
         inference_process_runtime_args = (
             gbml_config_pb_wrapper.inferencer_config.inferencer_args
         )
+        local_world_size = inference_process_runtime_args.get(
+            "num_inference_processes_per_machine", "1"
+        )
         assert isinstance(
             resource_config_wrapper.inferencer_config, VertexAiResourceConfig
         )
@@ -105,6 +108,7 @@ class GLTInferencer:
             args=job_args,
             environment_variables=[
                 {"name": "TF_CPP_MIN_LOG_LEVEL", "value": "3"},
+                {"name": "LOCAL_WORLD_SIZE", "value": local_world_size},
             ],
             machine_type=inferencer_resource_config.machine_type,
             accelerator_type=inferencer_resource_config.gpu_type.upper().replace(

--- a/python/tests/test_assets/distributed/run_distributed_dataset.py
+++ b/python/tests/test_assets/distributed/run_distributed_dataset.py
@@ -63,6 +63,7 @@ def run_distributed_dataset(
         main_worker_ip_address=master_ip_address,
         global_rank=rank,
         global_world_size=world_size,
+        local_world_size=1,
     )
 
     sample_edge_direction: Literal["in", "out"] = "out"

--- a/python/tests/unit/common/utils/vertex_ai_context_test.py
+++ b/python/tests/unit/common/utils/vertex_ai_context_test.py
@@ -1,9 +1,7 @@
 import os
 import unittest
-from unittest.mock import call, patch
+from unittest.mock import patch
 
-from gigl.common import GcsUri
-from gigl.common.services.vertex_ai import LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY
 from gigl.common.utils.vertex_ai_context import (
     DistributedContext,
     connect_worker_pool,
@@ -63,55 +61,58 @@ class TestVertexAIContext(unittest.TestCase):
         with self.assertRaises(Exception):
             get_rank()
 
+    @patch("torch.distributed.init_process_group")
+    @patch("torch.distributed.broadcast_object_list")
     @patch("subprocess.check_output", return_value=b"127.0.0.1")
     @patch("time.sleep", return_value=None)
-    @patch("gigl.common.utils.gcs.GcsUtils.upload_from_string")
     @patch.dict(
         os.environ,
         {
             "RANK": "0",
             "WORLD_SIZE": "2",
-            LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY: "gs://FAKE BUCKET DNE/some-file.txt",
             "CLOUD_ML_JOB_ID": "test_job_id",
         },
     )
-    def test_connect_worker_pool_leader(self, mock_upload, mock_sleep, mock_subprocess):
+    def test_connect_worker_pool_leader(
+        self,
+        mock_sleep,
+        mock_check_output,
+        mock_broadcast_object_list,
+        mock_init_process_group,
+    ):
         distributed_context: DistributedContext = connect_worker_pool()
         self.assertEqual(distributed_context.main_worker_ip_address, "127.0.0.1")
         self.assertEqual(distributed_context.global_rank, 0)
         self.assertEqual(distributed_context.global_world_size, 2)
-        mock_upload.assert_called_once_with(
-            gcs_path=GcsUri("gs://FAKE BUCKET DNE/some-file.txt"), content="127.0.0.1"
-        )
 
-    @patch("gigl.common.utils.vertex_ai_context._ping_host_ip")
+    @patch("torch.distributed.init_process_group")
+    @patch("torch.distributed.broadcast_object_list")
     @patch("subprocess.check_output", return_value=b"127.0.0.1")
     @patch("time.sleep", return_value=None)
-    @patch("gigl.common.utils.gcs.GcsUtils.read_from_gcs", return_value="127.0.0.1")
-    @patch("gigl.common.utils.gcs.GcsUtils.upload_from_string")
     @patch.dict(
         os.environ,
         {
             "RANK": "1",
             "WORLD_SIZE": "2",
-            LEADER_WORKER_INTERNAL_IP_FILE_PATH_ENV_KEY: "gs://FAKE BUCKET DNE/some-file.txt",
             "CLOUD_ML_JOB_ID": "test_job_id",
         },
     )
     def test_connect_worker_pool_worker(
-        self, mock_upload, mock_read, mock_sleep, mock_subprocess, mock_ping_host
+        self,
+        mock_sleep,
+        mock_check_output,
+        mock_broadcast_object_list,
+        mock_init_process_group,
     ):
-        mock_ping_host.side_effect = [False, True]
+        def _mock_broadcast_object_list(object_list, src):
+            # Simulate broadcasting
+            object_list[0] = "127.0.0.1"
+
+        mock_broadcast_object_list.side_effect = _mock_broadcast_object_list
         distributed_context: DistributedContext = connect_worker_pool()
         self.assertEqual(distributed_context.main_worker_ip_address, "127.0.0.1")
         self.assertEqual(distributed_context.global_rank, 1)
         self.assertEqual(distributed_context.global_world_size, 2)
-        mock_read.assert_has_calls(
-            [
-                call(GcsUri("gs://FAKE BUCKET DNE/some-file.txt")),
-                call(GcsUri("gs://FAKE BUCKET DNE/some-file.txt")),
-            ]
-        )
 
 
 if __name__ == "__main__":

--- a/python/tests/unit/common/utils/vertex_ai_context_test.py
+++ b/python/tests/unit/common/utils/vertex_ai_context_test.py
@@ -63,6 +63,7 @@ class TestVertexAIContext(unittest.TestCase):
 
     @patch("torch.distributed.init_process_group")
     @patch("torch.distributed.broadcast_object_list")
+    @patch("torch.distributed.destroy_process_group")
     @patch("subprocess.check_output", return_value=b"127.0.0.1")
     @patch("time.sleep", return_value=None)
     @patch.dict(
@@ -77,6 +78,7 @@ class TestVertexAIContext(unittest.TestCase):
         self,
         mock_sleep,
         mock_check_output,
+        mock_destroy_process_group,
         mock_broadcast_object_list,
         mock_init_process_group,
     ):
@@ -87,6 +89,7 @@ class TestVertexAIContext(unittest.TestCase):
 
     @patch("torch.distributed.init_process_group")
     @patch("torch.distributed.broadcast_object_list")
+    @patch("torch.distributed.destroy_process_group")
     @patch("subprocess.check_output", return_value=b"127.0.0.1")
     @patch("time.sleep", return_value=None)
     @patch.dict(
@@ -101,6 +104,7 @@ class TestVertexAIContext(unittest.TestCase):
         self,
         mock_sleep,
         mock_check_output,
+        mock_destroy_process_group,
         mock_broadcast_object_list,
         mock_init_process_group,
     ):

--- a/python/tests/unit/common/utils/vertex_ai_context_test.py
+++ b/python/tests/unit/common/utils/vertex_ai_context_test.py
@@ -51,7 +51,7 @@ class TestVertexAIContext(unittest.TestCase):
         self.assertEqual(get_rank(), 1)
 
     @patch.dict(os.environ, VAI_JOB_ENV | {"LOCAL_WORLD_SIZE": "4"})
-    def test_get_rank(self):
+    def test_get_local_world_size(self):
         self.assertEqual(get_local_world_size(), 4)
 
     def test_throws_if_not_on_vai(self):

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -48,6 +48,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             main_worker_ip_address=self._master_ip_address,
             global_rank=0,
             global_world_size=self._world_size,
+            local_world_size=1,
         )
 
     def test_distributed_neighbor_loader(self):
@@ -70,7 +71,6 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             num_neighbors=[2, 2],
             context=self._context,
             local_process_rank=0,
-            local_process_world_size=1,
             pin_memory_device=torch.device("cpu"),
         )
 
@@ -121,7 +121,6 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             input_nodes=(node_type, torch.tensor([[10, 12]])),
             context=self._context,
             local_process_rank=0,
-            local_process_world_size=1,
         )
         count = 0
         for datum in loader:
@@ -158,7 +157,6 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             num_neighbors=[2, 2],
             context=self._context,
             local_process_rank=0,
-            local_process_world_size=1,
             pin_memory_device=torch.device("cpu"),
         )
 
@@ -249,7 +247,6 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             input_nodes=torch.tensor([10]),
             context=self._context,
             local_process_rank=0,
-            local_process_world_size=1,
         )
 
         count = 0


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- Adds `local_world_size` to `DistributedContext`. This is a step towards making `DistributedContext` more conformant with the PyG [DistContext](https://pytorch-geometric.readthedocs.io/en/2.5.0/_modules/torch_geometric/distributed/dist_context.html) and simplifies training/inference apis more generally
- Sets `local_world_size` automatically in the `os.environ` of the spawned VAI jobs for GLT inference
- Simplifies `init_neighbor_loader_worker` to be more reliant on `distributed_context`
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
