### PR TITLE
By default silence tf log spam

### DIFF
--- a/python/gigl/common/services/vertex_ai.py
+++ b/python/gigl/common/services/vertex_ai.py
@@ -104,7 +104,7 @@ class VertexAiJobConfig:
     enable_web_access: bool = True
     # Default to suppress TensorFlow log spam
     # Like: ` E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered`
-    tf_cpp_min_log_level: Optional[int] = 2
+    tf_cpp_min_log_level: Optional[int] = 3
 
 
 class VertexAIService:

--- a/python/gigl/common/services/vertex_ai.py
+++ b/python/gigl/common/services/vertex_ai.py
@@ -104,7 +104,7 @@ class VertexAiJobConfig:
     enable_web_access: bool = True
     # Default to suppress TensorFlow log spam
     # Like: ` E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered`
-    tf_cpp_min_log_level: Optional[int] = 3
+    tf_cpp_min_log_level: Optional[int] = 2
 
 
 class VertexAIService:

--- a/python/gigl/common/services/vertex_ai.py
+++ b/python/gigl/common/services/vertex_ai.py
@@ -102,6 +102,9 @@ class VertexAiJobConfig:
         int
     ] = None  # Will default to DEFAULT_CUSTOM_JOB_TIMEOUT_S if not provided
     enable_web_access: bool = True
+    # Default to suppress TensorFlow log spam
+    # Like: ` E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered`
+    tf_cpp_min_log_level: Optional[int] = 3
 
 
 class VertexAIService:
@@ -171,6 +174,13 @@ class VertexAIService:
                 value=leader_worker_internal_ip_file_path.uri,
             )
         ]
+        if job_config.tf_cpp_min_log_level is not None:
+            env_vars.append(
+                env_var.EnvVar(
+                    name="TF_CPP_MIN_LOG_LEVEL",
+                    value=str(job_config.tf_cpp_min_log_level),
+                )
+            )
 
         container_spec = ContainerSpec(
             image_uri=job_config.container_uri,


### PR DESCRIPTION
Following https://stackoverflow.com/questions/35911252/disable-tensorflow-debugging-information so that our logs are cleaner.

Removes the lines like: `E external/local_xla/xla/stream_executor/cuda/cuda_dnn.cc:9261] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered`

See https://console.cloud.google.com/logs/query;query=resource.labels.job_id%3D%221669427416856002560%22%20timestamp%3E%3D%222025-06-11T19:54:24.209590Z%22;cursorTimestamp=2025-06-11T19:59:48.167215317Z;duration=PT1H?inv=1&invt=Abz2_w&project=external-snap-ci-github-gigl which doesn't have the tflog span in it.