### PR TITLE
Test correct node ids are set too

### DIFF
--- a/python/tests/unit/distributed/dataset_factory_test.py
+++ b/python/tests/unit/distributed/dataset_factory_test.py
@@ -9,8 +9,10 @@ from gigl.src.mocking.lib.versioning import get_mocked_dataset_artifact_metadata
 from gigl.src.mocking.mocking_assets.mocked_datasets_for_pipeline_tests import (
     CORA_USER_DEFINED_NODE_ANCHOR_MOCKED_DATASET_INFO,
 )
+from gigl.types.graph import DEFAULT_HOMOGENEOUS_NODE_TYPE
 
 
+# TODO(kmonte, mkolodner): Add more tests for heterogeneous datasets.
 class TestDatasetFactory(unittest.TestCase):
     def setUp(self):
         # Set up any necessary context or mock data
@@ -31,6 +33,7 @@ class TestDatasetFactory(unittest.TestCase):
         task_config_uri = get_mocked_dataset_artifact_metadata()[
             CORA_USER_DEFINED_NODE_ANCHOR_MOCKED_DATASET_INFO.name
         ].frozen_gbml_config_uri
+
         dataset = build_dataset_from_task_config_uri(
             task_config_uri,
             self._dist_context,
@@ -44,9 +47,19 @@ class TestDatasetFactory(unittest.TestCase):
             self.assertIsNone(dataset.test_node_ids)
         else:
             # Mapping despite being "homogeneous" as ABLP uses labels as edge types.
-            self.assertIsInstance(dataset.train_node_ids, abc.Mapping)
-            self.assertIsInstance(dataset.val_node_ids, abc.Mapping)
-            self.assertIsInstance(dataset.test_node_ids, abc.Mapping)
+            # Use assert isinstance instead of self.assertIsInstance to type narrow.
+            assert isinstance(dataset.train_node_ids, abc.Mapping)
+            self.assertTrue(
+                dataset.train_node_ids.keys() == set([DEFAULT_HOMOGENEOUS_NODE_TYPE])
+            )
+            assert isinstance(dataset.val_node_ids, abc.Mapping)
+            self.assertTrue(
+                dataset.val_node_ids.keys() == set([DEFAULT_HOMOGENEOUS_NODE_TYPE])
+            )
+            assert isinstance(dataset.test_node_ids, abc.Mapping)
+            self.assertTrue(
+                dataset.val_node_ids.keys() == set([DEFAULT_HOMOGENEOUS_NODE_TYPE])
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Originally, I wanted to test against a heterogeneous dataset too, but we don't have any one with labels setup, and we don't expose `_ssl_positive_label_percentage` here.

But I added these checks and might as well go for them :P