### PR TITLE
Add gigl.Module with RetrievalLoss and LinkPredictionGNN

### DIFF
--- a/python/gigl/module/loss.py
+++ b/python/gigl/module/loss.py
@@ -1,0 +1,192 @@
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+
+class RetrievalLoss(nn.Module):
+    """
+    A loss layer built on top of the tensorflow_recommenders implementation.
+    https://www.tensorflow.org/recommenders/api_docs/python/tfrs/tasks/Retrieval
+
+    The loss function by default calculates the loss by:
+    ```
+    cross_entropy(torch.mm(query_embeddings, candidate_embeddings.T), positive_indices, reduction='sum'),
+    ```
+    where the candidate embeddings are `torch.cat((positive_embeddings, random_negative_embeddings))`. It encourages the model to generate query embeddings that yield the highest similarity score with their own first hop compared with others' first hops and random negatives. We also filter out the cases where, in some rows, the query could accidentally treat its own positives as negatives.
+
+    Args:
+        loss (Optional[nn.Module]): Custom loss function to be used. If `None`, the default is `nn.CrossEntropyLoss(reduction="sum")`.
+        temperature (Optional[float]): Temperature scaling applied to scores before computing cross-entropy loss. If not `None`, scores are divided by the temperature value.
+        remove_accidental_hits (bool): Whether to remove accidental hits where the query's positive items are also present in the negative samples.
+    """
+
+    def __init__(
+        self,
+        loss: Optional[nn.Module] = None,
+        temperature: Optional[float] = None,
+        remove_accidental_hits: bool = False,
+    ):
+        super(RetrievalLoss, self).__init__()
+        self._loss = loss if loss is not None else nn.CrossEntropyLoss(reduction="sum")
+        self._temperature = temperature
+        if self._temperature is not None and self._temperature < 1e-12:
+            raise ValueError(
+                f"The temperature is expected to be greater than 1e-12, however you provided {self._temperature}"
+            )
+        self._remove_accidental_hits = remove_accidental_hits
+
+    def _calculate_batch_retrieval_loss(
+        self,
+        scores: torch.Tensor,
+        candidate_sampling_probability: Optional[torch.Tensor] = None,
+        query_ids: Optional[torch.Tensor] = None,
+        candidate_ids: Optional[torch.Tensor] = None,
+        device: torch.device = torch.device("cpu"),
+    ) -> torch.Tensor:
+        """
+        Args:
+          scores: [num_queries, num_candidates] tensor of candidate and query embeddings similarity
+          candidate_sampling_probability: [num_candidates], Optional tensor of candidate sampling probabilities.
+            When given will be used to correct the logits toreflect the sampling probability of negative candidates.
+          query_ids: [num_queries] Optional tensor containing query ids / anchor node ids.
+          candidate_ids: [num_candidates] Optional tensor containing candidate ids.
+          device: the device to set as default
+        """
+        num_queries: int = scores.shape[0]
+        num_candidates: int = scores.shape[1]
+        torch._assert(
+            num_queries <= num_candidates,
+            "Number of queries should be less than or equal to number of candidates in a batch",
+        )
+
+        labels = torch.eye(num_queries, num_candidates).to(
+            device=device
+        )  # [num_queries, num_candidates]
+        duplicates = torch.zeros_like(labels).to(
+            device=device
+        )  # [num_queries, num_candidates]
+
+        if self._temperature is not None:
+            scores = scores / self._temperature
+
+        # provide the corresponding candidate sampling probability to enable sampled softmax
+        if candidate_sampling_probability is not None:
+            scores = scores - torch.log(
+                torch.clamp(
+                    candidate_sampling_probability, min=1e-10
+                )  # frequency can be used so only limit its lower bound here
+            ).type(scores.dtype)
+
+        # obtain a mask that indicates true labels for each query when using multiple positives per query
+        if query_ids is not None:
+            duplicates = torch.maximum(
+                duplicates,
+                self._mask_by_query_ids(
+                    query_ids, num_queries, num_candidates, labels.dtype, device
+                ),
+            )  # [num_queries, num_candidates]
+
+        # obtain a mask that indicates true labels for each query when random negatives contain positives in this batch
+        if self._remove_accidental_hits:
+            if candidate_ids is None:
+                raise ValueError(
+                    "When accidental hit removal is enabled, candidate ids must be supplied."
+                )
+            duplicates = torch.maximum(
+                duplicates,
+                self._mask_by_candidate_ids(
+                    candidate_ids, num_queries, labels.dtype, device
+                ),
+            )  # [num_queries, num_candidates]
+
+        if query_ids is not None or self._remove_accidental_hits:
+            # mask out the extra positives in each row by setting their logits to min(scores.dtype)
+            scores = scores + (duplicates - labels) * torch.finfo(scores.dtype).min
+
+        return self._loss(scores, target=labels)
+
+    def _mask_by_query_ids(
+        self,
+        query_ids: torch.Tensor,
+        num_queries: int,
+        num_candidates: int,
+        dtype: torch.dtype,
+        device: torch.device = torch.device("cpu"),
+    ) -> torch.Tensor:
+        """
+        Args:
+            query_ids: [num_queries] query ids / anchor node ids in the batch
+            num_queries: number of queries / rows in the batch
+            num_candidates: number of candidates / columns in the batch
+            dtype: labels dtype
+            device: the device to set as default
+        """
+        query_ids = torch.unsqueeze(query_ids, 1)  # [num_queries, 1]
+        duplicates = torch.eq(query_ids, query_ids.T).type(
+            dtype
+        )  # [num_queries, num_queries]
+        if num_queries < num_candidates:
+            padding_zeros = torch.zeros(
+                (num_queries, num_candidates - num_queries), dtype=dtype
+            ).to(device=device)
+            return torch.cat(
+                (duplicates, padding_zeros), dim=1
+            )  # [num_queries, num_candidates]
+        return duplicates
+
+    def _mask_by_candidate_ids(
+        self,
+        candidate_ids: torch.Tensor,
+        num_queries: int,
+        dtype: torch.dtype,
+        device: torch.device = torch.device("cpu"),
+    ) -> torch.Tensor:
+        """
+        Args:
+            candidate_ids: [num_candidates] candidate ids in this batch
+            num_queries: number of queries / rows in the batch
+            dtype: labels dtype
+            device: the device to set as default
+        """
+        positive_indices = torch.arange(num_queries).to(device=device)  # [num_queries]
+        positive_candidate_ids = torch.gather(
+            candidate_ids, 0, positive_indices
+        ).unsqueeze(
+            1
+        )  # [num_queries, 1]
+        all_candidate_ids = torch.unsqueeze(candidate_ids, 1)  # [num_candidates, 1]
+        return torch.eq(positive_candidate_ids, all_candidate_ids.T).type(
+            dtype
+        )  # [num_queries, num_candidates]
+
+    def forward(
+        self,
+        repeated_candidate_scores: torch.Tensor,
+        candidate_ids: torch.Tensor,
+        repeated_query_ids: torch.Tensor,
+        device: torch.device,
+        candidate_sampling_probability: Optional[torch.Tensor] = None,
+    ):
+        """
+        Args:
+            repeated_candidate_scores (torch.Tensor): The prediction scores between each repeated query users and each candidates. In this case, `repeated` means
+                that we repeat each query user based on the number of positive labels they have.
+                Tensor shape: [num_positives, num_positives + num_hard_negatives + num_random_negatives]
+            candidate_ids (torch.Tensor): Concatenated Ids of the candidates. Tensor shape: [num_positives + num_hard_negatives + num_random_negatives]
+            repeated_query_ids (torch.Tensor): Repeated query user IDs. Tensor shape: [num_positives]
+            candidate_sampling_probability (Optional[torch.Tensor]): Optional tensor of candidate sampling probabilities.
+                When given will be used to correct the logits to reflect the sampling probability of negative candidates.
+                Tensor shape: [num_positives + num_hard_negatives + num_random_negatives]
+        """
+        if repeated_query_ids.numel():
+            loss = self._calculate_batch_retrieval_loss(
+                scores=repeated_candidate_scores,
+                candidate_sampling_probability=candidate_sampling_probability,
+                query_ids=repeated_query_ids,
+                candidate_ids=candidate_ids,
+                device=device,
+            )
+        else:
+            loss = torch.tensor(0.0).to(device=device)
+        return loss

