### PR TITLE
Allow for non-existant anchor node ids when creating labels

### DIFF
--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -436,9 +436,13 @@ def _get_padded_labels(
         mask, torch.full_like(ranges, PADDING_NODE.item()), indices[ranges]
     )
     labels = torch.cat(
-        [labels, torch.ones(extra_nodes_to_pad, max_range) * PADDING_NODE], dim=0
+        [
+            labels,
+            torch.ones(extra_nodes_to_pad, max_range, dtype=torch.int64) * PADDING_NODE,
+        ],
+        dim=0,
     )
-    return labels.to(dtype=torch.int64)
+    return labels
 
 
 def _check_sampling_direction(sampling_direction: str):

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -271,7 +271,7 @@ class HashedNodeAnchorLinkSplitter:
         splits: dict[NodeType, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         for anchor_node_type, collected_anchor_nodes in node_ids_by_node_type.items():
             max_node_id = max_node_id_by_type[anchor_node_type]
-            node_id_count = torch.zeros(max_node_id, dtype=torch.int64)
+            node_id_count = torch.zeros(max_node_id, dtype=torch.uint8)
             for anchor_nodes in collected_anchor_nodes:
                 node_id_count.add_(torch.bincount(anchor_nodes, minlength=max_node_id))
             # This line takes us from a count of all node ids, e.g. `[0, 2, 0, 1]`
@@ -349,7 +349,9 @@ def get_labels_for_anchor_nodes(
                 -1, # Positive node (padded)
             ],
         ]
-
+    If positive and negative label edge types are provided:
+        * All negative label node ids must be present in the positive label node ids.
+        * For any positive label node id that does not have a negative label, the negative label will be padded with `PADDING_NODE`.
     Args:
         dataset (Dataset): The dataset storing the graph info, must be heterogeneous.
         node_ids (torch.Tensor): The node ids to use for the labels. [N]
@@ -372,18 +374,26 @@ def get_labels_for_anchor_nodes(
         negative_node_topo = None
 
     # Labels is NxM, where N is the number of nodes, and M is the max number of labels.
-    positive_labels = _get_padded_labels(node_ids, positive_node_topo)
+    positive_labels = _get_padded_labels(
+        node_ids, positive_node_topo, allow_non_existant_node_ids=False
+    )
 
     if negative_node_topo is not None:
         # Labels is NxM, where N is the number of nodes, and M is the max number of labels.
-        negative_labels = _get_padded_labels(node_ids, negative_node_topo)
+        negative_labels = _get_padded_labels(
+            node_ids, negative_node_topo, allow_non_existant_node_ids=True
+        )
     else:
         negative_labels = None
 
     return positive_labels, negative_labels
 
 
-def _get_padded_labels(anchor_node_ids: torch.Tensor, topo: Topology) -> torch.Tensor:
+def _get_padded_labels(
+    anchor_node_ids: torch.Tensor,
+    topo: Topology,
+    allow_non_existant_node_ids: bool = False,
+) -> torch.Tensor:
     """Returns the padded labels and the max range of labels.
 
     Given anchor node ids and a topology, this function returns a tensor
@@ -393,6 +403,8 @@ def _get_padded_labels(anchor_node_ids: torch.Tensor, topo: Topology) -> torch.T
     Args:
         anchor_node_ids (torch.Tensor): The anchor node ids to use for the labels. [N]
         topo (Topology): The topology to use for the labels.
+        allow_non_existant_node_ids (bool): If True, will allow anchor node ids that do not exist in the topology.
+            This means that the returned tensor will be padded with `PADDING_NODE` for those anchor node ids.
     Returns:
         The shape of the returned tensor is [N, max_number_of_labels].
     """
@@ -402,6 +414,11 @@ def _get_padded_labels(anchor_node_ids: torch.Tensor, topo: Topology) -> torch.T
     # Note that GLT defaults to CSR under the hood, if this changes, we will need to update this.
     indptr = topo.indptr  # [N]
     indices = topo.indices  # [M]
+    extra_nodes_to_pad = 0
+    if allow_non_existant_node_ids:
+        valid_ids = anchor_node_ids < (indptr.size(0) - 1)
+        extra_nodes_to_pad = int(torch.count_nonzero(~valid_ids).item())
+        anchor_node_ids = anchor_node_ids[valid_ids]
     starts = indptr[anchor_node_ids]  # [N]
     ends = indptr[anchor_node_ids + 1]  # [N]
 
@@ -418,7 +435,10 @@ def _get_padded_labels(anchor_node_ids: torch.Tensor, topo: Topology) -> torch.T
     labels = torch.where(
         mask, torch.full_like(ranges, PADDING_NODE.item()), indices[ranges]
     )
-    return labels
+    labels = torch.cat(
+        [labels, torch.ones(extra_nodes_to_pad, max_range) * PADDING_NODE], dim=0
+    )
+    return labels.to(dtype=torch.int64)
 
 
 def _check_sampling_direction(sampling_direction: str):

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -585,7 +585,7 @@ class TestDataSplitters(unittest.TestCase):
         positive, negative = get_labels_for_anchor_nodes(
             dataset=ds, node_ids=node_ids, positive_label_edge_type=a_to_b
         )
-        expected = torch.tensor([[10, 11]])
+        expected = torch.tensor([[10, 11]], dtype=torch.int64)
         assert_close(positive, expected, rtol=0, atol=0)
         self.assertIsNone(negative)
 
@@ -595,15 +595,17 @@ class TestDataSplitters(unittest.TestCase):
         edges = {
             a_to_b: torch.tensor(
                 [
-                    [10, 10, 11, 11, 12],
-                    [10, 11, 12, 13, 10],
-                ]
+                    [10, 10, 11, 11, 12, 13],
+                    [10, 11, 12, 13, 10, 10],
+                ],
+                dtype=torch.int64,
             ),
             a_to_c: torch.tensor(
                 [
                     [10, 11, 12, 11],
                     [20, 30, 40, 50],
-                ]
+                ],
+                dtype=torch.int64,
             ),
         }
         ds = Dataset()
