### PR TITLE
Fix ABLP_loader setting of `batch` and `batch_size`

### DIFF
--- a/python/gigl/distributed/dist_ablp_neighborloader.py
+++ b/python/gigl/distributed/dist_ablp_neighborloader.py
@@ -172,13 +172,13 @@ class DistABLPLoader(DistLoader):
                     "When using heterogeneous ABLP, you must provide supervision_edge_types."
                 )
             self._is_input_heterogeneous = True
-            node_type, node_ids = input_nodes
+            anchor_node_type, anchor_node_ids = input_nodes
             # TODO (mkolodner-sc): We currently assume supervision edges are directed outward, revisit in future if
             # this assumption is no longer valid and/or is too opinionated
             assert (
-                supervision_edge_type[0] == node_type
+                supervision_edge_type[0] == anchor_node_type
             ), f"Label EdgeType are currently expected to be provided in outward edge direction as tuple (`anchor_node_type`,`relation`,`supervision_node_type`), \
-                got supervision edge type {supervision_edge_type} with anchor node type {node_type}"
+                got supervision edge type {supervision_edge_type} with anchor node type {anchor_node_type}"
             supervision_node_type = supervision_edge_type[2]
             if dataset.edge_dir == "in":
                 supervision_edge_type = reverse_edge_type(supervision_edge_type)
@@ -188,8 +188,8 @@ class DistABLPLoader(DistLoader):
                 raise ValueError(
                     f"Expected supervision edge type to be None for homogeneous input nodes, got {supervision_edge_type}"
                 )
-            node_ids = input_nodes
-            node_type = DEFAULT_HOMOGENEOUS_NODE_TYPE
+            anchor_node_ids = input_nodes
+            anchor_node_type = DEFAULT_HOMOGENEOUS_NODE_TYPE
             supervision_edge_type = DEFAULT_HOMOGENEOUS_EDGE_TYPE
             supervision_node_type = DEFAULT_HOMOGENEOUS_NODE_TYPE
         elif input_nodes is None:
@@ -206,8 +206,8 @@ class DistABLPLoader(DistLoader):
                     f"Expected supervision edge type to be None for homogeneous input nodes, got {supervision_edge_type}"
                 )
 
-            node_ids = dataset.node_ids
-            node_type = DEFAULT_HOMOGENEOUS_NODE_TYPE
+            anchor_node_ids = dataset.node_ids
+            anchor_node_type = DEFAULT_HOMOGENEOUS_NODE_TYPE
             supervision_edge_type = DEFAULT_HOMOGENEOUS_EDGE_TYPE
             supervision_node_type = DEFAULT_HOMOGENEOUS_NODE_TYPE
 
@@ -217,8 +217,10 @@ class DistABLPLoader(DistLoader):
                 f"Missing edge types in dataset: {missing_edge_types}. Edge types in dataset: {dataset.graph.keys()}"
             )
 
-        if len(node_ids.shape) != 1:
-            raise ValueError(f"input_nodes must be a 1D tensor, got {node_ids.shape}.")
+        if len(anchor_node_ids.shape) != 1:
+            raise ValueError(
+                f"input_nodes must be a 1D tensor, got {anchor_node_ids.shape}."
+            )
         (
             self._positive_label_edge_type,
             self._negative_label_edge_type,
@@ -227,7 +229,7 @@ class DistABLPLoader(DistLoader):
 
         positive_labels, negative_labels = get_labels_for_anchor_nodes(
             dataset=dataset,
-            node_ids=node_ids,
+            node_ids=anchor_node_ids,
             positive_label_edge_type=self._positive_label_edge_type,
             negative_label_edge_type=self._negative_label_edge_type,
         )
@@ -256,7 +258,7 @@ class DistABLPLoader(DistLoader):
             )
 
         curr_process_nodes = shard_nodes_by_process(
-            input_nodes=node_ids,
+            input_nodes=anchor_node_ids,
             local_process_rank=local_process_rank,
             local_process_world_size=local_process_world_size,
         )
