### PR TITLE
Require non-empty flags be provided

### DIFF
--- a/python/gigl/orchestration/kubeflow/runner.py
+++ b/python/gigl/orchestration/kubeflow/runner.py
@@ -250,12 +250,18 @@ if __name__ == "__main__":
         if not hasattr(args, flag):
             missing_flags.append(flag)
         elif len(getattr(args, flag)) == 0:
-            missing_flags.append(flag)
+            missing_values.append(flag)
 
     if missing_flags:
         raise ValueError(
             f"Missing the following flags for a {args.action} command: {missing_flags}. "
-            + f"All required flags are: {list(required_flags)}.\nDid you forget to provide a value for the flags?"
+            + f"All required flags are: {list(required_flags)}."
+        )
+
+    if missing_values:
+        raise ValueError(
+            f"Missing values for the following flags for a {args.action} command: {missing_values}. "
+            + f"All required flags are: {list(required_flags)}."
         )
 
     compiled_pipeline_path = UriFactory.create_uri(args.compiled_pipeline_path)

--- a/python/gigl/orchestration/kubeflow/runner.py
+++ b/python/gigl/orchestration/kubeflow/runner.py
@@ -244,14 +244,18 @@ if __name__ == "__main__":
     elif args.action == Action.COMPILE:
         required_flags = _REQUIRED_COMPILE_FLAGS
 
-    missing_flags = []
+    missing_flags: list[str] = []
+    missing_values: list[str] = []
     for flag in required_flags:
         if not hasattr(args, flag):
             missing_flags.append(flag)
+        elif len(getattr(args, flag)) == 0:
+            missing_flags.append(flag)
+
     if missing_flags:
         raise ValueError(
             f"Missing the following flags for a {args.action} command: {missing_flags}. "
-            + f"All required flags are: {list(required_flags)}"
+            + f"All required flags are: {list(required_flags)}.\nDid you forget to provide a value for the flags?"
         )
 
     compiled_pipeline_path = UriFactory.create_uri(args.compiled_pipeline_path)


### PR DESCRIPTION
If we provide these like: `--task_config_uri= /foo/bar/file.yaml` they will get passed in as an empty string, which is not what we want!

This can happen from our [make rule](https://github.com/Snapchat/GiGL/blob/f00d1d290acc9f3abd2dc10a77e9eb69e896c864/Makefile#L433-L445) too.

Maybe we should check that the URI exists but this may not always be possible due to permissions so let's just leave it as "non empty string" for now?

When it fails it looks like:

```
ValueError: Missing values for the following flags for a Action.RUN command: ['task_config_uri']. All required flags are: ['resource_config_uri', 'task_config_uri', 'container_image_cpu', 'container_image_cuda', 'container_image_dataflow'].
```
