### PR TITLE
Rollback breaking change breaking e2e tests

### DIFF
--- a/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
+++ b/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
@@ -24,13 +24,11 @@ runs:
   steps:
     - name: Submit Cloud Build job
       run: |
-        echo "Running command: ${{ inputs.cmd }} on branch $(git rev-parse --abbrev-ref HEAD)."
         gcloud builds submit . \
           --config=.github/cloud_builder/run_command_on_active_checkout.yaml \
           --substitutions=_CMD="${{ inputs.cmd }}" \
           --service-account="projects/${{ inputs.project }}/serviceAccounts/${{ inputs.service_account }}" \
           --project="${{ inputs.project }}" \
           --machine-type="${{ inputs.machine_type }}" \
-          --timeout="${{ inputs.timeout }}" \
-          --set-build-env-vars="GIT_HASH=$(git rev-parse HEAD),GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)"
+          --timeout="${{ inputs.timeout }}"
       shell: bash

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PY_TEST_FILES?="*_test.py"
 # adding `export GIGL_TEST_DEFAULT_RESOURCE_CONFIG=your_resource_config` to your shell config (~/.bashrc, ~/.zshrc, etc.)
 GIGL_TEST_DEFAULT_RESOURCE_CONFIG?=${PWD}/deployment/configs/unittest_resource_config.yaml
 
-GIT_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+GIT_BRANCH:=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
 # If we're in a git repo, then find only the ".md" files in our repo to format, else we format everything ".".
 # We do this because some of our dependencies (Spark) include md files,


### PR DESCRIPTION
https://github.com/Snapchat/GiGL/pull/100 broke our e2e tests, whoops. See https://github.com/Snapchat/GiGL/actions/runs/15743367245/job/44374020081 for a test that broke. 

`--set-build-env-vars` is not a valid flag for `gcloud builds submit`.

Will send out a follow up PR where I make the change from `--substitutions=_CMD="${{ inputs.cmd }}"` to `--substitutions=_CMD="${{ GIT_HASH=$(git rev-parse HEAD) inputs.cmd }}"`