### PR TITLE
Patch SerializedGraphMetadata Translator

### DIFF
--- a/python/gigl/common/data/load_torch_tensors.py
+++ b/python/gigl/common/data/load_torch_tensors.py
@@ -46,11 +46,13 @@ class SerializedGraphMetadata:
     edge_entity_info: Union[
         SerializedTFRecordInfo, Dict[EdgeType, SerializedTFRecordInfo]
     ]
-    # Positive Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases. If data has no positive labels across all edge types, this value is None
+    # Positive Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases.
+    # If there are no positive labels for any edge type, this value is None
     positive_label_entity_info: Optional[
         Union[SerializedTFRecordInfo, Dict[EdgeType, SerializedTFRecordInfo]]
     ] = None
-    # Negative Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases. If input has no negative labels across all edge types, this value is None.
+    # Negative Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases.
+    # If there are no negative labels for any edge type, this value is None.
     negative_label_entity_info: Optional[
         Union[SerializedTFRecordInfo, Dict[EdgeType, SerializedTFRecordInfo]]
     ] = None

--- a/python/gigl/common/data/load_torch_tensors.py
+++ b/python/gigl/common/data/load_torch_tensors.py
@@ -46,15 +46,13 @@ class SerializedGraphMetadata:
     edge_entity_info: Union[
         SerializedTFRecordInfo, Dict[EdgeType, SerializedTFRecordInfo]
     ]
-    # Positive Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases. May be None
-    # for specific edge types. If data has no positive labels across all edge types, this value is None
+    # Positive Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases. If data has no positive labels across all edge types, this value is None
     positive_label_entity_info: Optional[
-        Union[SerializedTFRecordInfo, Dict[EdgeType, Optional[SerializedTFRecordInfo]]]
+        Union[SerializedTFRecordInfo, Dict[EdgeType, SerializedTFRecordInfo]]
     ] = None
-    # Negative Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases. May be None
-    # for specific edge types. If input has no negative labels across all edge types, this value is None.
+    # Negative Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases. If input has no negative labels across all edge types, this value is None.
     negative_label_entity_info: Optional[
-        Union[SerializedTFRecordInfo, Dict[EdgeType, Optional[SerializedTFRecordInfo]]]
+        Union[SerializedTFRecordInfo, Dict[EdgeType, SerializedTFRecordInfo]]
     ] = None
 
 

--- a/python/gigl/distributed/dist_partitioner.py
+++ b/python/gigl/distributed/dist_partitioner.py
@@ -1269,6 +1269,7 @@ class DistPartitioner:
         """
         Partitions positive or negative labels of a graph. If heterogeneous, partitions labels for all edge type.
         Must call `partition_node` first to get the node partition book as input.
+        Note that labels are always partitioned by the source node, since the edges are always assumed to be anchor_node -> to -> supervision node.
         Args:
             node_partition_book (Union[PartitionBook, Dict[NodeType, PartitionBook]]): The computed Node Partition Book
             is_positive (bool): Whether positive labels are currently being registered. If False, negative labels will be partitioned.

--- a/python/gigl/distributed/dist_partitioner.py
+++ b/python/gigl/distributed/dist_partitioner.py
@@ -989,6 +989,10 @@ class DistPartitioner:
         Returns:
             torch.Tensor: Edge index tensor of positive or negative labels, depending on is_positive flag
         """
+        if edge_type.src_node_type not in node_partition_book:
+            raise ValueError(
+                f"Edge type {edge_type} source node type {edge_type.src_node_type} not found in the node partition book node keys: {node_partition_book.keys()}"
+            )
 
         target_node_partition_book = node_partition_book[edge_type.src_node_type]
         if is_positive:
@@ -1279,12 +1283,6 @@ class DistPartitioner:
                 self._positive_label_edge_index is not None
             ), "Must register positive labels prior to partitioning them"
 
