### PR TITLE
Run all node or edge enumeration BigQuery jobs in parallel

### DIFF
--- a/python/gigl/src/data_preprocessor/lib/enumerate/utils.py
+++ b/python/gigl/src/data_preprocessor/lib/enumerate/utils.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Sequence, Tuple
 
 import google.cloud.bigquery as bigquery
 
-from gigl.common.env_config import get_available_cpus
 from gigl.common.logger import Logger
 from gigl.env.pipelines_config import get_resource_config
 from gigl.src.common.constants import bq as bq_constants
@@ -247,7 +246,7 @@ class Enumerator:
     ) -> List[EnumeratorNodeTypeMetadata]:
         results: List[EnumeratorNodeTypeMetadata] = []
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=get_available_cpus()
+            max_workers=len(node_data_references)
         ) as executor:
             futures: List[concurrent.futures.Future] = list()
             for node_data_ref in node_data_references:
@@ -270,7 +269,7 @@ class Enumerator:
     ) -> List[EnumeratorEdgeTypeMetadata]:
         results: List[EnumeratorEdgeTypeMetadata] = []
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=get_available_cpus()
+            max_workers=len(edge_data_references)
         ) as executor:
             futures: List[concurrent.futures.Future] = list()
             for edge_data_ref in edge_data_references:

--- a/python/gigl/src/data_preprocessor/lib/enumerate/utils.py
+++ b/python/gigl/src/data_preprocessor/lib/enumerate/utils.py
@@ -245,6 +245,10 @@ class Enumerator:
         node_data_references: Sequence[NodeDataReference],
     ) -> List[EnumeratorNodeTypeMetadata]:
         results: List[EnumeratorNodeTypeMetadata] = []
+
+        logger.info(
+            f"Launch {len(node_data_references)} node enumeration jobs in parallel."
+        )
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=len(node_data_references)
         ) as executor:
@@ -268,6 +272,10 @@ class Enumerator:
         map_enumerator_node_type_metadata: Dict[NodeType, EnumeratorNodeTypeMetadata],
     ) -> List[EnumeratorEdgeTypeMetadata]:
         results: List[EnumeratorEdgeTypeMetadata] = []
+
+        logger.info(
+            f"Launch {len(edge_data_references)} edge enumeration jobs in parallel."
+        )
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=len(edge_data_references)
         ) as executor:


### PR DESCRIPTION
### Features
Enumerate all node data references or all edge data references in parallel.

Currently the parallelism is limited by the number of CPU(s) on the host machine. Since the enumeration jobs are BigQuery jobs, and the host machine only needs to launch job and then listen to job status, it is not computation intensive and is safe to run more jobs in parallel.

### Testing
Tested run pipelines and verified that all enumeration jobs were launched in parallel.   