@@ -614,7 +616,7 @@ class TestDataSplitters(unittest.TestCase):
         )
 
         # TODO(kmonte): Update to use a splitter once we've migrated splitter API.
-        node_ids = torch.tensor([10, 11])
+        node_ids = torch.tensor([10, 11, 13])
         positive, negative = get_labels_for_anchor_nodes(
             dataset=ds,
             node_ids=node_ids,
@@ -622,8 +624,12 @@ class TestDataSplitters(unittest.TestCase):
             negative_label_edge_type=a_to_c,
         )
 
-        expected_positive = torch.tensor([[10, 11], [12, 13]])
-        expected_negative = torch.tensor([[20, -1], [30, 50]])
+        expected_positive = torch.tensor(
+            [[10, 11], [12, 13], [10, -1]], dtype=torch.int64
+        )
+        expected_negative = torch.tensor(
+            [[20, -1], [30, 50], [-1, -1]], dtype=torch.int64
+        )
         assert_close(positive, expected_positive, rtol=0, atol=0)
         assert_close(negative, expected_negative, rtol=0, atol=0)
 
@@ -633,9 +639,10 @@ class TestDataSplitters(unittest.TestCase):
                 "CSR",
                 node_ids=torch.tensor([0, 1]),
                 topo=Topology(
-                    edge_index=torch.tensor([[0, 0, 1], [1, 2, 2]]), layout="CSR"
+                    edge_index=torch.tensor([[0, 0, 1], [1, 2, 2]], dtype=torch.int64),
+                    layout="CSR",
                 ),
-                expected=torch.tensor([[1, 2], [2, -1]]),
+                expected=torch.tensor([[1, 2], [2, -1]], dtype=torch.int64),
             ),
             param(
                 "CSC",
@@ -647,11 +654,12 @@ class TestDataSplitters(unittest.TestCase):
                         [
                             [1, 2, 0],
                             [0, 1, 1],
-                        ]
+                        ],
+                        dtype=torch.int64,
                     ),
                     layout="CSC",
                 ),
-                expected=torch.tensor([[1, -1], [0, 2]]),
+                expected=torch.tensor([[1, -1], [0, 2]], dtype=torch.int64),
             ),
         ]
     )

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -623,7 +623,7 @@ class TestDataSplitters(unittest.TestCase):
             positive_label_edge_type=a_to_b,
             negative_label_edge_type=a_to_c,
         )
-
+        # "DST" nodes for our anchor nodes (10, 11, 13).
         expected_positive = torch.tensor(
             [[10, 11], [12, 13], [10, -1]], dtype=torch.int64
         )


### PR DESCRIPTION
Instead of https://github.com/Snapchat/GiGL/pull/78 let's go with this approach.

Now, if there isa. positive node id with no corresponding hard negative labels, the nodes negative labels will be padded with our padding node, which is later stripped out.