-            self._assert_data_type_consistency(
-                input_entity=self._positive_label_edge_index,
-                is_node_entity=False,
-                is_subset=True,
-            )
-
             edge_label_types = sorted(self._positive_label_edge_index.keys())
 
             logger.info("Partitioning Positive Labels ...")
@@ -1293,12 +1291,6 @@ class DistPartitioner:
             assert (
                 self._negative_label_edge_index is not None
             ), "Must register negative labels partitioning them"
-
-            self._assert_data_type_consistency(
-                input_entity=self._negative_label_edge_index,
-                is_node_entity=False,
-                is_subset=True,
-            )
 
             edge_label_types = sorted(self._negative_label_edge_index.keys())
 

--- a/python/gigl/distributed/utils/serialized_graph_metadata_translator.py
+++ b/python/gigl/distributed/utils/serialized_graph_metadata_translator.py
@@ -121,9 +121,9 @@ def convert_pb_to_serialized_graph_metadata(
             tfrecord_uri_pattern=tfrecord_uri_pattern,
         )
 
-        if preprocessed_metadata_pb_wrapper.has_pos_edge_features(
-            condensed_edge_type=condensed_edge_type
-        ):
+        if preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
+            condensed_edge_type
+        ].HasField("positive_edge_info"):
             pos_edge_feature_spec_dict = preprocessed_metadata_pb_wrapper.condensed_edge_type_to_pos_edge_feature_schema_map[
                 condensed_edge_type
             ].feature_spec
@@ -139,9 +139,9 @@ def convert_pb_to_serialized_graph_metadata(
         else:
             positive_label_entity_info[edge_type] = None
 
-        if preprocessed_metadata_pb_wrapper.has_hard_neg_edge_features(
-            condensed_edge_type=condensed_edge_type
-        ):
+        if preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
+            condensed_edge_type
+        ].HasField("negative_edge_info"):
             hard_neg_edge_feature_spec_dict = preprocessed_metadata_pb_wrapper.condensed_edge_type_to_hard_neg_edge_feature_schema_map[
                 condensed_edge_type
             ].feature_spec

--- a/python/gigl/distributed/utils/serialized_graph_metadata_translator.py
+++ b/python/gigl/distributed/utils/serialized_graph_metadata_translator.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple, Union
+from typing import Dict, Tuple, Union
 
 from gigl.common import UriFactory
 from gigl.common.data.dataloaders import SerializedTFRecordInfo
@@ -62,8 +62,8 @@ def convert_pb_to_serialized_graph_metadata(
 
     node_entity_info: Dict[NodeType, SerializedTFRecordInfo] = {}
     edge_entity_info: Dict[EdgeType, SerializedTFRecordInfo] = {}
-    positive_label_entity_info: Dict[EdgeType, Optional[SerializedTFRecordInfo]] = {}
-    negative_label_entity_info: Dict[EdgeType, Optional[SerializedTFRecordInfo]] = {}
+    positive_label_entity_info: Dict[EdgeType, SerializedTFRecordInfo] = {}
+    negative_label_entity_info: Dict[EdgeType, SerializedTFRecordInfo] = {}
 
     preprocessed_metadata_pb = preprocessed_metadata_pb_wrapper.preprocessed_metadata_pb
 
@@ -97,23 +97,10 @@ def convert_pb_to_serialized_graph_metadata(
             graph_metadata_pb_wrapper.edge_type_to_condensed_edge_type_map[edge_type]
         )
 
-        if not preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
-            condensed_edge_type
-        ].HasField("main_edge_info"):
-            raise ValueError(
-                f"Missing required mainEdgeInfo field for edge type {edge_type}"
-            )
-
         edge_metadata = (
             preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
                 condensed_edge_type
             ]
