### PR TITLE
Fix some issues with out CICD tests

### DIFF
--- a/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
+++ b/.github/actions/run-cloud-run-command-on-active-checkout/action.yml
@@ -30,5 +30,6 @@ runs:
           --service-account="projects/${{ inputs.project }}/serviceAccounts/${{ inputs.service_account }}" \
           --project="${{ inputs.project }}" \
           --machine-type="${{ inputs.machine_type }}" \
-          --timeout="${{ inputs.timeout }}"
+          --timeout="${{ inputs.timeout }}" \
+          --polling-interval=15 # Polling interval is set to 15 seconds to avoid rate limiting issues with Cloud Build API
       shell: bash

--- a/.github/workflows/on-pr-comment.yml
+++ b/.github/workflows/on-pr-comment.yml
@@ -16,7 +16,7 @@ jobs:
   unit-test:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/unit_test') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 35 # Tests as of 2025-05-16 are taking ~25 mins to complete, 40% buffer
+    timeout-minutes: 55
     steps:
     - name: Run Unit Tests
       uses: snapchat/gigl/.github/actions/run-command-on-pr@main


### PR DESCRIPTION
Two changes in this pr:

1. Increase test timeout for unit tests, we see in e.g. https://console.cloud.google.com/cloud-build/builds/3ffc7864-8ab0-45da-9484-fd082940d9e8?project=external-snap-ci-github-gigl&invt=Ab1QZw&inv=1 that our unit tests may take 37 mins so let's bump again
2. Decrease polling limit for cloud build, to try and prevent errors discussed below.

I've been seeing the below errors for cloud build, which are odd because the jobs can still succeed we just fail cause the polling gets rate limited.

I do think the math here doesn't quite add up, if we're at 900 requests/min, then each job should hit 60/requests/min with 1second polling.

This means we should be able to run 15 jobs at the same time, which translates to 5 concurrent merges, as each merge launches three jobs (unit_test, e2e_test, integration_test). 

Now we should be able to run 75 concurrent merges. 

```
Waiting for build to complete. Polling interval: 1 second(s).
ERROR: (gcloud.builds.submit) RESOURCE_EXHAUSTED: Quota exceeded for quota metric 'Build and Operation Get requests' and limit 'Build and Operation Get requests per minute per user' of service 'cloudbuild.googleapis.com' for consumer 'project_number:87123883529'.
Request a higher quota limit.
https://cloud.google.com/docs/quotas/help/request_increase
- '@type': type.googleapis.com/google.rpc.ErrorInfo
  domain: googleapis.com
  metadata:
    consumer: projects/8[71](https://github.com/Snapchat/GiGL/actions/runs/15930905967/job/44939620402#step:4:73)23883529
    quota_limit: GetRequestsPerMinutePerUser
    quota_limit_value: '900'
    quota_location: global
    quota_metric: cloudbuild.googleapis.com/get_requests
    quota_unit: 1/min/{project}/{user}
    service: cloudbuild.googleapis.com
  reason: RATE_LIMIT_EXCEEDED
```

https://console.cloud.google.com/cloud-build/builds/3ffc7864-8ab0-45da-9484-fd082940d9e8?project=external-snap-ci-github-gigl&invt=Ab1QZw&inv=1


See https://cloud.google.com/sdk/gcloud/reference/builds/submit for doc and the cloud build flag I added.