@@ -315,7 +317,7 @@ class DistABLPLoader(DistLoader):
 
         sampler_input = ABLPNodeSamplerInput(
             node=curr_process_nodes,
-            input_type=node_type,
+            input_type=anchor_node_type,
             positive_labels=positive_labels,
             negative_labels=negative_labels,
             supervision_node_type=supervision_node_type,

--- a/python/gigl/distributed/dist_neighbor_sampler.py
+++ b/python/gigl/distributed/dist_neighbor_sampler.py
@@ -87,7 +87,7 @@ class DistABLPNeighborSampler(DistNeighborSampler):
             num_sampled_nodes_hetero: dict[NodeType, list[torch.Tensor]] = {}
             num_sampled_edges_hetero: dict[EdgeType, list[torch.Tensor]] = {}
             src_dict = inducer.init_node(input_nodes)
-            batch = src_dict
+            batch = {input_type: input_seeds}
             merge_dict(src_dict, out_nodes_hetero)
             count_dict(src_dict, num_sampled_nodes_hetero, 1)
 
@@ -151,7 +151,7 @@ class DistABLPNeighborSampler(DistNeighborSampler):
         else:
             assert input_type == supervision_node_type
             srcs = inducer.init_node(input_nodes[input_type])
-            batch = srcs
+            batch = input_seeds
             out_nodes: list[torch.Tensor] = []
             out_edges: list[tuple[torch.Tensor, torch.Tensor, torch.Tensor]] = []
             num_sampled_nodes: list[torch.Tensor] = []

--- a/python/gigl/distributed/utils/neighborloader.py
+++ b/python/gigl/distributed/utils/neighborloader.py
@@ -76,23 +76,24 @@ def shard_nodes_by_process(
     return nodes_for_current_process
 
 
-def labeled_to_homogeneous(supevision_edge_type: EdgeType, data: HeteroData) -> Data:
+def labeled_to_homogeneous(supervision_edge_type: EdgeType, data: HeteroData) -> Data:
     """
     Returns a Data object with the label edges removed.
 
     Args:
-        supevision_edge_type (EdgeType): The edge type that contains the supervision edges.
+        supervision_edge_type (EdgeType): The edge type that contains the supervision edges.
         data (HeteroData): Heterogeneous graph with the supervision edge type
     Returns:
         data (Data): Homogeneous graph with the labeled edge type removed
     """
-    homogeneous_data = data.edge_type_subgraph([supevision_edge_type]).to_homogeneous(
+    homogeneous_data = data.edge_type_subgraph([supervision_edge_type]).to_homogeneous(
         add_edge_type=False, add_node_type=False
     )
-    # Since this is "homogeneous", supervision_edge_type[0] and supevision_edge_type[2] are the same.
-    sample_node_type = supevision_edge_type[0]
+    # Since this is "homogeneous", supervision_edge_type[0] and supervision_edge_type[2] are the same.
+    sample_node_type = supervision_edge_type[0]
     homogeneous_data.num_sampled_nodes = data.num_sampled_nodes[sample_node_type]
-    homogeneous_data.num_sampled_edges = data.num_sampled_edges[supevision_edge_type]
+    homogeneous_data.num_sampled_edges = data.num_sampled_edges[supervision_edge_type]
+    homogeneous_data.batch_size = homogeneous_data.batch.numel()
     return homogeneous_data
 
 

--- a/python/tests/unit/distributed/utils/neighborloader_test.py
+++ b/python/tests/unit/distributed/utils/neighborloader_test.py
@@ -111,11 +111,17 @@ class LoaderUtilsTest(unittest.TestCase):
             "item": torch.tensor([2, 2]),
         }
 
+        data.batch = torch.tensor([0, 1])
+
         homogeneous_data = labeled_to_homogeneous(_U2I_EDGE_TYPE, data)
         self.assertIsInstance(homogeneous_data, Data)
         self.assertTrue(hasattr(homogeneous_data, "edge_index"))
+        self.assertTrue(hasattr(homogeneous_data, "batch"))
+        self.assertTrue(hasattr(homogeneous_data, "batch_size"))
         assert_tensor_equality(homogeneous_data.num_sampled_nodes, torch.tensor([1, 1]))
         assert_tensor_equality(homogeneous_data.num_sampled_edges, torch.tensor([1, 1]))
+        assert_tensor_equality(homogeneous_data.batch, torch.tensor([0, 1]))
+        self.assertEqual(homogeneous_data.batch_size, 2)
 
     def test_strip_label_edges(self):
         data = HeteroData()


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
Previously, we were including the positive labels which we fanout from in the `batch` and `batch_size` fields of the returned Data/HeteroData object. We should instead make it so that only the anchor nodes are included in this field. Additionally, the `batch_size` field was not being set previously when we convert a HeteroData object to a Data object.
- Added fix for above issues
- Add tests for above issues
- Some readability improvements to some variable naming
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