-        )
-
-        edge_feature_spec_dict = (
-            preprocessed_metadata_pb_wrapper.condensed_edge_type_to_feature_schema_map[
-                condensed_edge_type
-            ].feature_spec
         )
 
         edge_key = (
@@ -121,16 +108,18 @@ def convert_pb_to_serialized_graph_metadata(
             edge_metadata.dst_node_id_key,
         )
 
-        edge_entity_info[edge_type] = _build_serialized_tfrecord_entity_info(
-            preprocessed_metadata=edge_metadata.main_edge_info,
-            feature_spec_dict=edge_feature_spec_dict,
-            entity_key=edge_key,
-            tfrecord_uri_pattern=tfrecord_uri_pattern,
-        )
+        if edge_metadata.HasField("main_edge_info"):
+            edge_feature_spec_dict = preprocessed_metadata_pb_wrapper.condensed_edge_type_to_feature_schema_map[
+                condensed_edge_type
+            ].feature_spec
+            edge_entity_info[edge_type] = _build_serialized_tfrecord_entity_info(
+                preprocessed_metadata=edge_metadata.main_edge_info,
+                feature_spec_dict=edge_feature_spec_dict,
+                entity_key=edge_key,
+                tfrecord_uri_pattern=tfrecord_uri_pattern,
+            )
 
-        if preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
-            condensed_edge_type
-        ].HasField("positive_edge_info"):
+        if edge_metadata.HasField("positive_edge_info"):
             pos_edge_feature_spec_dict = preprocessed_metadata_pb_wrapper.condensed_edge_type_to_pos_edge_feature_schema_map[
                 condensed_edge_type
             ].feature_spec
@@ -143,12 +132,8 @@ def convert_pb_to_serialized_graph_metadata(
                 entity_key=edge_key,
                 tfrecord_uri_pattern=tfrecord_uri_pattern,
             )
-        else:
-            positive_label_entity_info[edge_type] = None
 
-        if preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
-            condensed_edge_type
-        ].HasField("negative_edge_info"):
+        if edge_metadata.HasField("negative_edge_info"):
             hard_neg_edge_feature_spec_dict = preprocessed_metadata_pb_wrapper.condensed_edge_type_to_hard_neg_edge_feature_schema_map[
                 condensed_edge_type
             ].feature_spec
@@ -161,31 +146,27 @@ def convert_pb_to_serialized_graph_metadata(
                 entity_key=edge_key,
                 tfrecord_uri_pattern=tfrecord_uri_pattern,
             )
-        else:
-            negative_label_entity_info[edge_type] = None
 
     if not graph_metadata_pb_wrapper.is_heterogeneous:
         # If our input is homogeneous, we remove the node/edge type component of the metadata fields.
         return SerializedGraphMetadata(
             node_entity_info=to_homogeneous(node_entity_info),
             edge_entity_info=to_homogeneous(edge_entity_info),
-            positive_label_entity_info=to_homogeneous(positive_label_entity_info),
-            negative_label_entity_info=to_homogeneous(negative_label_entity_info),
+            positive_label_entity_info=to_homogeneous(positive_label_entity_info)
+            if len(positive_label_entity_info) > 0
+            else None,
+            negative_label_entity_info=to_homogeneous(negative_label_entity_info)
+            if len(negative_label_entity_info) > 0
+            else None,
         )
     else:
         return SerializedGraphMetadata(
             node_entity_info=node_entity_info,
             edge_entity_info=edge_entity_info,
             positive_label_entity_info=positive_label_entity_info
-            if not all(
-                entity_info is None
-                for entity_info in positive_label_entity_info.values()
-            )
+            if len(positive_label_entity_info) > 0
             else None,
             negative_label_entity_info=negative_label_entity_info
-            if not all(
-                entity_info is None
-                for entity_info in negative_label_entity_info.values()
-            )
+            if len(negative_label_entity_info) > 0
             else None,
         )

