### PR TITLE
Ensure returned splits are on the input device

### DIFF
--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -282,7 +282,12 @@ class HashedNodeAnchorLinkSplitter:
         splits: dict[NodeType, Tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = {}
         for anchor_node_type, collected_anchor_nodes in node_ids_by_node_type.items():
             max_node_id = max_node_id_by_type[anchor_node_type]
-            node_id_count = torch.zeros(max_node_id, dtype=torch.uint8)
+            # Set device explicitly here so we don't default to CPU.
+            # TODO(kmonte): We should add tests for this - but we need to enable accelerators on our CI/CD first.
+            # Also, maybe swap setting device until later?
+            node_id_count = torch.zeros(
+                max_node_id, dtype=torch.uint8, device=anchor_nodes.device
+            )
             for anchor_nodes in collected_anchor_nodes:
                 node_id_count.add_(torch.bincount(anchor_nodes, minlength=max_node_id))
             # This line takes us from a count of all node ids, e.g. `[0, 2, 0, 1]`


### PR DESCRIPTION
Without this change, the returned splits would be on CPU, which caused our unit tests to fail (see below) when run on a machine with GPU as we will default to using GPU when available.

```
======================================================================
ERROR: test_ablp_dataloader_1_Positive_edges (distributed.distributed_neighborloader_test.DistributedNeighborLoaderTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/conda/envs/.../lib/python3.9/site-packages/parameterized/parameterized.py", line 620, in standalone_func
    return func(*(a + p.args), **p.kwargs, **kw)
  File "/GiGL/python/tests/unit/distributed/distributed_neighborloader_test.py", line 514, in test_ablp_dataloader
    mp.spawn(
  File "/opt/conda/envs/.../lib/python3.9/site-packages/torch/multiprocessing/spawn.py", line 328, in spawn
    return start_processes(fn, args, nprocs, join, daemon, start_method="spawn")
  File "/opt/conda/envs/.../lib/python3.9/site-packages/torch/multiprocessing/spawn.py", line 284, in start_processes
    while not context.join():
  File "/opt/conda/envs/.../lib/python3.9/site-packages/torch/multiprocessing/spawn.py", line 203, in join
    raise ProcessRaisedException(msg, error_index, failed_process.pid)
torch.multiprocessing.spawn.ProcessRaisedException: 

-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "/opt/conda/envs/.../lib/python3.9/site-packages/torch/multiprocessing/spawn.py", line 90, in _wrap
    fn(i, *args)
  File "/GiGL/python/tests/unit/distributed/distributed_neighborloader_test.py", line 138, in _run_distributed_ablp_neighbor_loader
    assert_tensor_equality(
  File "/GiGL/python/tests/test_assets/distributed/utils.py", line 39, in assert_tensor_equality
    torch.testing.assert_close(sorted_a, sorted_b)
  File "/opt/conda/envs/.../lib/python3.9/site-packages/torch/testing/_comparison.py", line 1530, in assert_close
    raise error_metas[0].to_error(msg)
AssertionError: The values for attribute 'device' do not match: cuda:0 != cpu.
```
**Scope of work done**
* Set device on splits to be the same as input device.

Did you add automated tests or write a test plan?

I tested this locally and it works, both resolving the above test failures, and also when I explicitely set the expected devices in data_splitters_tests.

However, since we don't have any machines with accelerators for CI/CD we can't add unit tests for this, saddly.

If you want to test this locally, modify one of the [test cases](https://github.com/Snapchat/GiGL/blob/3ca9db9543f20b814403b150d298f37141c162af/python/tests/unit/utils/data_splitters_test.py#L63-L80) with edges and expected to use `torch.device(cuda:0)` or equivalent.