### PR TITLE
Allow all devs to approve changes to run_command_on_active_checkout.yaml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,3 +5,7 @@
 .github/ @svij-sc @kmontemayor2-sc @nshah-sc
 requirements @svij-sc @kmontemayor2-sc @nshah-sc
 python/pyproject.toml @svij-sc @kmontemayor2-sc @nshah-sc
+
+# run_command_on_active_checkout.yaml gets updated when we build new images
+# As all devs may setup new images, we allow all of us to review it
+.github/cloud_builder/run_command_on_active_checkout.yaml @svij-sc @kmontemayor2-sc @nshah-sc @yliu2-sc @mkolodner-sc


### PR DESCRIPTION
As discussed offline, since this file get's modified when we build new docker images, it may be useful for all of us to be able to edit it. 