### PR TITLE
Update GiGL Splitter

### DIFF
--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -133,10 +133,7 @@ def _load_and_build_partitioned_dataset(
 
         loaded_graph_tensors.positive_label = positive_label_edges
 
-    if (
-        isinstance(splitter, HashedNodeAnchorLinkSplitter)
-        and splitter.should_convert_labels_to_edges
-    ):
+    if splitter is not None and splitter.should_convert_labels_to_edges:
         loaded_graph_tensors.treat_labels_as_edges(edge_dir=edge_dir)
 
     should_assign_edges_by_src_node: bool = False if edge_dir == "in" else True
@@ -146,11 +143,11 @@ def _load_and_build_partitioned_dataset(
 
     if should_assign_edges_by_src_node:
         logger.info(
-            f"Initializing {type(partitioner_class)} instance while partitioning edges to its source node machine"
+            f"Initializing {partitioner_class.__name__} instance while partitioning edges to its source node machine"
         )
     else:
         logger.info(
-            f"Initializing {type(partitioner_class)} instance while partitioning edges to its destination node machine"
+            f"Initializing {partitioner_class.__name__} instance while partitioning edges to its destination node machine"
         )
     partitioner = partitioner_class(
         should_assign_edges_by_src_node=should_assign_edges_by_src_node

--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -135,7 +135,7 @@ def _load_and_build_partitioned_dataset(
 
     if (
         isinstance(splitter, HashedNodeAnchorLinkSplitter)
-        and splitter._should_convert_labels_to_edges
+        and splitter.should_convert_labels_to_edges
     ):
         loaded_graph_tensors.treat_labels_as_edges(edge_dir=edge_dir)
 

--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -38,12 +38,6 @@ from gigl.distributed.utils.serialized_graph_metadata_translator import (
 )
 from gigl.src.common.types.graph_data import EdgeType
 from gigl.src.common.types.pb_wrappers.gbml_config import GbmlConfigPbWrapper
-from gigl.types.graph import (
-    DEFAULT_HOMOGENEOUS_EDGE_TYPE,
-    GraphPartitionData,
-    message_passing_to_negative_label,
-    message_passing_to_positive_label,
-)
 from gigl.utils.data_splitters import (
     HashedNodeAnchorLinkSplitter,
     NodeAnchorLinkSplitter,
@@ -61,7 +55,6 @@ def _load_and_build_partitioned_dataset(
     partitioner_class: Optional[Type[DistPartitioner]],
     node_tf_dataset_options: TFDatasetOptions,
     edge_tf_dataset_options: TFDatasetOptions,
-    should_convert_labels_to_edges: bool = False,
     splitter: Optional[NodeAnchorLinkSplitter] = None,
     _ssl_positive_label_percentage: Optional[float] = None,
 ) -> DistLinkPredictionDataset:
@@ -77,7 +70,6 @@ def _load_and_build_partitioned_dataset(
             DistPartitioner or subclass of it. If not provided, will initialize use the DistPartitioner class.
         node_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized node data is read.
         edge_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized edge data is read.
-        should_convert_labels_to_edges (bool): Whether to convert labels to edges in the graph. If this is set to true, the output dataset will be heterogeneous.
         splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets. If not provided (None), no splitting will be performed.
         _ssl_positive_label_percentage (Optional[float]): Percentage of edges to select as self-supervised labels. Must be None if supervised edge labels are provided in advance.
             Slotted for refactor once this functionality is available in the transductive `splitter` directly
@@ -104,8 +96,46 @@ def _load_and_build_partitioned_dataset(
         node_tf_dataset_options=node_tf_dataset_options,
         edge_tf_dataset_options=edge_tf_dataset_options,
     )
-    if should_convert_labels_to_edges:
-        loaded_graph_tensors.treat_labels_as_edges()
+
+    # TODO (mkolodner-sc): Move this code block (from here up to start of partitioning) to transductive splitter once that is ready
+    if _ssl_positive_label_percentage is not None:
+        assert (
+            loaded_graph_tensors.positive_label is None
+            and loaded_graph_tensors.negative_label is None
+        ), "Cannot have loaded positive and negative labels when attempting to select self-supervised positive edges from edge index."
+        positive_label_edges: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
+        if isinstance(loaded_graph_tensors.edge_index, abc.Mapping):
+            # This assert is required while `select_ssl_positive_label_edges` exists out of any splitter. Once this is in transductive splitter,
+            # we can remove this assert.
+            assert isinstance(
+                splitter, HashedNodeAnchorLinkSplitter
+            ), f"GiGL only supports {HashedNodeAnchorLinkSplitter.__name__} currently, got {type(splitter)}"
+            positive_label_edges = {}
+            for supervision_edge_type in splitter._supervision_edge_types:
+                assert supervision_edge_type in loaded_graph_tensors.edge_index
+                positive_label_edges[
+                    supervision_edge_type
+                ] = select_ssl_positive_label_edges(
+                    edge_index=loaded_graph_tensors.edge_index[supervision_edge_type],
+                    positive_label_percentage=_ssl_positive_label_percentage,
+                )
+        elif isinstance(loaded_graph_tensors.edge_index, torch.Tensor):
+            positive_label_edges = select_ssl_positive_label_edges(
+                edge_index=loaded_graph_tensors.edge_index,
+                positive_label_percentage=_ssl_positive_label_percentage,
+            )
+        else:
+            raise ValueError(
+                "Found no partitioned edge index when attempting to select positive labels"
+            )
+
+        loaded_graph_tensors.positive_label = positive_label_edges
+
+    if (
+        isinstance(splitter, HashedNodeAnchorLinkSplitter)
+        and splitter._should_convert_labels_to_edges
+    ):
+        loaded_graph_tensors.treat_labels_as_edges(edge_dir=edge_dir)
 
     should_assign_edges_by_src_node: bool = False if edge_dir == "in" else True
 
@@ -158,37 +188,6 @@ def _load_and_build_partitioned_dataset(
 
     partition_output = partitioner.partition()
 
-    # TODO (mkolodner-sc): Move this code block to transductive splitter once that is ready
-    if _ssl_positive_label_percentage is not None:
-        assert (
-            partition_output.partitioned_positive_labels is None
-            and partition_output.partitioned_negative_labels is None
-        ), "Cannot have partitioned positive and negative labels when attempting to select self-supervised positive edges from edge index."
-        positive_label_edges: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
-        # TODO (mkolodner-sc): Only add necessary edge types to positive label dictionary, rather than all of the keys in the partitioned edge index
-        if isinstance(partition_output.partitioned_edge_index, abc.Mapping):
-            positive_label_edges = {}
-            for (
-                edge_type,
-                graph_partition_data,
-            ) in partition_output.partitioned_edge_index.items():
-                edge_index = graph_partition_data.edge_index
-                positive_label_edges[edge_type] = select_ssl_positive_label_edges(
-                    edge_index=edge_index,
-                    positive_label_percentage=_ssl_positive_label_percentage,
-                )
-        elif isinstance(partition_output.partitioned_edge_index, GraphPartitionData):
-            positive_label_edges = select_ssl_positive_label_edges(
-                edge_index=partition_output.partitioned_edge_index.edge_index,
-                positive_label_percentage=_ssl_positive_label_percentage,
-            )
-        else:
-            raise ValueError(
-                "Found no partitioned edge index when attempting to select positive labels"
-            )
-
-        partition_output.partitioned_positive_labels = positive_label_edges
-
     logger.info(
         f"Initializing DistLinkPredictionDataset instance with edge direction {edge_dir}"
     )
@@ -215,7 +214,6 @@ def _build_dataset_process(
     partitioner_class: Optional[Type[DistPartitioner]],
     node_tf_dataset_options: TFDatasetOptions,
     edge_tf_dataset_options: TFDatasetOptions,
-    should_convert_labels_to_edges: bool = False,
     splitter: Optional[NodeAnchorLinkSplitter] = None,
     _ssl_positive_label_percentage: Optional[float] = None,
 ) -> None:
@@ -249,7 +247,6 @@ def _build_dataset_process(
             DistPartitioner or subclass of it. If not provided, will initialize use the DistPartitioner class.
         node_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized node data is read.
         edge_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized edge data is read.
-        should_convert_labels_to_edges (bool): Whether to convert labels to edges in the graph. If this is set to true, the output dataset will be heterogeneous.
         splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets. If not provided (None), no splitting will be performed.
         _ssl_positive_label_percentage (Optional[float]): Percentage of edges to select as self-supervised labels. Must be None if supervised edge labels are provided in advance.
             Slotted for refactor once this functionality is available in the transductive `splitter` directly
@@ -275,7 +272,6 @@ def _build_dataset_process(
         partitioner_class=partitioner_class,
         node_tf_dataset_options=node_tf_dataset_options,
         edge_tf_dataset_options=edge_tf_dataset_options,
-        should_convert_labels_to_edges=should_convert_labels_to_edges,
         splitter=splitter,
         _ssl_positive_label_percentage=_ssl_positive_label_percentage,
     )
@@ -296,7 +292,6 @@ def build_dataset(
     partitioner_class: Optional[Type[DistPartitioner]] = None,
     node_tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
     edge_tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
-    should_convert_labels_to_edges: bool = False,
     splitter: Optional[NodeAnchorLinkSplitter] = None,
     _ssl_positive_label_percentage: Optional[float] = None,
     _dataset_building_port: int = DEFAULT_MASTER_DATA_BUILDING_PORT,
@@ -313,8 +308,8 @@ def build_dataset(
             DistPartitioner or subclass of it. If not provided, will initialize use the DistPartitioner class.
         node_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized node data is read.
         edge_tf_dataset_options (TFDatasetOptions): Options provided to a tf.data.Dataset to tune how serialized edge data is read.
-        should_convert_labels_to_edges (bool): Whether to convert labels to edges in the graph. If this is set to true, the output dataset will be heterogeneous.
-        splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets. If not provided (None), no splitting will be performed.
+        splitter (Optional[NodeAnchorLinkSplitter]): Optional splitter to use for splitting the graph data into train, val, and test sets.
+            If not provided (None), no splitting will be performed.
         _ssl_positive_label_percentage (Optional[float]): Percentage of edges to select as self-supervised labels. Must be None if supervised edge labels are provided in advance.
             Slotted for refactor once this functionality is available in the transductive `splitter` directly
         _dataset_building_port (int): WARNING: You don't need to configure this unless port conflict issues. Slotted for refactor.
@@ -328,27 +323,8 @@ def build_dataset(
         sample_edge_direction == "in" or sample_edge_direction == "out"
     ), f"Provided edge direction from inference args must be one of `in` or `out`, got {sample_edge_direction}"
 
-    if should_convert_labels_to_edges:
-        if splitter is not None:
-            logger.warning(
-                f"Received splitter {splitter} and should_convert_labels_to_edges=True. Will use {splitter} to split the graph data."
-            )
-        else:
-            logger.info(
-                f"Using default splitter {type(HashedNodeAnchorLinkSplitter)} for ABLP labels."
-            )
-            # TODO(kmonte): Read train/val/test split counts from config.
-            # TODO(kmonte): Read label edge dir from config.
-            splitter = HashedNodeAnchorLinkSplitter(
-                sampling_direction=sample_edge_direction,
-                edge_types=[
-                    message_passing_to_positive_label(DEFAULT_HOMOGENEOUS_EDGE_TYPE),
-                    message_passing_to_negative_label(DEFAULT_HOMOGENEOUS_EDGE_TYPE),
-                ],
-            )
-        logger.info(
-            "Will be treating the ABLP labels as heterogeneous edges in the graph."
-        )
+    if splitter is not None:
+        logger.info(f"Received splitter {str(splitter.__class__)}.")
 
     manager = mp.Manager()
 
@@ -370,7 +346,6 @@ def build_dataset(
             partitioner_class,
             node_tf_dataset_options,
             edge_tf_dataset_options,
-            should_convert_labels_to_edges,
             splitter,
             _ssl_positive_label_percentage,
         ),
@@ -408,17 +383,27 @@ def build_dataset_from_task_config_uri(
     gbml_config_pb_wrapper = GbmlConfigPbWrapper.get_gbml_config_pb_wrapper_from_uri(
         gbml_config_uri=UriFactory.create_uri(task_config_uri)
     )
+
     if is_inference:
         args = dict(gbml_config_pb_wrapper.inferencer_config.inferencer_args)
+
+        sample_edge_direction = args.get("sample_edge_direction", "in")
         args_path = "inferencerConfig.inferencerArgs"
-        should_convert_labels_to_edges = False
+        splitter = None
     else:
         args = dict(gbml_config_pb_wrapper.trainer_config.trainer_args)
-        args_path = "trainerConfig.trainerArgs"
-        # TODO(kmonte): Maybe we should enable this as a flag?
-        should_convert_labels_to_edges = True
 
-    sample_edge_direction = args.get("sample_edge_direction", "in")
+        supervision_edge_types = (
+            gbml_config_pb_wrapper.task_metadata_pb_wrapper.get_supervision_edge_types()
+        )
+        sample_edge_direction = args.get("sample_edge_direction", "in")
+        args_path = "trainerConfig.trainerArgs"
+        # TODO(kmonte): Maybe we should enable `should_convert_labels_to_edges` as a flag?
+        splitter = HashedNodeAnchorLinkSplitter(
+            sampling_direction=sample_edge_direction,
+            supervision_edge_types=supervision_edge_types,
+            should_convert_labels_to_edges=True,
+        )
 
     assert sample_edge_direction in (
         "in",
@@ -462,7 +447,7 @@ def build_dataset_from_task_config_uri(
         distributed_context=distributed_context,
         sample_edge_direction=sample_edge_direction,
         partitioner_class=partitioner_class,
-        should_convert_labels_to_edges=should_convert_labels_to_edges,
+        splitter=splitter,
     )
 
     return dataset

--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -99,10 +99,13 @@ def _load_and_build_partitioned_dataset(
 
     # TODO (mkolodner-sc): Move this code block (from here up to start of partitioning) to transductive splitter once that is ready
     if _ssl_positive_label_percentage is not None:
-        assert (
-            loaded_graph_tensors.positive_label is None
-            and loaded_graph_tensors.negative_label is None
-        ), "Cannot have loaded positive and negative labels when attempting to select self-supervised positive edges from edge index."
+        if (
+            loaded_graph_tensors.positive_label is not None
+            or loaded_graph_tensors.negative_label is not None
+        ):
+            raise ValueError(
+                "Cannot have loaded positive and negative labels when attempting to select self-supervised positive edges from edge index."
+            )
         positive_label_edges: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
         if isinstance(loaded_graph_tensors.edge_index, abc.Mapping):
             # This assert is required while `select_ssl_positive_label_edges` exists out of any splitter. Once this is in transductive splitter,
@@ -112,7 +115,6 @@ def _load_and_build_partitioned_dataset(
             ), f"GiGL only supports {HashedNodeAnchorLinkSplitter.__name__} currently, got {type(splitter)}"
             positive_label_edges = {}
             for supervision_edge_type in splitter._supervision_edge_types:
-                assert supervision_edge_type in loaded_graph_tensors.edge_index
                 positive_label_edges[
                     supervision_edge_type
                 ] = select_ssl_positive_label_edges(
@@ -126,7 +128,7 @@ def _load_and_build_partitioned_dataset(
             )
         else:
             raise ValueError(
-                "Found no partitioned edge index when attempting to select positive labels"
+                f"Found an unknown edge index type: {type(loaded_graph_tensors.edge_index)} when attempting to select positive labels"
             )
 
         loaded_graph_tensors.positive_label = positive_label_edges
@@ -144,11 +146,11 @@ def _load_and_build_partitioned_dataset(
 
     if should_assign_edges_by_src_node:
         logger.info(
-            f"Initializing {partitioner_class.__name__} instance while partitioning edges to its source node machine"
+            f"Initializing {type(partitioner_class)} instance while partitioning edges to its source node machine"
         )
     else:
         logger.info(
-            f"Initializing {partitioner_class.__name__} instance while partitioning edges to its destination node machine"
+            f"Initializing {type(partitioner_class)} instance while partitioning edges to its destination node machine"
         )
     partitioner = partitioner_class(
         should_assign_edges_by_src_node=should_assign_edges_by_src_node
@@ -324,7 +326,7 @@ def build_dataset(
     ), f"Provided edge direction from inference args must be one of `in` or `out`, got {sample_edge_direction}"
 
     if splitter is not None:
-        logger.info(f"Received splitter {str(splitter.__class__)}.")
+        logger.info(f"Received splitter {type(splitter)}.")
 
     manager = mp.Manager()
 

--- a/python/gigl/types/graph.py
+++ b/python/gigl/types/graph.py
@@ -103,7 +103,9 @@ def _get_label_edges(
         labeled_edge_index (torch.Tensor): Edge index containing positive or negative labels for supervision
         edge_dir (Literal["in", "out"]): Direction of edges in the graph
         labeled_edge_type (EdgeType): Edge type used for the positive or negative labeled edges
-
+    Returns:
+        EdgeType: Labeled edge type, which has been reversed if edge_dir = "in"
+        torch.Tensor: Labeled edge index, which has its rows flipped if edge_dir = "in"
     """
     if edge_dir == "in":
         rev_edge_type = reverse_edge_type(labeled_edge_type)

--- a/python/gigl/types/graph.py
+++ b/python/gigl/types/graph.py
@@ -1,6 +1,7 @@
+import gc
 from collections import abc
 from dataclasses import dataclass
-from typing import Optional, TypeVar, Union, overload
+from typing import Literal, Optional, TypeVar, Union, overload
 
 import torch
 from graphlearn_torch.partition import PartitionBook
@@ -107,12 +108,16 @@ class LoadedGraphTensors:
     # Unpartitioned Negative Edge Label
     negative_label: Optional[Union[torch.Tensor, dict[EdgeType, torch.Tensor]]]
 
-    def treat_labels_as_edges(self) -> None:
+    def treat_labels_as_edges(self, edge_dir: Literal["in", "out"]) -> None:
         """
         Convert positive and negative labels to edges. Converts this object in-place to a "heterogeneous" representation.
+        If the edge direction is "in", we must reverse the supervision edge type.
 
         This function requires the following conditions and will throw if they are not met:
             1. The positive_label is not None
+
+        Args:
+            edge_dir: The edge direction of the graph.
 
         """
         if self.positive_label is None:
@@ -136,10 +141,17 @@ class LoadedGraphTensors:
                     "Detected multiple edge types in provided edge_index, but no edge types specified for provided positive label."
                 )
             positive_label_edge_type = message_passing_to_positive_label(main_edge_type)
+            if edge_dir == "in":
+                positive_label_edge_type = reverse_edge_type(positive_label_edge_type)
+                edge_index_with_labels[
+                    positive_label_edge_type
+                ] = self.positive_label.flip(0)
+            else:
+                edge_index_with_labels[positive_label_edge_type] = self.positive_label
             logger.info(
                 f"Treating homogeneous positive labels as edge type {positive_label_edge_type}."
             )
-            edge_index_with_labels[positive_label_edge_type] = self.positive_label
+
         elif isinstance(self.positive_label, dict):
             for (
                 positive_label_type,
@@ -148,10 +160,20 @@ class LoadedGraphTensors:
                 positive_label_edge_type = message_passing_to_positive_label(
                     positive_label_type
                 )
+                if edge_dir == "in":
+                    positive_label_edge_type = reverse_edge_type(
+                        positive_label_edge_type
+                    )
+                    edge_index_with_labels[
+                        positive_label_edge_type
+                    ] = positive_label_tensor.flip(0)
+                else:
+                    edge_index_with_labels[
+                        positive_label_edge_type
+                    ] = positive_label_tensor
                 logger.info(
                     f"Treating heterogeneous positive labels {positive_label_type} as edge type {positive_label_edge_type}."
                 )
-                edge_index_with_labels[positive_label_edge_type] = positive_label_tensor
 
         if isinstance(self.negative_label, torch.Tensor):
             if main_edge_type is None:
@@ -159,10 +181,16 @@ class LoadedGraphTensors:
                     "Detected multiple edge types in provided edge_index, but no edge types specified for provided negative label."
                 )
             negative_label_edge_type = message_passing_to_negative_label(main_edge_type)
+            if edge_dir == "in":
+                negative_label_edge_type = reverse_edge_type(negative_label_edge_type)
+                edge_index_with_labels[
+                    negative_label_edge_type
+                ] = self.negative_label.flip(0)
+            else:
+                edge_index_with_labels[negative_label_edge_type] = self.negative_label
             logger.info(
                 f"Treating homogeneous negative labels as edge type {negative_label_edge_type}."
             )
-            edge_index_with_labels[negative_label_edge_type] = self.negative_label
         elif isinstance(self.negative_label, dict):
             for (
                 negative_label_type,
@@ -171,10 +199,20 @@ class LoadedGraphTensors:
                 negative_label_edge_type = message_passing_to_negative_label(
                     negative_label_type
                 )
+                if edge_dir == "in":
+                    negative_label_edge_type = reverse_edge_type(
+                        negative_label_edge_type
+                    )
+                    edge_index_with_labels[
+                        negative_label_edge_type
+                    ] = negative_label_tensor.flip(0)
+                else:
+                    edge_index_with_labels[
+                        negative_label_edge_type
+                    ] = negative_label_tensor
                 logger.info(
                     f"Treating heterogeneous negative labels {negative_label_type} as edge type {negative_label_edge_type}."
                 )
-                edge_index_with_labels[negative_label_edge_type] = negative_label_tensor
 
         self.node_ids = to_heterogeneous_node(self.node_ids)
         self.node_features = to_heterogeneous_node(self.node_features)
@@ -182,6 +220,7 @@ class LoadedGraphTensors:
         self.edge_features = to_heterogeneous_edge(self.edge_features)
         self.positive_label = None
         self.negative_label = None
+        gc.collect()
 
 
 def message_passing_to_positive_label(
@@ -232,6 +271,23 @@ def message_passing_to_negative_label(
         return edge_type
 
 
+# TODO: add tests for this.
+def is_label_edge_type(
+    edge_type: _EdgeType,
+) -> bool:
+    """Check if an edge type is a label edge type.
+
+    Args:
+        edge_type (EdgeType): The edge type to check.
+
+    Returns:
+        bool: True if the edge type is a label edge type, False otherwise.
+    """
+    return _POSITIVE_LABEL_TAG in str(edge_type[1]) or _NEGATIVE_LABEL_TAG in str(
+        edge_type[1]
+    )
+
+
 def select_label_edge_types(
     message_passing_edge_type: _EdgeType, edge_entities: abc.Iterable[_EdgeType]
 ) -> tuple[_EdgeType, Optional[_EdgeType]]:
@@ -253,7 +309,7 @@ def select_label_edge_types(
             negative_label_type = edge_type
     if positive_label_type is None:
         raise ValueError(
-            f"Could not find positive label edge type for message passing edge type {message_passing_edge_type} from edge entities {edge_entities}."
+            f"Could not find positive label edge type for message passing edge type {message_passing_to_positive_label(message_passing_edge_type)} from edge entities {edge_entities}."
         )
     return positive_label_type, negative_label_type
 
@@ -403,3 +459,17 @@ def to_homogeneous(
         n = next(iter(x.values()))
         return n
     return x
+
+
+def reverse_edge_type(edge_type: _EdgeType) -> _EdgeType:
+    """
+    Reverses the source and destination node types of the provided edge type
+    Args:
+        edge_type (EdgeType): The target edge to have its source and destinated node types reversed
+    Returns:
+        EdgeType: The reversed edge type
+    """
+    if isinstance(edge_type, EdgeType):
+        return EdgeType(edge_type[2], edge_type[1], edge_type[0])
+    else:
+        return (edge_type[2], edge_type[1], edge_type[0])

--- a/python/gigl/types/graph.py
+++ b/python/gigl/types/graph.py
@@ -91,6 +91,28 @@ class PartitionOutput:
     ]
 
 
+def _get_label_edges(
+    labeled_edge_index: torch.Tensor,
+    edge_dir: Literal["in", "out"],
+    labeled_edge_type: EdgeType,
+) -> tuple[EdgeType, torch.Tensor]:
+    """
+    If edge direction is `out`, return the provided edge type and edge index. Otherwise, reverse the edge type and flip the edge index rows
+    so that the labeled edge index may be the same direction as the rest of the edges.
+    Args:
+        labeled_edge_index (torch.Tensor): Edge index containing positive or negative labels for supervision
+        edge_dir (Literal["in", "out"]): Direction of edges in the graph
+        labeled_edge_type (EdgeType): Edge type used for the positive or negative labeled edges
+
+    """
+    if edge_dir == "in":
+        rev_edge_type = reverse_edge_type(labeled_edge_type)
+        rev_labeled_edge_index = labeled_edge_index.flip(0)
+        return rev_edge_type, rev_labeled_edge_index
+    else:
+        return labeled_edge_type, labeled_edge_index
+
+
 # This dataclass should not be frozen, as we are expected to delete its members once they have been registered inside of the partitioner
 # in order to save memory.
 @dataclass
@@ -111,7 +133,8 @@ class LoadedGraphTensors:
     def treat_labels_as_edges(self, edge_dir: Literal["in", "out"]) -> None:
         """
         Convert positive and negative labels to edges. Converts this object in-place to a "heterogeneous" representation.
-        If the edge direction is "in", we must reverse the supervision edge type.
+        If the edge direction is "in", we must reverse the supervision edge type. This is because we assume that provided labels are directed
+        outwards in form (`anchor_node_type`, `relation`, `supervision_node_type`), and all edges in the edge index must be in the same direction.
 
         This function requires the following conditions and will throw if they are not met:
             1. The positive_label is not None
@@ -141,13 +164,12 @@ class LoadedGraphTensors:
                     "Detected multiple edge types in provided edge_index, but no edge types specified for provided positive label."
                 )
             positive_label_edge_type = message_passing_to_positive_label(main_edge_type)
-            if edge_dir == "in":
-                positive_label_edge_type = reverse_edge_type(positive_label_edge_type)
-                edge_index_with_labels[
-                    positive_label_edge_type
-                ] = self.positive_label.flip(0)
-            else:
-                edge_index_with_labels[positive_label_edge_type] = self.positive_label
+            labeled_edge_type, edge_index = _get_label_edges(
+                labeled_edge_index=self.positive_label,
+                edge_dir=edge_dir,
+                labeled_edge_type=positive_label_edge_type,
+            )
+            edge_index_with_labels[labeled_edge_type] = edge_index
             logger.info(
                 f"Treating homogeneous positive labels as edge type {positive_label_edge_type}."
             )
@@ -160,17 +182,12 @@ class LoadedGraphTensors:
                 positive_label_edge_type = message_passing_to_positive_label(
                     positive_label_type
                 )
-                if edge_dir == "in":
-                    positive_label_edge_type = reverse_edge_type(
-                        positive_label_edge_type
-                    )
-                    edge_index_with_labels[
-                        positive_label_edge_type
-                    ] = positive_label_tensor.flip(0)
-                else:
-                    edge_index_with_labels[
-                        positive_label_edge_type
-                    ] = positive_label_tensor
+                labeled_edge_type, edge_index = _get_label_edges(
+                    labeled_edge_index=positive_label_tensor,
+                    edge_dir=edge_dir,
+                    labeled_edge_type=positive_label_edge_type,
+                )
+                edge_index_with_labels[labeled_edge_type] = edge_index
                 logger.info(
                     f"Treating heterogeneous positive labels {positive_label_type} as edge type {positive_label_edge_type}."
                 )
@@ -181,13 +198,12 @@ class LoadedGraphTensors:
                     "Detected multiple edge types in provided edge_index, but no edge types specified for provided negative label."
                 )
             negative_label_edge_type = message_passing_to_negative_label(main_edge_type)
-            if edge_dir == "in":
-                negative_label_edge_type = reverse_edge_type(negative_label_edge_type)
-                edge_index_with_labels[
-                    negative_label_edge_type
-                ] = self.negative_label.flip(0)
-            else:
-                edge_index_with_labels[negative_label_edge_type] = self.negative_label
+            labeled_edge_type, edge_index = _get_label_edges(
+                labeled_edge_index=self.negative_label,
+                edge_dir=edge_dir,
+                labeled_edge_type=negative_label_edge_type,
+            )
+            edge_index_with_labels[labeled_edge_type] = edge_index
             logger.info(
                 f"Treating homogeneous negative labels as edge type {negative_label_edge_type}."
             )
@@ -199,17 +215,12 @@ class LoadedGraphTensors:
                 negative_label_edge_type = message_passing_to_negative_label(
                     negative_label_type
                 )
-                if edge_dir == "in":
-                    negative_label_edge_type = reverse_edge_type(
-                        negative_label_edge_type
-                    )
-                    edge_index_with_labels[
-                        negative_label_edge_type
-                    ] = negative_label_tensor.flip(0)
-                else:
-                    edge_index_with_labels[
-                        negative_label_edge_type
-                    ] = negative_label_tensor
+                labeled_edge_type, edge_index = _get_label_edges(
+                    labeled_edge_index=negative_label_tensor,
+                    edge_dir=edge_dir,
+                    labeled_edge_type=negative_label_edge_type,
+                )
+                edge_index_with_labels[labeled_edge_type] = edge_index
                 logger.info(
                     f"Treating heterogeneous negative labels {negative_label_type} as edge type {negative_label_edge_type}."
                 )
@@ -271,7 +282,6 @@ def message_passing_to_negative_label(
         return edge_type
 
 
-# TODO: add tests for this.
 def is_label_edge_type(
     edge_type: _EdgeType,
 ) -> bool:

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -1,7 +1,17 @@
 import gc
 from collections import defaultdict
 from collections.abc import Mapping
-from typing import Callable, Final, Literal, Optional, Protocol, Tuple, Union, overload
+from typing import (
+    Callable,
+    Final,
+    Literal,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    Union,
+    overload,
+)
 
 import torch
 from graphlearn_torch.data import Dataset, Topology
@@ -144,7 +154,7 @@ class HashedNodeAnchorLinkSplitter:
         if supervision_edge_types is None:
             supervision_edge_types = [DEFAULT_HOMOGENEOUS_EDGE_TYPE]
 
-        self._supervision_edge_types = supervision_edge_types
+        self._supervision_edge_types: Sequence[EdgeType] = supervision_edge_types
 
     @overload
     def __call__(

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -143,9 +143,11 @@ class HashedNodeAnchorLinkSplitter:
             num_test (Union[float, int]): The percentage of nodes to use for validation. Defaults to 0.1 (10%).
                                           If an integer is provided, than exactly that number of nodes will be in the test split.
             hash_function (Callable[[torch.Tensor, torch.Tensor], torch.Tensor]): The hash function to use. Defaults to `_fast_hash`.
-            supervision_edge_types (Optional[list[EdgeType]]): The supervision edge types we should use for splitting. Must be provided if we are splitting a heterogeneous graph.
-                If None, uses the default homogeneous edge type
-            should_convert_labels_to_edges (bool): Whether label should be converted into an edge type in the graph.
+            supervision_edge_types (Optional[list[EdgeType]]): The supervision edge types we should use for splitting.
+                Must be provided if we are splitting a heterogeneous graph. If None, uses the default message passing edge type in the graph.
+            should_convert_labels_to_edges (bool): Whether label should be converted into an edge type in the graph. If provided, will make
+                `gigl.distributed.build_dataset` convert all labels into edges, and will infer positive and negative edge types based on
+                `supervision_edge_types`.
         """
         _check_sampling_direction(sampling_direction)
         _check_val_test_percentage(num_val, num_test)
@@ -174,7 +176,6 @@ class HashedNodeAnchorLinkSplitter:
         # also be ("user", "positive", "story"), meaning that all edges in the loaded edge index tensor with this edge type will be treated as a labeled
         # edge and will be used for splitting.
 
-        # TODO (mkolodner-sc): Deprecate storing ` self._supervision_edge_types` as a private variable once the SSL splitter is prepared
         self._supervision_edge_types: Sequence[EdgeType] = supervision_edge_types
         if should_convert_labels_to_edges:
             self._labeled_edge_types: Sequence[EdgeType] = [

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -170,6 +170,10 @@ class HashedNodeAnchorLinkSplitter:
         # For example, if `should_convert_labels_to_edges=True` and we provide supervision_edge_types=[("user", "to", "story")], the
         # labeled edge types will be ("user", "to_gigl_positive", "story") and ("user", "to_gigl_negative", "story"), if there are negative labels.
 
+        # If `should_convert_labels_to_edges=False` and we provide supervision_edge_types=[("user", "positive", "story")], the labeled edge type will
+        # also be ("user", "positive", "story"), meaning that all edges in the loaded edge index tensor with this edge type will be treated as a labeled
+        # edge and will be used for splitting.
+
         self._supervision_edge_types: Sequence[EdgeType] = supervision_edge_types
         if should_convert_labels_to_edges:
             self._labeled_edge_types: Sequence[EdgeType] = [

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -1,6 +1,6 @@
 import gc
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from typing import Callable, Final, Literal, Optional, Protocol, Tuple, Union, overload
 
 import torch
@@ -12,6 +12,7 @@ from gigl.src.common.types.graph_data import EdgeType, NodeType
 from gigl.types.graph import (
     DEFAULT_HOMOGENEOUS_EDGE_TYPE,
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
+    is_label_edge_type,
 )
 
 logger = Logger()
@@ -115,7 +116,8 @@ class HashedNodeAnchorLinkSplitter:
         num_val: Union[float, int] = 0.1,
         num_test: Union[float, int] = 0.1,
         hash_function: Callable[[torch.Tensor], torch.Tensor] = _fast_hash,
-        edge_types: Optional[Union[EdgeType, Sequence[EdgeType]]] = None,
+        supervision_edge_types: Optional[list[EdgeType]] = None,
+        should_convert_labels_to_edges: bool = True,
     ):
         """Initializes the HashedNodeAnchorLinkSplitter.
 
@@ -126,8 +128,9 @@ class HashedNodeAnchorLinkSplitter:
             num_test (Union[float, int]): The percentage of nodes to use for validation. Defaults to 0.1 (10%).
                                           If an integer is provided, than exactly that number of nodes will be in the test split.
             hash_function (Callable[[torch.Tensor, torch.Tensor], torch.Tensor]): The hash function to use. Defaults to `_fast_hash`.
-            edge_types: The supervision edge types we should use for splitting.
-                        Must be provided if we are splitting a heterogeneous graph.
+            supervision_edge_types (Optional[list[EdgeType]]): The supervision edge types we should use for splitting. Must be provided if we are splitting a heterogeneous graph.
+                If None, uses the default homogeneous edge type
+            should_convert_labels_to_edges (bool): Whether label should be converted into an edge type in the graph.
         """
         _check_sampling_direction(sampling_direction)
         _check_val_test_percentage(num_val, num_test)
@@ -136,12 +139,12 @@ class HashedNodeAnchorLinkSplitter:
         self._num_val = num_val
         self._num_test = num_test
         self._hash_function = hash_function
+        self._should_convert_labels_to_edges = should_convert_labels_to_edges
 
-        if edge_types is None:
-            edge_types = [DEFAULT_HOMOGENEOUS_EDGE_TYPE]
-        elif isinstance(edge_types, EdgeType):
-            edge_types = [edge_types]
-        self._supervision_edge_types: Sequence[EdgeType] = edge_types
+        if supervision_edge_types is None:
+            supervision_edge_types = [DEFAULT_HOMOGENEOUS_EDGE_TYPE]
+
+        self._supervision_edge_types = supervision_edge_types
 
     @overload
     def __call__(
@@ -167,26 +170,10 @@ class HashedNodeAnchorLinkSplitter:
         Mapping[NodeType, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
     ]:
         if isinstance(edge_index, torch.Tensor):
-            if self._supervision_edge_types != [DEFAULT_HOMOGENEOUS_EDGE_TYPE]:
-                logger.warning(
-                    f"You provided edge-types {self._supervision_edge_types} but the edge index is homogeneous. Ignoring edge types."
-                )
             is_heterogeneous = False
             edge_index = {DEFAULT_HOMOGENEOUS_EDGE_TYPE: edge_index}
 
         else:
-            if (
-                self._supervision_edge_types == [DEFAULT_HOMOGENEOUS_EDGE_TYPE]
-                or not self._supervision_edge_types
-            ):
-                raise ValueError(
-                    "If edge_index is a mapping, edges_to_split must be provided."
-                )
-            missing = set(self._supervision_edge_types) - edge_index.keys()
-            if missing:
-                raise ValueError(
-                    f"Missing edge types from provided edge index: {missing}. Expected edges types {self._supervision_edge_types} to be in the mapping, but got {edge_index.keys()}."
-                )
             is_heterogeneous = True
 
         # First, find max node id per node type.
@@ -197,7 +184,21 @@ class HashedNodeAnchorLinkSplitter:
         # We also store references to all tensors of a given node type, for convenient access later.
         max_node_id_by_type: dict[NodeType, int] = defaultdict(int)
         node_ids_by_node_type: dict[NodeType, list[torch.Tensor]] = defaultdict(list)
-        for edge_type_to_split in self._supervision_edge_types:
+        for edge_type_to_split, coo_edges in edge_index.items():
+            is_label = False
+            if self._should_convert_labels_to_edges and is_label_edge_type(
+                edge_type_to_split
+            ):
+                is_label = True
+            elif (
+                not self._should_convert_labels_to_edges
+                and edge_type_to_split in self._supervision_edge_types
+            ):
+                is_label = True
+            # We skip if the current edge type is not a labeled edge type, since we don't want to generate splits for edges which aren't used for supervision
+            if not is_label:
+                continue
+
             coo_edges = edge_index[edge_type_to_split]
             _check_edge_index(coo_edges)
             anchor_nodes = (
@@ -270,6 +271,11 @@ class HashedNodeAnchorLinkSplitter:
             val = nodes_to_select[num_train : num_val + num_train]  # 1 x num_val_nodes
             test = nodes_to_select[num_train + num_val :]  # 1 x num_test_nodes
             splits[anchor_node_type] = (train, val, test)
+        if len(splits) == 0:
+            raise ValueError(
+                f"Found no edge types to split from the provided edge index: {edge_index.keys()} using supervision edge types {self._supervision_edge_types}"
+            )
+
         if is_heterogeneous:
             return splits
         else:

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -159,6 +159,17 @@ class HashedNodeAnchorLinkSplitter:
         if supervision_edge_types is None:
             supervision_edge_types = [DEFAULT_HOMOGENEOUS_EDGE_TYPE]
 
+        # Supervision edge types are the edge type which will be used for positive and negative labels.
+        # Labeled edge types are the actual edge type that be injected into the edge index tensor.
+        # If should_convert_labels_to_edges=False, supervision edge types and labeled edge types will be the same,
+        # since the supervision edge type already exists in the edge index graph. Otherwise, we assume that the
+        # edge index tensor initially only contains the message passing edges, and will inject the labeled edge into the
+        # edge index based on some provided labels. As a result, the labeled edge types will be an augmented version of the
+        # supervision edge types.
+
+        # For example, if `should_convert_labels_to_edges=True` and we provide supervision_edge_types=[("user", "to", "story")], the
+        # labeled edge types will be ("user", "to_gigl_positive", "story") and ("user", "to_gigl_negative", "story"), if there are negative labels.
+
         self._supervision_edge_types: Sequence[EdgeType] = supervision_edge_types
         if should_convert_labels_to_edges:
             self._labeled_edge_types: Sequence[EdgeType] = [

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -180,6 +180,10 @@ class HashedNodeAnchorLinkSplitter:
         Mapping[NodeType, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
     ]:
         if isinstance(edge_index, torch.Tensor):
+            if self._supervision_edge_types != [DEFAULT_HOMOGENEOUS_EDGE_TYPE]:
+                logger.warning(
+                    f"You provided edge-types {self._supervision_edge_types} but the edge index is homogeneous. Ignoring supervision edge types."
+                )
             is_heterogeneous = False
             edge_index = {DEFAULT_HOMOGENEOUS_EDGE_TYPE: edge_index}
 

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -174,6 +174,7 @@ class HashedNodeAnchorLinkSplitter:
         # also be ("user", "positive", "story"), meaning that all edges in the loaded edge index tensor with this edge type will be treated as a labeled
         # edge and will be used for splitting.
 
+        # TODO (mkolodner-sc): Deprecate storing ` self._supervision_edge_types` as a private variable once the SSL splitter is prepared
         self._supervision_edge_types: Sequence[EdgeType] = supervision_edge_types
         if should_convert_labels_to_edges:
             self._labeled_edge_types: Sequence[EdgeType] = [
@@ -210,9 +211,9 @@ class HashedNodeAnchorLinkSplitter:
         Mapping[NodeType, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
     ]:
         if isinstance(edge_index, torch.Tensor):
-            if self._supervision_edge_types != [DEFAULT_HOMOGENEOUS_EDGE_TYPE]:
+            if self._labeled_edge_types != [DEFAULT_HOMOGENEOUS_EDGE_TYPE]:
                 logger.warning(
-                    f"You provided edge-types {self._supervision_edge_types} but the edge index is homogeneous. Ignoring supervision edge types."
+                    f"You provided edge-types {self._labeled_edge_types} but the edge index is homogeneous. Ignoring supervision edge types."
                 )
             is_heterogeneous = False
             edge_index = {DEFAULT_HOMOGENEOUS_EDGE_TYPE: edge_index}
@@ -308,7 +309,7 @@ class HashedNodeAnchorLinkSplitter:
             splits[anchor_node_type] = (train, val, test)
         if len(splits) == 0:
             raise ValueError(
-                f"Found no edge types to split from the provided edge index: {edge_index.keys()} using supervision edge types {self._supervision_edge_types}"
+                f"Found no edge types to split from the provided edge index: {edge_index.keys()} using labeled edge types {self._labeled_edge_types}"
             )
 
         if is_heterogeneous:

--- a/python/tests/integration/distributed/distributed_dataset_test.py
+++ b/python/tests/integration/distributed/distributed_dataset_test.py
@@ -146,7 +146,9 @@ class DistDatasetTestCase(unittest.TestCase):
                 "Test GLT Dataset Split with heterogeneous toy dataset",
                 mocked_dataset_info=TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
                 is_heterogeneous=False,
-                split_fn=HashedNodeAnchorLinkSplitter(sampling_direction="out"),
+                split_fn=HashedNodeAnchorLinkSplitter(
+                    sampling_direction="out", should_convert_labels_to_edges=True
+                ),
             ),
             param(
                 "Test GLT Dataset Load in parallel with homogeneous toy NABLP dataset",
@@ -154,9 +156,10 @@ class DistDatasetTestCase(unittest.TestCase):
                 is_heterogeneous=True,
                 split_fn=HashedNodeAnchorLinkSplitter(
                     sampling_direction="out",
-                    edge_types=EdgeType(
-                        NodeType("story"), Relation("to"), NodeType("user")
-                    ),
+                    supervision_edge_types=[
+                        EdgeType(NodeType("story"), Relation("to"), NodeType("user"))
+                    ],
+                    should_convert_labels_to_edges=True,
                 ),
             ),
             param(
@@ -167,10 +170,11 @@ class DistDatasetTestCase(unittest.TestCase):
                     sampling_direction="out",
                     num_test=1,
                     num_val=1,
-                    edge_types=[
+                    supervision_edge_types=[
                         EdgeType(NodeType("story"), Relation("to"), NodeType("user")),
                         EdgeType(NodeType("user"), Relation("to"), NodeType("story")),
                     ],
+                    should_convert_labels_to_edges=True,
                 ),
             ),
         ]

--- a/python/tests/integration/distributed/distributed_dataset_test.py
+++ b/python/tests/integration/distributed/distributed_dataset_test.py
@@ -143,15 +143,15 @@ class DistDatasetTestCase(unittest.TestCase):
     @parameterized.expand(
         [
             param(
-                "Test GLT Dataset Split with heterogeneous toy dataset",
+                "Test GLT Dataset Split with homogeneous toy NABLP dataset",
                 mocked_dataset_info=TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
                 is_heterogeneous=False,
                 split_fn=HashedNodeAnchorLinkSplitter(
-                    sampling_direction="out", should_convert_labels_to_edges=True
+                    sampling_direction="out", should_convert_labels_to_edges=False
                 ),
             ),
             param(
-                "Test GLT Dataset Load in parallel with homogeneous toy NABLP dataset",
+                "Test GLT Dataset Load in parallel with heterogeneous toy dataset",
                 mocked_dataset_info=HETEROGENEOUS_TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
                 is_heterogeneous=True,
                 split_fn=HashedNodeAnchorLinkSplitter(
@@ -159,11 +159,11 @@ class DistDatasetTestCase(unittest.TestCase):
                     supervision_edge_types=[
                         EdgeType(NodeType("story"), Relation("to"), NodeType("user"))
                     ],
-                    should_convert_labels_to_edges=True,
+                    should_convert_labels_to_edges=False,
                 ),
             ),
             param(
-                "Test GLT Dataset Load in parallel with homogeneous toy NABLP dataset - two supervision edge types",
+                "Test GLT Dataset Load in parallel with heterogeneous toy NABLP dataset - two supervision edge types",
                 mocked_dataset_info=HETEROGENEOUS_TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
                 is_heterogeneous=True,
                 split_fn=HashedNodeAnchorLinkSplitter(
@@ -174,7 +174,7 @@ class DistDatasetTestCase(unittest.TestCase):
                         EdgeType(NodeType("story"), Relation("to"), NodeType("user")),
                         EdgeType(NodeType("user"), Relation("to"), NodeType("story")),
                     ],
-                    should_convert_labels_to_edges=True,
+                    should_convert_labels_to_edges=False,
                 ),
             ),
         ]

--- a/python/tests/unit/distributed/distributed_dataset_test.py
+++ b/python/tests/unit/distributed/distributed_dataset_test.py
@@ -18,6 +18,7 @@ from gigl.src.mocking.mocking_assets.mocked_datasets_for_pipeline_tests import (
     HETEROGENEOUS_TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
     TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
 )
+from gigl.types.graph import DEFAULT_HOMOGENEOUS_EDGE_TYPE
 from tests.test_assets.distributed.run_distributed_dataset import (
     run_distributed_dataset,
 )
@@ -32,6 +33,8 @@ class _FakeSplitter:
         ],
     ):
         self.splits = splits
+        self._should_convert_labels_to_edges = False
+        self._supervision_edge_types = [DEFAULT_HOMOGENEOUS_EDGE_TYPE]
 
     def __call__(self, edge_index):
         return self.splits

--- a/python/tests/unit/distributed/distributed_dataset_test.py
+++ b/python/tests/unit/distributed/distributed_dataset_test.py
@@ -33,11 +33,14 @@ class _FakeSplitter:
         ],
     ):
         self.splits = splits
-        self._should_convert_labels_to_edges = False
         self._supervision_edge_types = [DEFAULT_HOMOGENEOUS_EDGE_TYPE]
 
     def __call__(self, edge_index):
         return self.splits
+
+    @property
+    def should_convert_labels_to_edges(self):
+        return False
 
 
 _USER = NodeType("user")

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -37,6 +37,7 @@ from gigl.types.graph import (
     to_heterogeneous_node,
     to_homogeneous,
 )
+from gigl.utils.data_splitters import HashedNodeAnchorLinkSplitter
 from tests.test_assets.distributed.run_distributed_dataset import (
     run_distributed_dataset,
 )
@@ -423,11 +424,15 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
         )
         expected_data_count = 2161
 
+        splitter = HashedNodeAnchorLinkSplitter(
+            sampling_direction="in", should_convert_labels_to_edges=True
+        )
+
         dataset = build_dataset(
             serialized_graph_metadata=serialized_graph_metadata,
             distributed_context=self._context,
             sample_edge_direction="in",
-            should_convert_labels_to_edges=True,
+            splitter=splitter,
         )
 
         mp.spawn(

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -422,7 +422,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             graph_metadata_pb_wrapper=gbml_config_pb_wrapper.graph_metadata_pb_wrapper,
             tfrecord_uri_pattern=".*.tfrecord(.gz)?$",
         )
-        expected_data_count = 2161
+        expected_data_count = 2168
 
         splitter = HashedNodeAnchorLinkSplitter(
             sampling_direction="in", should_convert_labels_to_edges=True

--- a/python/tests/unit/types_tests/graph_test.py
+++ b/python/tests/unit/types_tests/graph_test.py
@@ -84,7 +84,7 @@ class GraphTypesTyest(unittest.TestCase):
     @parameterized.expand(
         [
             param(
-                "valid_inputs",
+                "valid_inputs, sample_edge_dir = in",
                 node_ids=torch.tensor([0, 1, 2]),
                 node_features=torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
                 edge_index=torch.tensor([[0, 1], [1, 2]]),
@@ -217,8 +217,8 @@ class GraphTypesTyest(unittest.TestCase):
             positive_label=positive_label,
             negative_label=negative_label,
         )
-
-        graph_tensors.treat_labels_as_edges()
+        # TODO (mkolodner-sc): Parameterize this variable for testing
+        graph_tensors.treat_labels_as_edges(edge_dir="out")
         self.assertIsNone(graph_tensors.positive_label)
         self.assertIsNone(graph_tensors.negative_label)
         assert isinstance(graph_tensors.edge_index, dict)

--- a/python/tests/unit/types_tests/graph_test.py
+++ b/python/tests/unit/types_tests/graph_test.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Union
+from typing import Literal, Union
 
 import torch
 from parameterized import param, parameterized
@@ -9,6 +9,7 @@ from gigl.types.graph import (
     DEFAULT_HOMOGENEOUS_EDGE_TYPE,
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
     LoadedGraphTensors,
+    is_label_edge_type,
     message_passing_to_negative_label,
     message_passing_to_positive_label,
     select_label_edge_types,
@@ -84,25 +85,45 @@ class GraphTypesTyest(unittest.TestCase):
     @parameterized.expand(
         [
             param(
-                "valid_inputs, sample_edge_dir = in",
+                "valid_inputs, edge_dir=in",
                 node_ids=torch.tensor([0, 1, 2]),
                 node_features=torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
                 edge_index=torch.tensor([[0, 1], [1, 2]]),
                 edge_features=torch.tensor([[0.1, 0.2], [0.3, 0.4]]),
-                positive_label=torch.tensor([[0, 2]]),
-                negative_label=torch.tensor([[1, 0]]),
+                positive_label=torch.tensor([[0], [2]]),
+                negative_label=torch.tensor([[1], [0]]),
                 expected_edge_index={
                     DEFAULT_HOMOGENEOUS_EDGE_TYPE: torch.tensor([[0, 1], [1, 2]]),
                     message_passing_to_positive_label(
                         DEFAULT_HOMOGENEOUS_EDGE_TYPE
-                    ): torch.tensor([[0, 2]]),
+                    ): torch.tensor([[2], [0]]),
                     message_passing_to_negative_label(
                         DEFAULT_HOMOGENEOUS_EDGE_TYPE
-                    ): torch.tensor([[1, 0]]),
+                    ): torch.tensor([[0], [1]]),
                 },
+                edge_dir="in",
             ),
             param(
-                "heterogeneous_inputs, positive and negative provided",
+                "valid_inputs, edge_dir=out",
+                node_ids=torch.tensor([0, 1, 2]),
+                node_features=torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]]),
+                edge_index=torch.tensor([[0, 1], [1, 2]]),
+                edge_features=torch.tensor([[0.1, 0.2], [0.3, 0.4]]),
+                positive_label=torch.tensor([[0], [2]]),
+                negative_label=torch.tensor([[1], [0]]),
+                expected_edge_index={
+                    DEFAULT_HOMOGENEOUS_EDGE_TYPE: torch.tensor([[0, 1], [1, 2]]),
+                    message_passing_to_positive_label(
+                        DEFAULT_HOMOGENEOUS_EDGE_TYPE
+                    ): torch.tensor([[0], [2]]),
+                    message_passing_to_negative_label(
+                        DEFAULT_HOMOGENEOUS_EDGE_TYPE
+                    ): torch.tensor([[1], [0]]),
+                },
+                edge_dir="out",
+            ),
+            param(
+                "heterogeneous_inputs, positive and negative provided, edge_dir=out",
                 node_ids={
                     NodeType("foo"): torch.tensor([0, 1]),
                     NodeType("bar"): torch.tensor([2, 3]),
@@ -130,12 +151,12 @@ class GraphTypesTyest(unittest.TestCase):
                 positive_label={
                     EdgeType(
                         NodeType("foo"), Relation("labels"), NodeType("bar")
-                    ): torch.tensor([[0, 2]])
+                    ): torch.tensor([[0], [2]])
                 },
                 negative_label={
                     EdgeType(
                         NodeType("bar"), Relation("labels"), NodeType("foo")
-                    ): torch.tensor([[1, 0]])
+                    ): torch.tensor([[1], [0]])
                 },
                 expected_edge_index={
                     EdgeType(
@@ -146,14 +167,15 @@ class GraphTypesTyest(unittest.TestCase):
                     ): torch.tensor([[2, 3], [0, 1]]),
                     message_passing_to_positive_label(
                         EdgeType(NodeType("foo"), Relation("labels"), NodeType("bar"))
-                    ): torch.tensor([[0, 2]]),
+                    ): torch.tensor([[0], [2]]),
                     message_passing_to_negative_label(
                         EdgeType(NodeType("bar"), Relation("labels"), NodeType("foo"))
-                    ): torch.tensor([[1, 0]]),
+                    ): torch.tensor([[1], [0]]),
                 },
+                edge_dir="out",
             ),
             param(
-                "heterogeneous_inputs, only positive label provided",
+                "heterogeneous_inputs, positive and negative provided, edge_dir=in",
                 node_ids={
                     NodeType("foo"): torch.tensor([0, 1]),
                     NodeType("bar"): torch.tensor([2, 3]),
@@ -181,7 +203,59 @@ class GraphTypesTyest(unittest.TestCase):
                 positive_label={
                     EdgeType(
                         NodeType("foo"), Relation("labels"), NodeType("bar")
-                    ): torch.tensor([[0, 2]])
+                    ): torch.tensor([[0], [2]])
+                },
+                negative_label={
+                    EdgeType(
+                        NodeType("bar"), Relation("labels"), NodeType("foo")
+                    ): torch.tensor([[1], [0]])
+                },
+                expected_edge_index={
+                    EdgeType(
+                        NodeType("foo"), Relation("to"), NodeType("bar")
+                    ): torch.tensor([[0, 1], [2, 3]]),
+                    EdgeType(
+                        NodeType("bar"), Relation("to"), NodeType("foo")
+                    ): torch.tensor([[2, 3], [0, 1]]),
+                    message_passing_to_positive_label(
+                        EdgeType(NodeType("bar"), Relation("labels"), NodeType("foo"))
+                    ): torch.tensor([[2], [0]]),
+                    message_passing_to_negative_label(
+                        EdgeType(NodeType("foo"), Relation("labels"), NodeType("bar"))
+                    ): torch.tensor([[0], [1]]),
+                },
+                edge_dir="in",
+            ),
+            param(
+                "heterogeneous_inputs, only positive label provided, edge_dir=out",
+                node_ids={
+                    NodeType("foo"): torch.tensor([0, 1]),
+                    NodeType("bar"): torch.tensor([2, 3]),
+                },
+                node_features={
+                    NodeType("foo"): torch.tensor([[1.0, 2.0], [3.0, 4.0]]),
+                    NodeType("bar"): torch.tensor([[5.0, 6.0], [7.0, 8.0]]),
+                },
+                edge_index={
+                    EdgeType(
+                        NodeType("foo"), Relation("to"), NodeType("bar")
+                    ): torch.tensor([[0, 1], [2, 3]]),
+                    EdgeType(
+                        NodeType("bar"), Relation("to"), NodeType("foo")
+                    ): torch.tensor([[2, 3], [0, 1]]),
+                },
+                edge_features={
+                    EdgeType(
+                        NodeType("foo"), Relation("to"), NodeType("bar")
+                    ): torch.tensor([[0.1, 0.2], [0.3, 0.4]]),
+                    EdgeType(
+                        NodeType("bar"), Relation("to"), NodeType("foo")
+                    ): torch.tensor([[0.5, 0.6], [0.7, 0.8]]),
+                },
+                positive_label={
+                    EdgeType(
+                        NodeType("foo"), Relation("labels"), NodeType("bar")
+                    ): torch.tensor([[0], [2]])
                 },
                 negative_label=None,
                 expected_edge_index={
@@ -193,8 +267,9 @@ class GraphTypesTyest(unittest.TestCase):
                     ): torch.tensor([[2, 3], [0, 1]]),
                     message_passing_to_positive_label(
                         EdgeType(NodeType("foo"), Relation("labels"), NodeType("bar"))
-                    ): torch.tensor([[0, 2]]),
+                    ): torch.tensor([[0], [2]]),
                 },
+                edge_dir="out",
             ),
         ]
     )
@@ -208,6 +283,7 @@ class GraphTypesTyest(unittest.TestCase):
         positive_label: Union[torch.Tensor, dict[EdgeType, torch.Tensor]],
         negative_label: Union[torch.Tensor, dict[EdgeType, torch.Tensor]],
         expected_edge_index: dict[EdgeType, torch.Tensor],
+        edge_dir: Literal["in", "out"],
     ):
         graph_tensors = LoadedGraphTensors(
             node_ids=node_ids,
@@ -217,8 +293,7 @@ class GraphTypesTyest(unittest.TestCase):
             positive_label=positive_label,
             negative_label=negative_label,
         )
-        # TODO (mkolodner-sc): Parameterize this variable for testing
-        graph_tensors.treat_labels_as_edges(edge_dir="out")
+        graph_tensors.treat_labels_as_edges(edge_dir=edge_dir)
         self.assertIsNone(graph_tensors.positive_label)
         self.assertIsNone(graph_tensors.negative_label)
         assert isinstance(graph_tensors.edge_index, dict)
@@ -267,6 +342,39 @@ class GraphTypesTyest(unittest.TestCase):
             ),
             select_label_edge_types(message_passing_edge_type, edge_types),
         )
+
+    @parameterized.expand(
+        [
+            param(
+                "valid positive label edge type",
+                input_edge_type=EdgeType(
+                    NodeType("foo"), Relation("to_gigl_positive"), NodeType("bar")
+                ),
+                is_expected_label=True,
+            ),
+            param(
+                "valid negative label edge type",
+                input_edge_type=EdgeType(
+                    NodeType("bar"), Relation("to_gigl_negative"), NodeType("foo")
+                ),
+                is_expected_label=True,
+            ),
+            param(
+                "invalid label edge type",
+                input_edge_type=EdgeType(
+                    NodeType("foo"), Relation("to"), NodeType("bar")
+                ),
+                is_expected_label=False,
+            ),
+        ]
+    )
+    def test_is_label_edge_type(
+        self, _, input_edge_type: EdgeType, is_expected_label: bool
+    ):
+        if is_expected_label:
+            self.assertTrue(is_label_edge_type(edge_type=input_edge_type))
+        else:
+            self.assertFalse(is_label_edge_type(edge_type=input_edge_type))
 
 
 if __name__ == "__main__":

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -223,6 +223,7 @@ class TestDataSplitters(unittest.TestCase):
             hash_function=hash_function,
             num_val=val_num,
             num_test=test_num,
+            should_convert_labels_to_edges=False,
         )
         train, val, test = splitter(edges)
 
@@ -430,7 +431,8 @@ class TestDataSplitters(unittest.TestCase):
             hash_function=hash_function,
             num_val=val_num,
             num_test=test_num,
-            edge_types=edge_types_to_split,
+            supervision_edge_types=edge_types_to_split,
+            should_convert_labels_to_edges=False,
         )
         split = splitter(edges)
 
@@ -472,11 +474,12 @@ class TestDataSplitters(unittest.TestCase):
         edge_types_to_split,
     ):
         with self.assertRaises(ValueError):
-            HashedNodeAnchorLinkSplitter(
-                sampling_direction="in", edge_types=edge_types_to_split
-            )(
-                edge_index=edges,
+            splitter = HashedNodeAnchorLinkSplitter(
+                sampling_direction="in",
+                supervision_edge_types=edge_types_to_split,
+                should_convert_labels_to_edges=False,
             )
+            splitter(edge_index=edges)
 
     def test_node_based_link_splitter_no_train_nodes(self):
         edges = torch.stack(
@@ -486,9 +489,13 @@ class TestDataSplitters(unittest.TestCase):
             ]
         )
         with self.assertRaises(ValueError):
-            HashedNodeAnchorLinkSplitter(
-                sampling_direction="in", num_val=5, num_test=5
-            )(edges)
+            splitter = HashedNodeAnchorLinkSplitter(
+                sampling_direction="in",
+                num_val=5,
+                num_test=5,
+                should_convert_labels_to_edges=False,
+            )
+            splitter(edge_index=edges)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
Updated the split API and functionality in GiGL.
- Moves `should_convert_labels_to_edge` to the splitter class and make `supervision_edge_types` param more explicit
- Update SSL building logic to infer edge types based on the supervision edges, rather than all edges
- Update `treat_labels_as_edges` to correctly handle labeled edges in both "in" and "out" edge directions
- Update corresponding tests
 
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
