### PR TITLE
Introduce utility to fetch free ports from master node rank zero

### DIFF
--- a/python/gigl/distributed/__init__.py
+++ b/python/gigl/distributed/__init__.py
@@ -2,7 +2,7 @@
 GLT Distributed Classes implemented in GiGL
 """
 
-all = [
+__all__ = [
     "DistNeighborLoader",
     "DistLinkPredictionDataset",
     "DistributedContext",

--- a/python/gigl/distributed/__init__.py
+++ b/python/gigl/distributed/__init__.py
@@ -2,6 +2,16 @@
 GLT Distributed Classes implemented in GiGL
 """
 
+all = [
+    "DistNeighborLoader",
+    "DistLinkPredictionDataset",
+    "DistributedContext",
+    "DistPartitioner",
+    "DistRangePartitioner",
+    "build_dataset",
+    "build_dataset_from_task_config_uri",
+]
+
 from gigl.distributed.dataset_factory import (
     build_dataset,
     build_dataset_from_task_config_uri,

--- a/python/gigl/distributed/utils/__init__.py
+++ b/python/gigl/distributed/utils/__init__.py
@@ -2,7 +2,7 @@
 Utility functions for distributed computing.
 """
 
-all = [
+__all__ = [
     "get_available_device",
     "get_free_ports_from_master_node",
     "get_free_port",

--- a/python/gigl/distributed/utils/__init__.py
+++ b/python/gigl/distributed/utils/__init__.py
@@ -1,5 +1,18 @@
+"""
+Utility functions for distributed computing.
+"""
+
+all = [
+    "get_available_device",
+    "get_free_master_ports",
+    "get_free_port",
+    "get_process_group_name",
+    "init_neighbor_loader_worker",
+]
+
 from .device import get_available_device
 from .init_neighbor_loader_worker import (
     get_process_group_name,
     init_neighbor_loader_worker,
 )
+from .networking import get_free_master_ports, get_free_port

--- a/python/gigl/distributed/utils/__init__.py
+++ b/python/gigl/distributed/utils/__init__.py
@@ -4,7 +4,7 @@ Utility functions for distributed computing.
 
 all = [
     "get_available_device",
-    "get_free_master_ports",
+    "get_free_ports_from_master_node",
     "get_free_port",
     "get_process_group_name",
     "init_neighbor_loader_worker",
@@ -15,4 +15,4 @@ from .init_neighbor_loader_worker import (
     get_process_group_name,
     init_neighbor_loader_worker,
 )
-from .networking import get_free_master_ports, get_free_port
+from .networking import get_free_port, get_free_ports_from_master_node

--- a/python/gigl/distributed/utils/networking.py
+++ b/python/gigl/distributed/utils/networking.py
@@ -40,7 +40,7 @@ def get_free_ports(num_ports: int) -> list[int]:
     return ports
 
 
-def get_free_master_ports(
+def get_free_ports_from_master_node(
     num_ports=1, _global_rank_override: Optional[int] = None
 ) -> list[int]:
     """

--- a/python/gigl/distributed/utils/networking.py
+++ b/python/gigl/distributed/utils/networking.py
@@ -10,7 +10,7 @@ logger = Logger()
 
 def get_free_port() -> int:
     """
-    Find a free port and return the socket (to keep open) and port number.
+    Get a free port number.
     Returns:
         int: A free port number on the current machine.
     """
@@ -19,7 +19,7 @@ def get_free_port() -> int:
 
 def get_free_ports(num_ports: int) -> list[int]:
     """
-    Get a list of free ports.
+    Get a list of free port numbers.
     Args:
         num_ports (int): Number of free ports to find.
     Returns:

--- a/python/gigl/distributed/utils/networking.py
+++ b/python/gigl/distributed/utils/networking.py
@@ -1,5 +1,5 @@
 import socket
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
 

--- a/python/gigl/distributed/utils/networking.py
+++ b/python/gigl/distributed/utils/networking.py
@@ -44,7 +44,7 @@ def get_free_ports_from_master_node(
     num_ports=1, _global_rank_override: Optional[int] = None
 ) -> list[int]:
     """
-    Get a free port from master node, that can be used for communication between workers.
+    Get free ports from master node, that can be used for communication between workers.
     Args:
         num_ports (int): Number of free ports to find.
         _global_rank_override (Optional[int]): Override for the global rank,

--- a/python/gigl/distributed/utils/networking.py
+++ b/python/gigl/distributed/utils/networking.py
@@ -1,0 +1,48 @@
+import socket
+from typing import Optional
+
+import torch
+
+
+def get_free_port() -> tuple[socket.socket, int]:
+    """
+    Find a free port and return the socket (to keep open) and port number.
+    Returns:
+        tuple[socket.socket, int]: A tuple containing the socket and the free port number.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("", 0))  # OS assigns a free port
+    return s, s.getsockname()[1]
+
+
+def get_free_master_ports(
+    num_ports=1, _global_rank_override: Optional[int] = None
+) -> list[int]:
+    """
+    Get a free port from master node, that can be used for communication between workers.
+    """
+    assert (
+        torch.distributed.is_initialized()
+    ), "Distributed environment must be initialized to communicate free ports on master"
+    assert num_ports >= 1, "num_ports must be >= 1"
+
+    rank = (
+        torch.distributed.get_rank()
+        if _global_rank_override is None
+        else _global_rank_override
+    )
+    ports: list[int] = []
+    if rank == 0:
+        # Find a free port on the master node
+        s, port = get_free_port()
+        ports.append(port)
+    else:
+        ports.append(0)  # dummy for non rank 0 processes
+
+    # Wrap port in a tensor to communicate
+    port_tensor = torch.tensor(
+        ports, dtype=torch.int32, device="cuda" if torch.cuda.is_available() else "cpu"
+    )
+    # Broadcast from master from rank 0 to all other ranks
+    torch.distributed.broadcast(port_tensor, src=0)
+    return port_tensor.tolist()

--- a/python/tests/unit/distributed/utils/networking_test.py
+++ b/python/tests/unit/distributed/utils/networking_test.py
@@ -19,19 +19,23 @@ def run_in_dist_context(
         rank=rank,
     )
     try:
-        ports = get_free_master_ports(num_ports=num_ports)
-        # Check that all ranks see the same port broadcasted from master (rank 0)
-        port_tensor = torch.tensor(ports, dtype=torch.int32)
-        gathered = [torch.zeros_like(port_tensor) for _ in range(world_size)]
-        dist.all_gather(gathered, port_tensor)
-        gathered_ports = [p.item() for p in gathered]
-
-        # Assert all ports are the same
-        assert all(
-            p == gathered_ports[0] for p in gathered_ports
-        ), f"Ports not synchronized: {gathered_ports}"
-        # Assert the port is a positive integer
-        assert gathered_ports[0] > 0
+        ports: list[int] = get_free_master_ports(num_ports=num_ports)
+        # Check that all ranks see the same ports broadcasted from master (rank 0)
+        gathered_ports = [
+            torch.zeros(num_ports, dtype=torch.int32) for _ in range(world_size)
+        ]
+        dist.all_gather_object(gathered_ports, ports)
+        assert len(gathered_ports) == world_size, (
+            f"Expected {world_size} ports, but got {len(gathered_ports)}"
+        )
+        assert all(isinstance(p, int) and p > 0 for p in gathered_ports), (
+            f"All gathered ports should be positive integers, but got: {gathered_ports}"
+        )
+        for rank in range(world_size):
+            port_n = [gathered_ports[rank][port_num] for port_num in range(num_ports)]
+            assert all(
+                p == port_n[0] for p in port_n
+            ), f"Ports not synchronized across ranks: {port_n}"
     finally:
         dist.destroy_process_group()
 
@@ -69,5 +73,8 @@ class TestGetFreeMasterPorts(unittest.TestCase):
         )
 
     def test_fails_if_process_group_not_initialized(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(
+            RuntimeError,
+            msg="An error should be raised since the `dist.init_process_group` is not initialized"
+        ):
             get_free_master_ports(num_ports=1)

--- a/python/tests/unit/distributed/utils/networking_test.py
+++ b/python/tests/unit/distributed/utils/networking_test.py
@@ -1,0 +1,73 @@
+import unittest
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from parameterized import param, parameterized
+
+from gigl.distributed.utils import get_free_master_ports, get_free_port
+
+
+def run_in_dist_context(
+    rank: int, world_size: int, init_process_group_init_method: str, num_ports: int
+):
+    # Initialize distributed process group
+    dist.init_process_group(
+        backend="gloo",
+        init_method=init_process_group_init_method,
+        world_size=world_size,
+        rank=rank,
+    )
+    try:
+        ports = get_free_master_ports(num_ports=num_ports)
+        # Check that all ranks see the same port broadcasted from master (rank 0)
+        port_tensor = torch.tensor(ports, dtype=torch.int32)
+        gathered = [torch.zeros_like(port_tensor) for _ in range(world_size)]
+        dist.all_gather(gathered, port_tensor)
+        gathered_ports = [p.item() for p in gathered]
+
+        # Assert all ports are the same
+        assert all(
+            p == gathered_ports[0] for p in gathered_ports
+        ), f"Ports not synchronized: {gathered_ports}"
+        # Assert the port is a positive integer
+        assert gathered_ports[0] > 0
+    finally:
+        dist.destroy_process_group()
+
+
+class TestGetFreeMasterPorts(unittest.TestCase):
+    def tearDown(self):
+        dist.destroy_process_group()
+
+    @parameterized.expand(
+        [
+            param(
+                "Test fetching 1 port for world_size = 1",
+                num_ports=1,
+                world_size=1,
+            ),
+            param(
+                "Test fetching 1 port for world_size = 2",
+                num_ports=1,
+                world_size=2,
+            ),
+            param(
+                "Test fetching 2 ports for world_size = 2",
+                num_ports=2,
+                world_size=2,
+            ),
+        ]
+    )
+    def test_get_free_master_ports_two_ranks(self, _, num_ports: int, world_size: int):
+        port = get_free_port()
+        init_process_group_init_method = f"tcp://127.0.0.1:{port}"
+        mp.spawn(
+            run_in_dist_context,
+            args=(world_size, init_process_group_init_method, num_ports),
+            nprocs=world_size,
+        )
+
+    def test_fails_if_process_group_not_initialized(self):
+        with self.assertRaises(RuntimeError):
+            get_free_master_ports(num_ports=1)

--- a/python/tests/unit/distributed/utils/networking_test.py
+++ b/python/tests/unit/distributed/utils/networking_test.py
@@ -4,6 +4,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from parameterized import param, parameterized
+
 from gigl.distributed.utils import get_free_port, get_free_ports_from_master_node
 
 

--- a/python/tests/unit/distributed/utils/networking_test.py
+++ b/python/tests/unit/distributed/utils/networking_test.py
@@ -8,7 +8,7 @@ from parameterized import param, parameterized
 from gigl.distributed.utils import get_free_port, get_free_ports_from_master_node
 
 
-def run_in_dist_context(
+def test_fetching_free_ports_in_dist_context(
     rank: int, world_size: int, init_process_group_init_method: str, num_ports: int
 ):
     # Initialize distributed process group
@@ -78,7 +78,7 @@ class TestGetFreeMasterPorts(unittest.TestCase):
         port = get_free_port()
         init_process_group_init_method = f"tcp://127.0.0.1:{port}"
         mp.spawn(
-            fn=run_in_dist_context,
+            fn=test_fetching_free_ports_in_dist_context,
             args=(world_size, init_process_group_init_method, num_ports),
             nprocs=world_size,
         )

--- a/python/tests/unit/distributed/utils/networking_test.py
+++ b/python/tests/unit/distributed/utils/networking_test.py
@@ -4,11 +4,10 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from parameterized import param, parameterized
-
 from gigl.distributed.utils import get_free_port, get_free_ports_from_master_node
 
 
-def __test_fetching_free_ports_in_dist_context(
+def _test_fetching_free_ports_in_dist_context(
     rank: int, world_size: int, init_process_group_init_method: str, num_ports: int
 ):
     # Initialize distributed process group
@@ -45,7 +44,7 @@ def __test_fetching_free_ports_in_dist_context(
         dist.destroy_process_group()
 
 
-class TestGetFreeMasterPorts(unittest.TestCase):
+class TestDistributedNetworkingUtils(unittest.TestCase):
     def tearDown(self):
         if dist.is_initialized():
             print("Destroying process group")
@@ -78,12 +77,12 @@ class TestGetFreeMasterPorts(unittest.TestCase):
         port = get_free_port()
         init_process_group_init_method = f"tcp://127.0.0.1:{port}"
         mp.spawn(
-            fn=__test_fetching_free_ports_in_dist_context,
+            fn=_test_fetching_free_ports_in_dist_context,
             args=(world_size, init_process_group_init_method, num_ports),
             nprocs=world_size,
         )
 
-    def test_fails_if_process_group_not_initialized(self):
+    def test_get_free_ports_from_master_fails_if_process_group_not_initialized(self):
         with self.assertRaises(
             AssertionError,
             msg="An error should be raised since the `dist.init_process_group` is not initialized",

--- a/python/tests/unit/distributed/utils/networking_test.py
+++ b/python/tests/unit/distributed/utils/networking_test.py
@@ -8,7 +8,7 @@ from parameterized import param, parameterized
 from gigl.distributed.utils import get_free_port, get_free_ports_from_master_node
 
 
-def test_fetching_free_ports_in_dist_context(
+def __test_fetching_free_ports_in_dist_context(
     rank: int, world_size: int, init_process_group_init_method: str, num_ports: int
 ):
     # Initialize distributed process group
@@ -78,7 +78,7 @@ class TestGetFreeMasterPorts(unittest.TestCase):
         port = get_free_port()
         init_process_group_init_method = f"tcp://127.0.0.1:{port}"
         mp.spawn(
-            fn=test_fetching_free_ports_in_dist_context,
+            fn=__test_fetching_free_ports_in_dist_context,
             args=(world_size, init_process_group_init_method, num_ports),
             nprocs=world_size,
         )

--- a/python/tests/unit/distributed/utils/networking_test.py
+++ b/python/tests/unit/distributed/utils/networking_test.py
@@ -5,7 +5,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 from parameterized import param, parameterized
 
-from gigl.distributed.utils import get_free_master_ports, get_free_port
+from gigl.distributed.utils import get_free_port, get_free_ports_from_master_node
 
 
 def run_in_dist_context(
@@ -19,7 +19,7 @@ def run_in_dist_context(
         rank=rank,
     )
     try:
-        free_ports: list[int] = get_free_master_ports(num_ports=num_ports)
+        free_ports: list[int] = get_free_ports_from_master_node(num_ports=num_ports)
         assert len(free_ports) == num_ports
 
         # Check that all ranks see the same ports broadcasted from master (rank 0)
@@ -72,7 +72,9 @@ class TestGetFreeMasterPorts(unittest.TestCase):
             ),
         ]
     )
-    def test_get_free_master_ports_two_ranks(self, _name, num_ports, world_size):
+    def test_get_free_ports_from_master_node_two_ranks(
+        self, _name, num_ports, world_size
+    ):
         port = get_free_port()
         init_process_group_init_method = f"tcp://127.0.0.1:{port}"
         mp.spawn(
@@ -86,4 +88,4 @@ class TestGetFreeMasterPorts(unittest.TestCase):
             AssertionError,
             msg="An error should be raised since the `dist.init_process_group` is not initialized",
         ):
-            get_free_master_ports(num_ports=1)
+            get_free_ports_from_master_node(num_ports=1)


### PR DESCRIPTION
**Scope of work done**

Introducing utility functions to get free ports.
Specifically, introduced `gigl.distributed.utils.get_free_ports_from_master_node()` which helps  get free ports from master node, that can be used for communication between workers. This will help reduce situations where certain nodes are already taken.


<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
