### PR TITLE
ignore pickle files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ graphlearn_torch.egg-info/
 fossa
 fossa.bundle
 fossa*.zip
+
+# Ignore *all* pickled files, we should *never* put these in git.
+*.pkl


### PR DESCRIPTION
Ignore are pickled files from git. We should never put these into git as a best practice reason (pickled objects are generally unsafe to execute, are very sensitive to python versioning, and are large binaries we don't want in our repo).

However, I do occasionally pickle stuff locally to save on time loading datasets, see https://github.com/Snapchat/GiGL/blob/20c81a0168e9700dc44684ac0509442526478805/examples/distributed/homogeneous_training.py#L357-L370 and would like to avoid needing to make sure I don't accidentally commit them.