--- a/python/gigl/distributed/utils/serialized_graph_metadata_translator.py
+++ b/python/gigl/distributed/utils/serialized_graph_metadata_translator.py
@@ -97,6 +97,13 @@ def convert_pb_to_serialized_graph_metadata(
             graph_metadata_pb_wrapper.edge_type_to_condensed_edge_type_map[edge_type]
         )
 
+        if not preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
+            condensed_edge_type
+        ].HasField("main_edge_info"):
+            raise ValueError(
+                f"Missing required mainEdgeInfo field for edge type {edge_type}"
+            )
+
         edge_metadata = (
             preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
                 condensed_edge_type

--- a/python/tests/unit/distributed/dataset_input_metadata_translator_test.py
+++ b/python/tests/unit/distributed/dataset_input_metadata_translator_test.py
@@ -35,8 +35,8 @@ class TranslatorTestCase(unittest.TestCase):
                 SerializedTFRecordInfo,
                 Dict[NodeType, SerializedTFRecordInfo],
                 Dict[EdgeType, SerializedTFRecordInfo],
-                Dict[NodeType, Optional[SerializedTFRecordInfo]],
-                Dict[EdgeType, Optional[SerializedTFRecordInfo]],
+                Dict[NodeType, SerializedTFRecordInfo],
+                Dict[EdgeType, SerializedTFRecordInfo],
             ]
         ],
         is_heterogeneous: bool,
@@ -50,8 +50,8 @@ class TranslatorTestCase(unittest.TestCase):
                     SerializedTFRecordInfo,
                     Dict[NodeType, SerializedTFRecordInfo],
                     Dict[EdgeType, SerializedTFRecordInfo],
-                    Dict[NodeType, Optional[SerializedTFRecordInfo]],
-                    Dict[EdgeType, Optional[SerializedTFRecordInfo]],
+                    Dict[NodeType, SerializedTFRecordInfo],
+                    Dict[EdgeType, SerializedTFRecordInfo],
                 ]
             ]: Entity information of which type correctness is being checked for. If heterogeneous, this is expected to be a dictionary.
             is_heterogeneous (bool): Whether the provided input data is heterogeneous or homogeneous
@@ -230,8 +230,10 @@ class TranslatorTestCase(unittest.TestCase):
 
         has_positive_labels = all(
             [
-                preprocessed_metadata_pb_wrapper.has_pos_edge_features(
-                    condensed_edge_type=condensed_edge_type
+                preprocessed_metadata_pb_wrapper.preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
+                    condensed_edge_type
+                ].HasField(
+                    "positive_edge_info"
                 )
                 for condensed_edge_type in graph_metadata_pb_wrapper.condensed_edge_types
             ]
@@ -242,16 +244,17 @@ class TranslatorTestCase(unittest.TestCase):
                 is_heterogeneous=graph_metadata_pb_wrapper.is_heterogeneous,
                 expected_entity_types=graph_metadata_pb_wrapper.edge_types,
             )
-            serialized_positive_label_info_iterable: list[
-                Optional[SerializedTFRecordInfo]
-            ]
+            serialized_positive_label_info_iterable: list[SerializedTFRecordInfo]
             if isinstance(
                 serialized_graph_metadata.positive_label_entity_info, abc.Mapping
             ):
                 serialized_positive_label_info_iterable = list(
                     serialized_graph_metadata.positive_label_entity_info.values()
                 )
-            else:
+            elif isinstance(
+                serialized_graph_metadata.positive_label_entity_info,
+                SerializedTFRecordInfo,
+            ):
                 serialized_positive_label_info_iterable = [
                     serialized_graph_metadata.positive_label_entity_info
                 ]
@@ -265,8 +268,10 @@ class TranslatorTestCase(unittest.TestCase):
                 graph_metadata_pb_wrapper.edge_types,
                 serialized_positive_label_info_iterable,
             ):
