### PR TITLE
Add self link in notebooks

### DIFF
--- a/examples/MAG240M/fetch_data.ipynb
+++ b/examples/MAG240M/fetch_data.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# (Optional) Fetch MAG240M Data into your own project"
+    "# (Optional) Fetch MAG240M Data into your own project\n",
+    "\n",
+    "Latest version of this notebook can be found on [github](https://github.com/Snapchat/GiGL/blob/main/examples/MAG240M/fetch_data.ipynb)\n"
    ]
   },
   {

--- a/examples/MAG240M/mag240m.ipynb
+++ b/examples/MAG240M/mag240m.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# MAG240M E2E Example"
+    "# MAG240M E2E Example\n",
+    "\n",
+    "Latest version of this notebook can be found on [github](https://github.com/Snapchat/GiGL/blob/main/examples/MAG240M/mag240m.ipynb)\n"
    ]
   },
   {

--- a/examples/toy_visual_example/toy_example_walkthrough.ipynb
+++ b/examples/toy_visual_example/toy_example_walkthrough.ipynb
@@ -1,24 +1,14 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
-    "\n",
-    "from gigl.common.utils.jupyter_magics import change_working_dir_to_gigl_root\n",
-    "change_working_dir_to_gigl_root()"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Toy Example - Tabularized GiGL\n",
+    "\n",
+    "Latest version of this notebook can be found on [github](https://github.com/Snapchat/GiGL/blob/main/examples/toy_visual_example/toy_example_walkthrough.ipynb)\n",
+    "\n",
     "\n",
     "This notebook provides a walkthrough of preprocessing, subgraph sampling, and split generation components with a small toy graph for GiGL's Tabularized setting for training/inference. It will help you understand how each of these components prepare tabularized subgraphs.\n",
     "\n",
@@ -57,6 +47,19 @@
     "    - Input: `frozen_gbml_config.yaml`\n",
     "    - Output: Embeddings and/or prediction assets.\n",
     "&nbsp;\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "from gigl.common.utils.jupyter_magics import change_working_dir_to_gigl_root\n",
+    "change_working_dir_to_gigl_root()"
    ]
   },
   {


### PR DESCRIPTION
**Scope of work done**

A comment was brought up when we added the notebook examples to our repo to include a self link to the notebook so folks viewing the rendering from the doc website have easy access to it.

Currently, the doc website renders rich HTML, with no obvious way to directly navigate to the underlying notebook.

i.e.https://snapchat.github.io/GiGL/examples/toy_visual_example/toy_example_walkthrough.html
<img width="780" alt="Screenshot 2025-07-03 at 3 01 43 PM" src="https://github.com/user-attachments/assets/996f9db8-c8c8-42f6-a6da-0304c3e363d5" />


<!-- Description of PR goes here -->


<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
