### PR TITLE
Try (again) to tag E2E pipelines with git branch

### DIFF
--- a/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
+++ b/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
@@ -26,7 +26,7 @@ runs:
       run: |
         gcloud builds submit . \
           --config=.github/cloud_builder/run_command_on_active_checkout.yaml \
-          --substitutions=_CMD="${{ inputs.cmd }}" \
+          --substitutions=_CMD="GIT_HASH=$(git rev-parse HEAD) ${{ inputs.cmd }}" \
           --service-account="projects/${{ inputs.project }}/serviceAccounts/${{ inputs.service_account }}" \
           --project="${{ inputs.project }}" \
           --machine-type="${{ inputs.machine_type }}" \

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PY_TEST_FILES?="*_test.py"
 # adding `export GIGL_TEST_DEFAULT_RESOURCE_CONFIG=your_resource_config` to your shell config (~/.bashrc, ~/.zshrc, etc.)
 GIGL_TEST_DEFAULT_RESOURCE_CONFIG?=${PWD}/deployment/configs/unittest_resource_config.yaml
 
-GIT_BRANCH:=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+GIT_BRANCH?=$(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 
 # If we're in a git repo, then find only the ".md" files in our repo to format, else we format everything ".".
 # We do this because some of our dependencies (Spark) include md files,


### PR DESCRIPTION
Again what I'd like to do is add the git branch name to our e2e test runs. For example one of our existing runs, [https://console.cloud.google.com/vertex-ai/pipelines/locations/us-central1/runs/cora-glt-udl-test-on--04698?inv=1&invt=Ab0dkw&project=external-snap-ci-github-gigl](https://console.cloud.google.com/vertex-ai/pipelines/locations/us-central1/runs/cora-glt-udl-test-on--04698?inv=1&invt=Ab0dkw&project=external-snap-ci-github-gigl) **does not** have any git branch name in it.

Adding the branch name to runs helps easily identify which runs are yours, and is generally helpful.

The last attempt to do this, https://github.com/Snapchat/GiGL/pull/100, [broke our tests](https://github.com/Snapchat/GiGL/actions/runs/15743367245/job/44374020081) as --set-build-env-vars is not a valid flag for gcloud builds submit.


Instead, I'll try to manually put the `GIT_BRANCH` into the CLI env. 

I tested locally with:

```make
echo:
	@echo "GIT_BRANCH: ${GIT_BRANCH}"
```

and: 

```
GIT_BRANCH=hello make echo
GIT_BRANCH: hello
```