### PR TITLE
Add Port as parameter to `build_dataset`

### DIFF
--- a/examples/distributed/heterogeneous_inference.py
+++ b/examples/distributed/heterogeneous_inference.py
@@ -343,7 +343,9 @@ def _run_example_inference(
 
     # We call a GiGL function to launch a process for loading TFRecords into memory, partitioning the graph across multiple machines,
     # and registering that information to a DistLinkPredictionDataset class.
-    dataset = build_dataset_from_task_config_uri(task_config_uri=task_config_uri)
+    dataset = build_dataset_from_task_config_uri(
+        task_config_uri=task_config_uri, distributed_context=distributed_context
+    )
 
     # Read from GbmlConfig for preprocessed data metadata, GNN model uri, and bigquery embedding table path, and additional inference args
     gbml_config_pb_wrapper = GbmlConfigPbWrapper.get_gbml_config_pb_wrapper_from_uri(

--- a/examples/distributed/heterogeneous_inference.py
+++ b/examples/distributed/heterogeneous_inference.py
@@ -343,9 +343,7 @@ def _run_example_inference(
 
     # We call a GiGL function to launch a process for loading TFRecords into memory, partitioning the graph across multiple machines,
     # and registering that information to a DistLinkPredictionDataset class.
-    dataset = build_dataset_from_task_config_uri(
-        task_config_uri=task_config_uri, distributed_context=distributed_context
-    )
+    dataset = build_dataset_from_task_config_uri(task_config_uri=task_config_uri)
 
     # Read from GbmlConfig for preprocessed data metadata, GNN model uri, and bigquery embedding table path, and additional inference args
     gbml_config_pb_wrapper = GbmlConfigPbWrapper.get_gbml_config_pb_wrapper_from_uri(

--- a/python/tests/unit/distributed/distributed_dataset_test.py
+++ b/python/tests/unit/distributed/distributed_dataset_test.py
@@ -488,7 +488,7 @@ class DistributedDatasetTestCase(unittest.TestCase):
 
     # This tests that we can build a dataset when manually specifying a port.
     # TODO (mkolodner-sc): Remove this test once we deprecate the `port` field
-    def test_build_dataset_with_maunual_port(self):
+    def test_build_dataset_with_manual_port(self):
         mocked_dataset_artifact_metadata: MockedDatasetArtifactMetadata = (
             get_mocked_dataset_artifact_metadata()[
                 TOY_GRAPH_USER_DEFINED_NODE_ANCHOR_MOCKED_DATASET_INFO.name

--- a/python/tests/unit/distributed/distributed_dataset_test.py
+++ b/python/tests/unit/distributed/distributed_dataset_test.py
@@ -486,6 +486,47 @@ class DistributedDatasetTestCase(unittest.TestCase):
         self.assertTrue(labeled_edge_type not in dataset.edge_pb)
         self.assertTrue(message_passing_edge_type in dataset.edge_pb)
 
+    # This tests that we can build a dataset when manually specifying a port.
+    # TODO (mkolodner-sc): Remove this test once we deprecate the `port` field
+    def test_build_dataset_with_maunual_port(self):
+        mocked_dataset_artifact_metadata: MockedDatasetArtifactMetadata = (
+            get_mocked_dataset_artifact_metadata()[
+                TOY_GRAPH_USER_DEFINED_NODE_ANCHOR_MOCKED_DATASET_INFO.name
+            ]
+        )
+        gbml_config_pb_wrapper = (
+            GbmlConfigPbWrapper.get_gbml_config_pb_wrapper_from_uri(
+                gbml_config_uri=mocked_dataset_artifact_metadata.frozen_gbml_config_uri
+            )
+        )
+
+        preprocessed_metadata_pb_wrapper = (
+            gbml_config_pb_wrapper.preprocessed_metadata_pb_wrapper
+        )
+        graph_metadata_pb_wrapper = gbml_config_pb_wrapper.graph_metadata_pb_wrapper
+
+        serialized_graph_metadata = convert_pb_to_serialized_graph_metadata(
+            preprocessed_metadata_pb_wrapper=preprocessed_metadata_pb_wrapper,
+            graph_metadata_pb_wrapper=graph_metadata_pb_wrapper,
+            tfrecord_uri_pattern=".*\.tfrecord(\.gz)?$",
+        )
+
+        distributed_context = DistributedContext(
+            main_worker_ip_address="localhost",
+            global_rank=0,
+            global_world_size=1,
+        )
+
+        port = gigl.distributed.utils.get_free_port()
+
+        dataset = build_dataset(
+            serialized_graph_metadata=serialized_graph_metadata,
+            distributed_context=distributed_context,
+            sample_edge_direction="in",
+            should_load_tensors_in_parallel=True,
+            _dataset_building_port=port,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- Adds back the port as a parameter to the `build_dataset` utility
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