-                if preprocessed_metadata_pb_wrapper.has_pos_edge_features(
-                    condensed_edge_type=condensed_edge_type
+                if preprocessed_metadata_pb_wrapper.preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
+                    condensed_edge_type
+                ].HasField(
+                    "positive_edge_info"
                 ):
                     assert (
                         seralized_positive_label_info is not None
@@ -315,8 +320,10 @@ class TranslatorTestCase(unittest.TestCase):
 
         has_negative_labels = all(
             [
-                preprocessed_metadata_pb_wrapper.has_hard_neg_edge_features(
-                    condensed_edge_type=condensed_edge_type
+                preprocessed_metadata_pb_wrapper.preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
+                    condensed_edge_type
+                ].HasField(
+                    "negative_edge_info"
                 )
                 for condensed_edge_type in graph_metadata_pb_wrapper.condensed_edge_types
             ]
@@ -327,16 +334,17 @@ class TranslatorTestCase(unittest.TestCase):
                 is_heterogeneous=graph_metadata_pb_wrapper.is_heterogeneous,
                 expected_entity_types=graph_metadata_pb_wrapper.edge_types,
             )
-            serialized_negative_label_info_iterable: list[
-                Optional[SerializedTFRecordInfo]
-            ]
+            serialized_negative_label_info_iterable: list[SerializedTFRecordInfo]
             if isinstance(
                 serialized_graph_metadata.negative_label_entity_info, abc.Mapping
             ):
                 serialized_negative_label_info_iterable = list(
                     serialized_graph_metadata.negative_label_entity_info.values()
                 )
-            else:
+            elif isinstance(
+                serialized_graph_metadata.negative_label_entity_info,
+                SerializedTFRecordInfo,
+            ):
                 serialized_negative_label_info_iterable = [
                     serialized_graph_metadata.negative_label_entity_info
                 ]
@@ -350,8 +358,10 @@ class TranslatorTestCase(unittest.TestCase):
                 graph_metadata_pb_wrapper.edge_types,
                 serialized_negative_label_info_iterable,
             ):
