### PR TITLE
Tag E2E integration test pipelines with git branch

### DIFF
--- a/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
+++ b/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
@@ -17,7 +17,7 @@ inputs:
   timeout:
     description: "Specified as duration i.e. '2h15m5s' is two hours, fifteen minutes, and five seconds"
     default: "3h"
-  
+
 
 runs:
   using: "composite"
@@ -30,5 +30,6 @@ runs:
           --service-account="projects/${{ inputs.project }}/serviceAccounts/${{ inputs.service_account }}" \
           --project="${{ inputs.project }}" \
           --machine-type="${{ inputs.machine_type }}" \
-          --timeout="${{ inputs.timeout }}"
+          --timeout="${{ inputs.timeout }}" \
+          --set-build-env-vars="GIT_HASH=$(git rev-parse HEAD),GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)"
       shell: bash

--- a/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
+++ b/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
@@ -24,6 +24,7 @@ runs:
   steps:
     - name: Submit Cloud Build job
       run: |
+        echo "Running command: ${{ inputs.cmd }} on branch $(git rev-parse --abbrev-ref HEAD)."
         gcloud builds submit . \
           --config=.github/cloud_builder/run_command_on_active_checkout.yaml \
           --substitutions=_CMD="${{ inputs.cmd }}" \

--- a/.github/workflows/on-pr-comment.yml
+++ b/.github/workflows/on-pr-comment.yml
@@ -73,8 +73,7 @@ jobs:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
         command: |
-          echo "Running E2E tests on branch $(git rev-parse --abbrev-ref HEAD)."
-          GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" make run_all_e2e_tests
+          make run_all_e2e_tests
 
   lint-test:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/lint_test') }}

--- a/.github/workflows/on-pr-comment.yml
+++ b/.github/workflows/on-pr-comment.yml
@@ -73,7 +73,8 @@ jobs:
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
         command: |
-          make run_all_e2e_tests
+          echo "Running E2E tests on branch $(git rev-parse --abbrev-ref HEAD)."
+          GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" make run_all_e2e_tests
 
   lint-test:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/lint_test') }}

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PY_TEST_FILES?="*_test.py"
 # adding `export GIGL_TEST_DEFAULT_RESOURCE_CONFIG=your_resource_config` to your shell config (~/.bashrc, ~/.zshrc, etc.)
 GIGL_TEST_DEFAULT_RESOURCE_CONFIG?=${PWD}/deployment/configs/unittest_resource_config.yaml
 
-GIT_BRANCH:=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+GIT_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
 # If we're in a git repo, then find only the ".md" files in our repo to format, else we format everything ".".
 # We do this because some of our dependencies (Spark) include md files,


### PR DESCRIPTION
**Scope of work done**

Try to pipe in GIT_BRANCH to cloud build workers, so we can have our e2e pipelines named with the git branch.

e.g. https://console.cloud.google.com/vertex-ai/pipelines/locations/us-central1/runs/cora-glt-udl-test-on--04698?inv=1&invt=Ab0dkw&project=external-snap-ci-github-gigl will have the branch name in it.


Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

Tested that the make file changes work locally. 

I cannot test the gh action changes easily locally so let's "test on main".

If the integration tests start failing let's roll this back immediately. 

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES



