### PR TITLE
Refactor homogeneous to not use dist context + leverage automatic infering ports

### DIFF
--- a/examples/distributed/homogeneous_inference.py
+++ b/examples/distributed/homogeneous_inference.py
@@ -395,8 +395,9 @@ def _run_example_inference(
     inference_batch_size = gbml_config_pb_wrapper.inferencer_config.inference_batch_size
 
     local_world_size: int
-    if inferencer_args.get("local_world_size") is not None:
-        local_world_size = int(inferencer_args.get("local_world_size"))
+    arg_local_world_size = inferencer_args.get("local_world_size")
+    if arg_local_world_size is not None:
+        local_world_size = int(arg_local_world_size)
         logger.info(f"Using local_world_size from inferencer_args: {local_world_size}")
         if torch.cuda.is_available() and local_world_size != torch.cuda.device_count():
             logger.warning(


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

Leverages https://github.com/Snapchat/GiGL/pull/96 and https://github.com/Snapchat/GiGL/pull/98; reducing the need to call `connect_worker_pool` and passing around a `distributed_context` object. This also moves the logic of this inferencer to automatically infer ports, ip address from master node, et al using process groups that now the inferencer initializes.

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

Homogeneous inference is used by our e2e `cora_glt_udl_test`; similarly backwards compatibility is tested by `dblp_glt_test` which uses heterogeneous inference and has not been updated. Thus running e2e integration tests below.

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