-                if preprocessed_metadata_pb_wrapper.has_hard_neg_edge_features(
-                    condensed_edge_type=condensed_edge_type
+                if preprocessed_metadata_pb_wrapper.preprocessed_metadata_pb.condensed_edge_type_to_preprocessed_metadata[
+                    condensed_edge_type
+                ].HasField(
+                    "negative_edge_info"
                 ):
                     assert (
                         serialized_negative_label_info is not None

--- a/python/tests/unit/distributed/dataset_input_metadata_translator_test.py
+++ b/python/tests/unit/distributed/dataset_input_metadata_translator_test.py
@@ -258,6 +258,10 @@ class TranslatorTestCase(unittest.TestCase):
                 serialized_positive_label_info_iterable = [
                     serialized_graph_metadata.positive_label_entity_info
                 ]
+            else:
+                raise ValueError(
+                    f"Expected positive labels to be a dictionary or of type `SerializedTFRecordInfo`, got {type(serialized_graph_metadata.positive_label_entity_info)}"
+                )
 
             self.assertEqual(
                 len(graph_metadata_pb_wrapper.edge_types),
@@ -348,6 +352,10 @@ class TranslatorTestCase(unittest.TestCase):
                 serialized_negative_label_info_iterable = [
                     serialized_graph_metadata.negative_label_entity_info
                 ]
+            else:
+                raise ValueError(
+                    f"Expected negative labels to be a dictionary or of type `SerializedTFRecordInfo`, got {type(serialized_graph_metadata.negative_label_entity_info)}"
+                )
 
             self.assertEqual(
                 len(graph_metadata_pb_wrapper.edge_types),

--- a/python/tests/unit/distributed/distributed_dataset_test.py
+++ b/python/tests/unit/distributed/distributed_dataset_test.py
@@ -8,15 +8,30 @@ from parameterized import param, parameterized
 from torch.multiprocessing import Manager
 from torch.testing import assert_close
 
+from gigl.common.data.load_torch_tensors import (
+    SerializedGraphMetadata,
+    SerializedTFRecordInfo,
+)
 from gigl.distributed import (
     DistLinkPredictionDataset,
     DistPartitioner,
     DistRangePartitioner,
+    DistributedContext,
+    build_dataset,
 )
-from gigl.src.common.types.graph_data import EdgeType, NodeType
+from gigl.distributed.utils.serialized_graph_metadata_translator import (
+    convert_pb_to_serialized_graph_metadata,
+)
+from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
+from gigl.src.common.types.pb_wrappers.gbml_config import GbmlConfigPbWrapper
+from gigl.src.mocking.lib.versioning import (
+    MockedDatasetArtifactMetadata,
+    get_mocked_dataset_artifact_metadata,
+)
 from gigl.src.mocking.mocking_assets.mocked_datasets_for_pipeline_tests import (
     HETEROGENEOUS_TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
     TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
+    TOY_GRAPH_USER_DEFINED_NODE_ANCHOR_MOCKED_DATASET_INFO,
 )
 from gigl.types.graph import DEFAULT_HOMOGENEOUS_EDGE_TYPE
 from tests.test_assets.distributed.run_distributed_dataset import (
@@ -400,6 +415,87 @@ class DistributedDatasetTestCase(unittest.TestCase):
         self.assert_tensor_equal(dataset.test_node_ids, expected_test_node_ids)
         # Check that the node ids have *all* node ids, including nodes not included in train, val, and test.
         self.assert_tensor_equal(dataset.node_ids, expected_node_ids)
+
+    # This tests that if we build a dataset with a supervision edge type which is not a message passing edge type, we still correctly load the supervision edge
+    def test_build_dataset_with_unique_supervision_edge_type(self):
+        master_port = glt.utils.get_free_port(self._master_ip_address)
+        mocked_dataset_artifact_metadata: MockedDatasetArtifactMetadata = (
+            get_mocked_dataset_artifact_metadata()[
+                TOY_GRAPH_USER_DEFINED_NODE_ANCHOR_MOCKED_DATASET_INFO.name
+            ]
+        )
+        gbml_config_pb_wrapper = (
+            GbmlConfigPbWrapper.get_gbml_config_pb_wrapper_from_uri(
+                gbml_config_uri=mocked_dataset_artifact_metadata.frozen_gbml_config_uri
+            )
+        )
+
+        preprocessed_metadata_pb_wrapper = (
+            gbml_config_pb_wrapper.preprocessed_metadata_pb_wrapper
+        )
+        graph_metadata_pb_wrapper = gbml_config_pb_wrapper.graph_metadata_pb_wrapper
+
+        serialized_graph_metadata = convert_pb_to_serialized_graph_metadata(
+            preprocessed_metadata_pb_wrapper=preprocessed_metadata_pb_wrapper,
+            graph_metadata_pb_wrapper=graph_metadata_pb_wrapper,
+            tfrecord_uri_pattern=".*\.tfrecord(\.gz)?$",
+        )
+
+        # We augment the serialized graph metadata to make the supervision edge type different than the message passing edge type
+        assert isinstance(
+            serialized_graph_metadata.node_entity_info, SerializedTFRecordInfo
+        )
+        assert isinstance(
+            serialized_graph_metadata.edge_entity_info, SerializedTFRecordInfo
+        )
+        assert isinstance(
+            serialized_graph_metadata.positive_label_entity_info,
+            SerializedTFRecordInfo,
+        )
+        assert isinstance(
+            serialized_graph_metadata.negative_label_entity_info,
+            SerializedTFRecordInfo,
+        )
+
+        node_type = NodeType("user")
+        message_passing_edge_type = EdgeType(node_type, Relation("to"), node_type)
+        labeled_edge_type = EdgeType(node_type, Relation("labeled"), node_type)
+
+        augmented_serialized_graph_metadata = SerializedGraphMetadata(
+            node_entity_info={node_type: serialized_graph_metadata.node_entity_info},
+            edge_entity_info={
+                message_passing_edge_type: serialized_graph_metadata.edge_entity_info
+            },
+            positive_label_entity_info={
+                labeled_edge_type: serialized_graph_metadata.positive_label_entity_info
+            },
+            negative_label_entity_info={
+                labeled_edge_type: serialized_graph_metadata.negative_label_entity_info
+            },
+        )
+
+        distributed_context = DistributedContext(
+            main_worker_ip_address="localhost",
+            global_rank=0,
+            global_world_size=1,
+        )
+
+        dataset = build_dataset(
+            serialized_graph_metadata=augmented_serialized_graph_metadata,
+            distributed_context=distributed_context,
+            sample_edge_direction="in",
+            should_load_tensors_in_parallel=True,
+            _dataset_building_port=master_port,
+        )
+
+        self.assertTrue(
+            isinstance(dataset.positive_edge_label, abc.Mapping)
+            and labeled_edge_type in dataset.positive_edge_label
+        )
+        self.assertTrue(
+            isinstance(dataset.negative_edge_label, abc.Mapping)
+            and labeled_edge_type in dataset.negative_edge_label
+        )
 
 
 if __name__ == "__main__":

--- a/python/tests/unit/distributed/distributed_dataset_test.py
+++ b/python/tests/unit/distributed/distributed_dataset_test.py
@@ -488,14 +488,15 @@ class DistributedDatasetTestCase(unittest.TestCase):
             _dataset_building_port=master_port,
         )
 
-        self.assertTrue(
-            isinstance(dataset.positive_edge_label, abc.Mapping)
-            and labeled_edge_type in dataset.positive_edge_label
-        )
-        self.assertTrue(
-            isinstance(dataset.negative_edge_label, abc.Mapping)
-            and labeled_edge_type in dataset.negative_edge_label
-        )
+        assert isinstance(
+            dataset.positive_edge_label, abc.Mapping
+        ), f"Positive edge indices must be a dictionary, got {type(dataset.positive_edge_label)}"
+        self.assertTrue(labeled_edge_type in dataset.positive_edge_label)
+
+        assert isinstance(
+            dataset.negative_edge_label, abc.Mapping
+        ), f"Negative edge indices must be a dictionary, got {type(dataset.negative_edge_label)}"
+        self.assertTrue(labeled_edge_type in dataset.negative_edge_label)
 
 
 if __name__ == "__main__":

--- a/python/tests/unit/distributed/distributed_dataset_test.py
+++ b/python/tests/unit/distributed/distributed_dataset_test.py
@@ -492,11 +492,17 @@ class DistributedDatasetTestCase(unittest.TestCase):
             dataset.positive_edge_label, abc.Mapping
         ), f"Positive edge indices must be a dictionary, got {type(dataset.positive_edge_label)}"
         self.assertTrue(labeled_edge_type in dataset.positive_edge_label)
+        self.assertTrue(message_passing_edge_type not in dataset.positive_edge_label)
 
         assert isinstance(
             dataset.negative_edge_label, abc.Mapping
         ), f"Negative edge indices must be a dictionary, got {type(dataset.negative_edge_label)}"
         self.assertTrue(labeled_edge_type in dataset.negative_edge_label)
+        self.assertTrue(message_passing_edge_type not in dataset.negative_edge_label)
+
+        assert isinstance(dataset.edge_pb, abc.Mapping)
+        self.assertTrue(labeled_edge_type not in dataset.edge_pb)
+        self.assertTrue(message_passing_edge_type in dataset.edge_pb)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
PR which patches two items with the translator
- Fix a bug where we weren't loading positive labels if the label's `feature_dim` is set to 0
- Modify code so that an edge type exists which doesn't have a `mainEdgeInfo` field and only a `positiveEdgeInfo`, we still are able to load, partition, and register that label to the dataset
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