--- a/python/gigl/module/models.py
+++ b/python/gigl/module/models.py
@@ -1,0 +1,53 @@
+from typing import Optional, Union
+
+import torch
+import torch.nn as nn
+from torch_geometric.data import Data, HeteroData
+
+from gigl.src.common.models.pyg.link_prediction import LinkPredictionDecoder
+from gigl.src.common.types.graph_data import NodeType
+
+
+class LinkPredictionGNN(nn.Module):
+    """
+    Link Prediction GNN model for both homogeneous and heterogeneous use cases
+    Args:
+        encoder (nn.Module): Either BasicGNN or Heterogeneous GNN for generating embeddings
+        decoder (nn.Module): LinkPredictionDecoder for transforming embeddings into scores
+    """
+
+    def __init__(
+        self,
+        encoder: nn.Module,
+        decoder: LinkPredictionDecoder,
+    ) -> None:
+        super().__init__()
+        self._encoder = encoder
+        self._decoder = decoder
+
+    def forward(
+        self,
+        data: Union[Data, HeteroData],
+        device: torch.device,
+        output_node_types: Optional[list[NodeType]] = None,
+    ) -> dict[NodeType, torch.Tensor]:
+        if isinstance(data, HeteroData):
+            if output_node_types is None:
+                raise ValueError(
+                    "Output node types must be specified in forward() pass for heterogeneous model"
+                )
+            return self._encoder(
+                data=data, output_node_types=output_node_types, device=device
+            )
+        else:
+            return self._encoder(data=data, device=device)
+
+    def decode(
+        self,
+        query_embeddings: torch.Tensor,
+        candidate_embeddings: torch.Tensor,
+    ) -> torch.Tensor:
+        return self._decoder(
+            query_embeddings=query_embeddings,
+            candidate_embeddings=candidate_embeddings,
+        )

