### PR TITLE
added reservation in vm script

### DIFF
--- a/scripts/create_dev_instance.py
+++ b/scripts/create_dev_instance.py
@@ -269,7 +269,11 @@ if __name__ == "__main__":
         if values.get("startup_script")
         else ""
     )
-    reservation_clause = f"        --reservation={values['reservation']}" if values.get('reservation') else ""
+    reservation_clause = (
+        f"        --reservation={values['reservation']}"
+        if values.get("reservation")
+        else ""
+    )
 
     gcloud_cmd = inspect.cleandoc(
         f"""

--- a/scripts/create_dev_instance.py
+++ b/scripts/create_dev_instance.py
@@ -61,6 +61,11 @@ class SupportedParams:
                 description="Labels for the VM instance in the form of key=value,key2=value2",
                 required=False,
             ),
+            "reservation": Param(
+                default=None,
+                description="Reservation to use for the VM instance. If not provided, the VM will be created without a reservation.",
+                required=False,
+            ),
         }
 
 
@@ -283,6 +288,7 @@ if __name__ == "__main__":
         --shielded-vtpm \
         --shielded-integrity-monitoring \
         --labels=goog-ec-src=vm_add-gcloud{ops_agent_clause}{extra_labels_clause} \
+        --reservation={values['reservation']} \
         --reservation-affinity=any
         """
     ).strip()

--- a/scripts/create_dev_instance.py
+++ b/scripts/create_dev_instance.py
@@ -269,6 +269,7 @@ if __name__ == "__main__":
         if values.get("startup_script")
         else ""
     )
+    reservation_clause = f"        --reservation={values['reservation']}" if values.get('reservation') else ""
 
     gcloud_cmd = inspect.cleandoc(
         f"""
@@ -288,8 +289,8 @@ if __name__ == "__main__":
         --shielded-vtpm \
         --shielded-integrity-monitoring \
         --labels=goog-ec-src=vm_add-gcloud{ops_agent_clause}{extra_labels_clause} \
-        --reservation={values['reservation']} \
-        --reservation-affinity=any
+        --reservation-affinity=any \
+        {reservation_clause}
         """
     ).strip()
 


### PR DESCRIPTION
**Scope of work done**

Added the reservation arg in `create_dev_instance.py` so we can pass in any reservation if needed for creating VMs.

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
