### PR TITLE
Ensure node ids are always selected into the same split

### DIFF
--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -264,6 +264,16 @@ def _build_dataset_process(
         master_port=dataset_building_port,
         num_rpc_threads=16,
     )
+    # HashedNodeAnchorLinkSplitter requires rpc to be initialized, so we initialize it here.
+    should_teardown_process_group = False
+    if isinstance(splitter, HashedNodeAnchorLinkSplitter):
+        should_teardown_process_group = True
+        torch.distributed.init_process_group(
+            backend="gloo",
+            init_method=f"tcp://{distributed_context.main_worker_ip_address}:{dataset_building_port}",
+            world_size=distributed_context.global_world_size,
+            rank=distributed_context.global_rank,
+        )
 
     output_dataset: DistLinkPredictionDataset = _load_and_build_partitioned_dataset(
         serialized_graph_metadata=serialized_graph_metadata,
@@ -282,6 +292,8 @@ def _build_dataset_process(
     # machines may require rpc setup for partitioning, which will result in failure.
     barrier()
     shutdown_rpc()
+    if should_teardown_process_group:
+        torch.distributed.destroy_process_group()
 
 
 def build_dataset(

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -96,7 +96,19 @@ def _fast_hash(x: torch.Tensor) -> torch.Tensor:
         x.bitwise_xor_(x >> 15)
         x.multiply_(0x846CA68B)
         x.bitwise_xor_(x >> 16)
+        # And again for better mixing ;)
+        x.bitwise_xor_(x >> 16)
+        x.multiply_(0x7FEB352D)
+        x.bitwise_xor_(x >> 15)
+        x.multiply_(0x846CA68B)
+        x.bitwise_xor_(x >> 16)
     elif x.dtype == torch.int64:
+        x.bitwise_xor_(x >> 30)
+        x.multiply_(0xBF58476D1CE4E5B9)
+        x.bitwise_xor_(x >> 27)
+        x.multiply_(0x94D049BB133111EB)
+        x.bitwise_xor_(x >> 31)
+        # And again for better mixing ;)
         x.bitwise_xor_(x >> 30)
         x.multiply_(0xBF58476D1CE4E5B9)
         x.bitwise_xor_(x >> 27)
@@ -129,8 +141,8 @@ class HashedNodeAnchorLinkSplitter:
     def __init__(
         self,
         sampling_direction: Union[Literal["in", "out"], str],
-        num_val: Union[float, int] = 0.1,
-        num_test: Union[float, int] = 0.1,
+        num_val: float = 0.1,
+        num_test: float = 0.1,
         hash_function: Callable[[torch.Tensor], torch.Tensor] = _fast_hash,
         supervision_edge_types: Optional[list[EdgeType]] = None,
         should_convert_labels_to_edges: bool = True,
@@ -139,10 +151,8 @@ class HashedNodeAnchorLinkSplitter:
 
         Args:
             sampling_direction (Union[Literal["in", "out"], str]): The direction to sample the nodes. Either "in" or "out".
-            num_val (Union[float, int]): The percentage of nodes to use for training. Defaults to 0.1 (10%).
-                                         If an integer is provided, than exactly that number of nodes will be in the validation split.
-            num_test (Union[float, int]): The percentage of nodes to use for validation. Defaults to 0.1 (10%).
-                                          If an integer is provided, than exactly that number of nodes will be in the test split.
+            num_val (float): The percentage of nodes to use for training. Defaults to 0.1 (10%).
+            num_test (float): The percentage of nodes to use for validation. Defaults to 0.1 (10%).
             hash_function (Callable[[torch.Tensor, torch.Tensor], torch.Tensor]): The hash function to use. Defaults to `_fast_hash`.
             supervision_edge_types (Optional[list[EdgeType]]): The supervision edge types we should use for splitting.
                 Must be provided if we are splitting a heterogeneous graph. If None, uses the default message passing edge type in the graph.
@@ -293,32 +303,53 @@ class HashedNodeAnchorLinkSplitter:
             del node_id_count
             gc.collect()
 
-            hash_values = torch.argsort(self._hash_function(nodes_to_select))  # 1 x M
-            nodes_to_select = nodes_to_select[hash_values]  # 1 x M
-
-            # hash_values no longer needed, so we can clean up it's memory.
-            del hash_values
-            gc.collect()
-
-            if isinstance(self._num_val, int):
-                num_val = self._num_val
-            else:
-                num_val = int(nodes_to_select.numel() * self._num_val)
-            if isinstance(self._num_test, int):
-                num_test = self._num_test
-            else:
-                num_test = int(nodes_to_select.numel() * self._num_test)
-
-            num_train = nodes_to_select.numel() - num_val - num_test
-            if num_train <= 0:
-                raise ValueError(
-                    f"Invalid number of nodes to split. Expected more than 0. Originally had {nodes_to_select.numel()} nodes but due to having `num_test` = {self._num_test} and `num_val` = {self._num_val} got no training node.."
+            hash_values = self._hash_function(nodes_to_select)  # 1 x M
+            # Now, we want to normalize the hash values to [0, 1) range so we can select them easily into splits.
+            # We want to do this *globally* e.g. across all processes,
+            # so that we can ensure that the same nodes are selected for the same split across all processes.
+            # If we don't do this, then if we have `[0, 1, 2, 3, 4]` on one process and `[4, 5, 6, 7]` on another,
+            # wihh the identity hash `4` may end up in Test in one process and Train in another,
+            max_hash_value = hash_values.max().item()
+            min_hash_value = hash_values.min().item()
+            if torch.distributed.is_initialized():
+                all_max_and_mins = [
+                    torch.zeros(2, dtype=torch.int64)
+                    for _ in range(torch.distributed.get_world_size())
+                ]
+                torch.distributed.all_gather(
+                    all_max_and_mins,
+                    torch.tensor([max_hash_value, min_hash_value], dtype=torch.int64),
                 )
+                global_max_hash_value = max_hash_value
+                global_min_hash_value = min_hash_value
+                for max_and_min in all_max_and_mins:
+                    global_max_hash_value = max(
+                        global_max_hash_value, max_and_min[0].item()
+                    )
+                    global_min_hash_value = min(
+                        global_min_hash_value, max_and_min[1].item()
+                    )
+            else:
+                logger.warning(
+                    "Distributed process group is not initialized, will split only on local process."
+                )
+                global_max_hash_value = max_hash_value
+                global_min_hash_value = min_hash_value
+            hash_values = (
+                hash_values - global_min_hash_value
+            ) / global_max_hash_value  # Normalize the hash values to [0, 1)
 
-            train = nodes_to_select[:num_train]  # 1 x num_train_nodes
-            val = nodes_to_select[num_train : num_val + num_train]  # 1 x num_val_nodes
-            test = nodes_to_select[num_train + num_val :]  # 1 x num_test_nodes
+            # Now that we've normalized the hash values, we can select the train, val, and test nodes.
+            test_inds = hash_values >= 1 - self._num_test
+            val_inds = (hash_values >= 1 - self._num_test - self._num_val) & ~test_inds
+            train_inds = ~test_inds & ~val_inds
+            train = nodes_to_select[train_inds]  # 1 x num_train_nodes
+            val = nodes_to_select[val_inds]  # 1 x num_val_nodes
+            test = nodes_to_select[test_inds]  # 1 x num_test_nodes
             splits[anchor_node_type] = (train, val, test)
+            # We no longer need the hash values and nodes to select, so we can clean up their memory.
+            del nodes_to_select, hash_values, train_inds, val_inds, test_inds
+            gc.collect()
         if len(splits) == 0:
             raise ValueError(
                 f"Found no edge types to split from the provided edge index: {edge_index.keys()} using labeled edge types {self._labeled_edge_types}"

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -308,7 +308,7 @@ class HashedNodeAnchorLinkSplitter:
             # We want to do this *globally* e.g. across all processes,
             # so that we can ensure that the same nodes are selected for the same split across all processes.
             # If we don't do this, then if we have `[0, 1, 2, 3, 4]` on one process and `[4, 5, 6, 7]` on another,
-            # wihh the identity hash `4` may end up in Test in one process and Train in another,
+            # with the identity hash `4` may end up in Test in one rank and Train in another.
             max_hash_value = hash_values.max().item()
             min_hash_value = hash_values.min().item()
             if torch.distributed.is_initialized():
@@ -340,9 +340,9 @@ class HashedNodeAnchorLinkSplitter:
             ) / global_max_hash_value  # Normalize the hash values to [0, 1)
 
             # Now that we've normalized the hash values, we can select the train, val, and test nodes.
-            test_inds = hash_values >= 1 - self._num_test
-            val_inds = (hash_values >= 1 - self._num_test - self._num_val) & ~test_inds
-            train_inds = ~test_inds & ~val_inds
+            test_inds = hash_values >= 1 - self._num_test  # 1 x M
+            val_inds = (hash_values >= 1 - self._num_test - self._num_val) & ~test_inds  # 1 x M
+            train_inds = ~test_inds & ~val_inds  # 1 x M
             train = nodes_to_select[train_inds]  # 1 x num_train_nodes
             val = nodes_to_select[val_inds]  # 1 x num_val_nodes
             test = nodes_to_select[test_inds]  # 1 x num_test_nodes

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -125,6 +125,10 @@ def _fast_hash(x: torch.Tensor) -> torch.Tensor:
 class HashedNodeAnchorLinkSplitter:
     """Selects train, val, and test nodes based on some provided edge index.
 
+    NOTE: This splitter must be called when a Torch distributed process group is initialized.
+    e.g. `torch.distributed.init_process_group` must be called before using this splitter.
+
+
     In node-based splitting, a node may only ever live in one split. E.g. if one
     node has two label edges, *both* of those edges will be placed into the same split.
 
@@ -333,11 +337,9 @@ class HashedNodeAnchorLinkSplitter:
                         global_min_hash_value, max_and_min[1].item()
                     )
             else:
-                logger.warning(
-                    "Distributed process group is not initialized, will split only on local process."
+                raise RuntimeError(
+                    f"{type(self).__name__} requires a Torch distributed process group, but none was found. Please initialize a process group (`torch.distributed.init_process_group`) before using this splitter."
                 )
-                global_max_hash_value = max_hash_value
-                global_min_hash_value = min_hash_value
             hash_values = (
                 hash_values - global_min_hash_value
             ) / global_max_hash_value  # Normalize the hash values to [0, 1)

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -341,7 +341,9 @@ class HashedNodeAnchorLinkSplitter:
 
             # Now that we've normalized the hash values, we can select the train, val, and test nodes.
             test_inds = hash_values >= 1 - self._num_test  # 1 x M
-            val_inds = (hash_values >= 1 - self._num_test - self._num_val) & ~test_inds  # 1 x M
+            val_inds = (
+                hash_values >= 1 - self._num_test - self._num_val
+            ) & ~test_inds  # 1 x M
             train_inds = ~test_inds & ~val_inds  # 1 x M
             train = nodes_to_select[train_inds]  # 1 x num_train_nodes
             val = nodes_to_select[val_inds]  # 1 x num_val_nodes

--- a/python/tests/test_assets/distributed/utils.py
+++ b/python/tests/test_assets/distributed/utils.py
@@ -1,6 +1,8 @@
-from typing import Optional
+from typing import Callable, Optional
 
 import torch
+
+from gigl.distributed.utils import get_free_port
 
 
 def assert_tensor_equality(
@@ -37,3 +39,18 @@ def assert_tensor_equality(
 
         # Compare the sorted tensors
         torch.testing.assert_close(sorted_a, sorted_b)
+
+
+def get_process_group_init_method(
+    host: str = "localhost", port_picker: Callable[[], int] = get_free_port
+) -> str:
+    """
+    Returns the initialization method for the process group.
+    This is should be used with torch.distributed.init_process_group
+    Args:
+        host (str): The host address for the process group.
+        port_picker (Callable[[], int]): A callable that returns a free port number.
+    Returns:
+        str: The initialization method for the process group.
+    """
+    return f"tcp://{host}:{port_picker()}"

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -654,7 +654,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
 
     # TODO: (mkolodner-sc) - Figure out why this test is failing on Google Cloud Build
     @unittest.skip("Failing on Google Cloud Build - skiping for now")
-    def _test_dblp_supervised(self):
+    def test_dblp_supervised(self):
         dblp_supervised_info = get_mocked_dataset_artifact_metadata()[
             DBLP_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO.name
         ]

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -42,10 +42,7 @@ from gigl.utils.data_splitters import HashedNodeAnchorLinkSplitter
 from tests.test_assets.distributed.run_distributed_dataset import (
     run_distributed_dataset,
 )
-from tests.test_assets.distributed.utils import (
-    assert_tensor_equality,
-    get_process_group_init_method,
-)
+from tests.test_assets.distributed.utils import assert_tensor_equality
 
 _POSITIVE_EDGE_TYPE = message_passing_to_positive_label(DEFAULT_HOMOGENEOUS_EDGE_TYPE)
 _NEGATIVE_EDGE_TYPE = message_passing_to_negative_label(DEFAULT_HOMOGENEOUS_EDGE_TYPE)
@@ -381,14 +378,6 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             global_world_size=self._world_size,
         )
 
-    def tearDown(self):
-        if torch.distributed.is_initialized():
-            print("Destroying process group")
-            # Ensure the process group is destroyed after each test
-            # to avoid interference with subsequent tests
-            torch.distributed.destroy_process_group()
-        super().tearDown()
-
     def test_distributed_neighbor_loader(self):
         master_port = glt.utils.get_free_port(self._master_ip_address)
         expected_data_count = 2708
@@ -551,10 +540,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             graph_metadata_pb_wrapper=gbml_config_pb_wrapper.graph_metadata_pb_wrapper,
             tfrecord_uri_pattern=".*.tfrecord(.gz)?$",
         )
-        # HashedNodeAnchorLinkSplitter requires a process group to be initialized.
-        torch.distributed.init_process_group(
-            rank=0, world_size=1, init_method=get_process_group_init_method()
-        )
+
         splitter = HashedNodeAnchorLinkSplitter(
             sampling_direction="in", should_convert_labels_to_edges=True
         )
@@ -602,7 +588,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
 
     # TODO: (mkolodner-sc) - Figure out why this test is failing on Google Cloud Build
     @unittest.skip("Failing on Google Cloud Build - skiping for now")
-    def test_dblp_supervised(self):
+    def _test_dblp_supervised(self):
         dblp_supervised_info = get_mocked_dataset_artifact_metadata()[
             DBLP_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO.name
         ]
@@ -621,10 +607,6 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
 
         supervision_edge_types = (
             gbml_config_pb_wrapper.task_metadata_pb_wrapper.get_supervision_edge_types()
-        )
-        # HashedNodeAnchorLinkSplitter requires a process group to be initialized.
-        torch.distributed.init_process_group(
-            rank=0, world_size=1, init_method=get_process_group_init_method()
         )
 
         splitter = HashedNodeAnchorLinkSplitter(
@@ -671,10 +653,6 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
 
         supervision_edge_types = (
             gbml_config_pb_wrapper.task_metadata_pb_wrapper.get_supervision_edge_types()
-        )
-        # HashedNodeAnchorLinkSplitter requires a process group to be initialized.
-        torch.distributed.init_process_group(
-            rank=0, world_size=1, init_method=get_process_group_init_method()
         )
 
         splitter = HashedNodeAnchorLinkSplitter(

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -42,7 +42,10 @@ from gigl.utils.data_splitters import HashedNodeAnchorLinkSplitter
 from tests.test_assets.distributed.run_distributed_dataset import (
     run_distributed_dataset,
 )
-from tests.test_assets.distributed.utils import assert_tensor_equality
+from tests.test_assets.distributed.utils import (
+    assert_tensor_equality,
+    get_process_group_init_method,
+)
 
 _POSITIVE_EDGE_TYPE = message_passing_to_positive_label(DEFAULT_HOMOGENEOUS_EDGE_TYPE)
 _NEGATIVE_EDGE_TYPE = message_passing_to_negative_label(DEFAULT_HOMOGENEOUS_EDGE_TYPE)
@@ -378,6 +381,14 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             global_world_size=self._world_size,
         )
 
+    def tearDown(self):
+        if torch.distributed.is_initialized():
+            print("Destroying process group")
+            # Ensure the process group is destroyed after each test
+            # to avoid interference with subsequent tests
+            torch.distributed.destroy_process_group()
+        super().tearDown()
+
     def test_distributed_neighbor_loader(self):
         master_port = glt.utils.get_free_port(self._master_ip_address)
         expected_data_count = 2708
@@ -540,7 +551,10 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             graph_metadata_pb_wrapper=gbml_config_pb_wrapper.graph_metadata_pb_wrapper,
             tfrecord_uri_pattern=".*.tfrecord(.gz)?$",
         )
-
+        # HashedNodeAnchorLinkSplitter requires a process group to be initialized.
+        torch.distributed.init_process_group(
+            rank=0, world_size=1, init_method=get_process_group_init_method()
+        )
         splitter = HashedNodeAnchorLinkSplitter(
             sampling_direction="in", should_convert_labels_to_edges=True
         )
@@ -608,6 +622,10 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
         supervision_edge_types = (
             gbml_config_pb_wrapper.task_metadata_pb_wrapper.get_supervision_edge_types()
         )
+        # HashedNodeAnchorLinkSplitter requires a process group to be initialized.
+        torch.distributed.init_process_group(
+            rank=0, world_size=1, init_method=get_process_group_init_method()
+        )
 
         splitter = HashedNodeAnchorLinkSplitter(
             sampling_direction="in",
@@ -653,6 +671,10 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
 
         supervision_edge_types = (
             gbml_config_pb_wrapper.task_metadata_pb_wrapper.get_supervision_edge_types()
+        )
+        # HashedNodeAnchorLinkSplitter requires a process group to be initialized.
+        torch.distributed.init_process_group(
+            rank=0, world_size=1, init_method=get_process_group_init_method()
         )
 
         splitter = HashedNodeAnchorLinkSplitter(

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -552,7 +552,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             splitter=splitter,
         )
 
-        assert dataset.train_node_ids is not None
+        assert dataset.train_node_ids is not None, "Train node ids must exist."
 
         mp.spawn(
             fn=_run_cora_supervised,

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -559,7 +559,9 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             args=(
                 dataset,
                 self._context,
-                to_homogeneous(dataset.train_node_ids).numel(),
+                to_homogeneous(
+                    dataset.train_node_ids
+                ).numel(),  # Use to_homogeneous to make MyPy happy since dataset.train_node_ids is a dict.
             ),
         )
 

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -540,7 +540,6 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             graph_metadata_pb_wrapper=gbml_config_pb_wrapper.graph_metadata_pb_wrapper,
             tfrecord_uri_pattern=".*.tfrecord(.gz)?$",
         )
-        expected_data_count = 2168
 
         splitter = HashedNodeAnchorLinkSplitter(
             sampling_direction="in", should_convert_labels_to_edges=True
@@ -553,8 +552,15 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             splitter=splitter,
         )
 
+        assert dataset.train_node_ids is not None
+
         mp.spawn(
-            fn=_run_cora_supervised, args=(dataset, self._context, expected_data_count)
+            fn=_run_cora_supervised,
+            args=(
+                dataset,
+                self._context,
+                to_homogeneous(dataset.train_node_ids).numel(),
+            ),
         )
 
     def test_multiple_neighbor_loader(self):

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -475,6 +475,10 @@ class TestDataSplitters(unittest.TestCase):
             ),
         ]
         # We need to guarantee that a given node id is always selected into the same split, on every rank.
+        # _run_splitter_distributed uses the identity hash function, so we can reason about hash values easily.
+        # The way HashedNodeAnchorLinkSplitter works is that it hashes the node ids, and then splits them into train, val, test based on the hash value.
+        # The splitting is done by first normalizing the hash values to [0, 1], and then selecting the train, val, test splits based on the provided percentages.
+        # e.g. test = normalized_hash_value >= (1 - test_percentage)
         expected_splits = [
             (
                 torch.arange(16, dtype=torch.int64),

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -563,6 +563,20 @@ class TestDataSplitters(unittest.TestCase):
         with self.assertRaises(ValueError):
             _check_edge_index(edges)
 
+    def test_hashed_node_anchor_link_splitter_requires_process_group(self):
+        edges = torch.stack(
+            [
+                torch.arange(0, 40, 2, dtype=torch.int64),
+                torch.zeros(20, dtype=torch.int64),
+            ]
+        )
+        splitter = HashedNodeAnchorLinkSplitter(
+            sampling_direction="out",
+            should_convert_labels_to_edges=False,
+        )
+        with self.assertRaises(RuntimeError):
+            splitter(edges)
+
     def test_get_labels_for_anchor_nodes(self):
         edges = torch.tensor(
             [


### PR DESCRIPTION
Changes:
* update _fast_hash to run again to improve mixing - without this our N=20 node ids had splits like [18], [0], [2]
* enforce `val_num` and `test_num` as floats - since we can't guarantee counts easily anymore.
* Update splitting logic to ensure nodes are always selected into the same split [discussed more below].
* Added a (basic) test for the "distributed" case.
* Removed some tests that relied on integer counts.

The issue with our previous splitting logic, is that even though a given node id would always have the same hash on different machines, since we sorted the hashed, it's "position" may be different and so it may be selected into different splits.

For instance, let's assume the hash function is the identity, and `rank_0_nodes: [0, 1, 2, 3] rank_1_nodes: [3, 4, 5, 6]`

On rank 0, `3` would be selected into Test, as its hash value is the greatest sorted, while it would be in train on rank 1.

Now what we do is fine the globally largest/smallest hash and then normalize the hash values per machine.

We then select the nodes based on the normalized values, since the hashes are consistent, and they get normalized the same, the same node id will be selected into the same split always now.