--- a/python/gigl/src/common/models/layers/loss.py
+++ b/python/gigl/src/common/models/layers/loss.py
@@ -7,8 +7,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from gigl.common.logger import Logger
 from gigl.src.common.types.graph_data import CondensedEdgeType
 from gigl.src.common.types.task_inputs import BatchCombinedScores, BatchScores
+
+logger = Logger()
 
 
 class ModelResultType(Enum):
@@ -205,6 +208,10 @@ class RetrievalLoss(nn.Module):
                 f"The temperature is expected to be greater than 1e-12, however you provided {self._temperature}"
             )
         self._remove_accidental_hits = remove_accidental_hits
+        logger.warning(
+            "Calculating retrieval loss with the class at gigl.src.common.models.layers.loss.RetrievalLoss is deprecated and will be removed in a future release. "
+            "Please use the `gigl.module.loss.RetrievalLoss` class instead."
+        )
 
     def calculate_batch_retrieval_loss(
         self,
@@ -334,7 +341,7 @@ class RetrievalLoss(nn.Module):
         self,
         batch_combined_scores: BatchCombinedScores,
         repeated_query_embeddings: torch.FloatTensor,
-        candidate_sampling_probability: Optional[torch.FloatTensor],
+        candidate_sampling_probability: Optional[torch.FloatTensor] = None,
         device: torch.device = torch.device("cpu"),
     ) -> Tuple[torch.Tensor, int]:
         candidate_ids = torch.cat(

--- a/python/gigl/src/common/models/pyg/link_prediction.py
+++ b/python/gigl/src/common/models/pyg/link_prediction.py
@@ -4,10 +4,13 @@ import torch
 import torch.nn as nn
 import torch_geometric
 
+from gigl.common.logger import Logger
 from gigl.src.common.models.layers.decoder import LinkPredictionDecoder
 from gigl.src.common.models.layers.task import NodeAnchorBasedLinkPredictionTasks
 from gigl.src.common.types.graph_data import NodeType
 from gigl.src.common.types.model import GraphBackend
+
+logger = Logger()
 
 
 class LinkPredictionGNN(nn.Module):
@@ -26,6 +29,11 @@ class LinkPredictionGNN(nn.Module):
         tasks: Optional[NodeAnchorBasedLinkPredictionTasks] = None,
     ) -> None:
         super().__init__()
+
+        logger.warning(
+            "gigl.src.common.models.layers.nn.link_prediction.LinkPredictionGNN is deprecated and will be removed in a future release. "
+            "Please use the `gigl.module.models.LinkPredictionGNN` class instead."
+        )
         self.__encoder = encoder
         self.__decoder = decoder
         self.__tasks = tasks

--- a/python/tests/unit/src/common/models/layers/loss_test.py
+++ b/python/tests/unit/src/common/models/layers/loss_test.py
@@ -3,7 +3,7 @@ import unittest
 import torch
 import torch.nn.functional as F
 
-from gigl.src.common.models.layers.loss import RetrievalLoss
+from gigl.module.loss import RetrievalLoss
 
 
 class RetrievalLossTest(unittest.TestCase):
@@ -105,7 +105,7 @@ class RetrievalLossTest(unittest.TestCase):
         min_float = torch.finfo(torch.float).min
         loss = RetrievalLoss(remove_accidental_hits=False)
         scores = torch.mm(self.query_embeddings, self.candidate_embeddings.T)
-        actual1 = loss.calculate_batch_retrieval_loss(scores)
+        actual1 = loss._calculate_batch_retrieval_loss(scores)
         expected1 = torch.tensor(
             [
                 [0.8321, 0.8647, 0.0000, 0.0000, 0.6748, 0.7376],
@@ -125,7 +125,7 @@ class RetrievalLossTest(unittest.TestCase):
 
         loss = RetrievalLoss(remove_accidental_hits=True)
         scores = torch.mm(self.query_embeddings, self.candidate_embeddings.T)
-        actual2 = loss.calculate_batch_retrieval_loss(
+        actual2 = loss.__calculate_batch_retrieval_loss(
             scores,
             candidate_ids=self.candidate_ids,
         )
@@ -146,7 +146,7 @@ class RetrievalLossTest(unittest.TestCase):
         )
 
         # by filtering out other positives from the same query, we should see smaller loss
-        actual3 = loss.calculate_batch_retrieval_loss(
+        actual3 = loss._calculate_batch_retrieval_loss(
             scores,
             candidate_ids=self.candidate_ids,
             query_ids=self.query_ids,


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

Currently, it is a bit awkward to use the existing LinkPredictionGNN and RetrievalLoss due to assumptions we made as part of offline SGS GiGL. For example, we need to provide a `output_node_types` to the forward pass of the model even if we are in the homogeneous setting, and index into a dictionary as a result as well when getting the output from the forward pass. Additionally, we need to populate an opinionated `BatchCombinedScores` dataclass in order to calculate RetrievalLoss. This is not PyG-conformant. 

This PR moves these two fields to their own files in a new `gigl.module` folder and removes these awkward assumptions from these classes. 


<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
