### PR TITLE
Remove unnecessary distributed calls in Dataloader setup

### DIFF
--- a/examples/link_prediction/heterogeneous_inference.py
+++ b/examples/link_prediction/heterogeneous_inference.py
@@ -28,7 +28,7 @@ import torch
 import torch.distributed
 import torch.multiprocessing as mp
 from examples.link_prediction.models import init_example_gigl_heterogeneous_model
-from graphlearn_torch.distributed import barrier, shutdown_rpc
+from graphlearn_torch.distributed import barrier
 
 import gigl.distributed
 import gigl.distributed.utils
@@ -269,9 +269,6 @@ def _inference_process(
     logger.info(
         f"--- All machines local rank {local_rank} finished inference for node type {inference_node_type}. Deleted data loader"
     )
-
-    # Clean up for a graceful exit
-    shutdown_rpc()
 
 
 def _run_example_inference(

--- a/examples/link_prediction/heterogeneous_inference.py
+++ b/examples/link_prediction/heterogeneous_inference.py
@@ -265,6 +265,8 @@ def _inference_process(
     del data_loader
     gc.collect()
 
+    torch.distributed.destroy_process_group()
+
     logger.info(
         f"--- All machines local rank {local_rank} finished inference for node type {inference_node_type}. Deleted data loader"
     )

--- a/examples/link_prediction/heterogeneous_inference.py
+++ b/examples/link_prediction/heterogeneous_inference.py
@@ -28,7 +28,6 @@ import torch
 import torch.distributed
 import torch.multiprocessing as mp
 from examples.link_prediction.models import init_example_gigl_heterogeneous_model
-from graphlearn_torch.distributed import barrier
 
 import gigl.distributed
 import gigl.distributed.utils
@@ -195,7 +194,7 @@ def _inference_process(
     # We add a barrier here so that all machines and processes have initialized their dataloader at the start of the inference loop. Otherwise, on-the-fly subgraph
     # sampling may fail.
 
-    barrier()
+    torch.distributed.barrier()
 
     t = time.time()
     data_loading_start_time = time.time()
@@ -261,7 +260,7 @@ def _inference_process(
     # machine + process -- otherwise we may fail on processes which are still doing on-the-fly subgraph sampling. We then call `gc.collect()` to cleanup the memory
     # used by the data_loader on the current machine.
 
-    barrier()
+    torch.distributed.barrier()
 
     del data_loader
     gc.collect()

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -265,8 +265,6 @@ def _inference_process(
         f"--- All machines local rank {local_rank} finished inference. Deleted data loader"
     )
 
-    # Clean up for a graceful exit
-
 
 def _run_example_inference(
     job_name: str,

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -27,7 +27,7 @@ from typing import Dict, List
 import torch
 import torch.multiprocessing as mp
 from examples.link_prediction.models import init_example_gigl_homogeneous_model
-from graphlearn_torch.distributed import barrier, shutdown_rpc
+from graphlearn_torch.distributed import barrier
 
 import gigl.distributed
 import gigl.distributed.utils
@@ -267,7 +267,6 @@ def _inference_process(
     )
 
     # Clean up for a graceful exit
-    shutdown_rpc()
 
 
 def _run_example_inference(

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -261,6 +261,8 @@ def _inference_process(
     del data_loader
     gc.collect()
 
+    torch.distributed.destroy_process_group()
+
     logger.info(
         f"--- All machines local rank {local_rank} finished inference. Deleted data loader"
     )

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -27,7 +27,6 @@ from typing import Dict, List
 import torch
 import torch.multiprocessing as mp
 from examples.link_prediction.models import init_example_gigl_homogeneous_model
-from graphlearn_torch.distributed import barrier
 
 import gigl.distributed
 import gigl.distributed.utils
@@ -195,7 +194,7 @@ def _inference_process(
     # We add a barrier here so that all machines and processes have initialized their dataloader at the start of the inference loop. Otherwise, on-the-fly subgraph
     # sampling may fail.
 
-    barrier()
+    torch.distributed.barrier()
 
     t = time.time()
     data_loading_start_time = time.time()
@@ -257,7 +256,7 @@ def _inference_process(
     # machine + process -- otherwise we may fail on processes which are still doing on-the-fly subgraph sampling. We then call `gc.collect()` to cleanup the memory
     # used by the data_loader on the current machine.
 
-    barrier()
+    torch.distributed.barrier()
 
     del data_loader
     gc.collect()

--- a/python/gigl/distributed/dist_ablp_neighborloader.py
+++ b/python/gigl/distributed/dist_ablp_neighborloader.py
@@ -159,8 +159,8 @@ class DistABLPLoader(DistLoader):
         # https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_loader.py#L125C1-L126C1
         self._shutdowned = True
 
-        node_world_size: int
-        node_rank: int
+        machine_world_size: int
+        machine_rank: int
         rank: int
         world_size: int
         local_rank: int
@@ -178,13 +178,13 @@ class DistABLPLoader(DistLoader):
             ), "context: DistributedContext provided, so local_process_rank must be provided."
 
             master_ip_address = context.main_worker_ip_address
-            node_world_size = context.global_world_size
-            node_rank = context.global_rank
+            machine_world_size = context.global_world_size
+            machine_rank = context.global_rank
             local_world_size = local_process_world_size
             local_rank = local_process_rank
 
-            rank = node_rank * local_world_size + local_rank
-            world_size = node_world_size * local_world_size
+            rank = machine_rank * local_world_size + local_rank
+            world_size = machine_world_size * local_world_size
 
             if not torch.distributed.is_initialized():
                 logger.info(
@@ -220,9 +220,9 @@ class DistABLPLoader(DistLoader):
                         + f"count_ranks_per_ip_address = {count_ranks_per_ip_address}"
                     )
 
-            node_world_size = len(count_ranks_per_ip_address)
+            machine_world_size = len(count_ranks_per_ip_address)
             local_rank = rank % local_world_size
-            node_rank = rank // local_world_size
+            machine_rank = rank // local_world_size
 
         del (
             context,
@@ -332,14 +332,10 @@ class DistABLPLoader(DistLoader):
             local_process_world_size=local_world_size,
         )
 
-        # Sets up processes and torch device for initializing the GLT DistNeighborLoader, setting up RPC and worker groups to minimize
+        # Sets up processes for initializing the dataloader, setting up worker groups to minimize
         # the memory overhead and CPU contention.
-        neighbor_loader_ports = gigl.distributed.utils.get_free_ports_from_master_node(
-            num_ports=local_world_size
-        )
-        neighbor_loader_port_for_current_rank = neighbor_loader_ports[local_rank]
         logger.info(
-            f"Initializing neighbor loader worker in process: {local_rank}/{local_world_size} using device: {self.to_device} on port {neighbor_loader_port_for_current_rank}."
+            f"Initializing neighbor loader worker in process: {local_rank}/{local_world_size} using device: {self.to_device}"
         )
         should_use_cpu_workers = self.to_device.type == "cpu"
         if should_use_cpu_workers and num_cpu_threads is None:
@@ -350,12 +346,10 @@ class DistABLPLoader(DistLoader):
             num_cpu_threads = DEFAULT_NUM_CPU_THREADS
 
         gigl.distributed.utils.init_neighbor_loader_worker(
-            master_ip_address=master_ip_address,
             local_process_rank=local_rank,
             local_process_world_size=local_world_size,
-            rank=node_rank,
-            world_size=node_world_size,
-            master_worker_port=neighbor_loader_port_for_current_rank,
+            machine_rank=machine_rank,
+            machine_world_size=machine_world_size,
             device=self.to_device,
             should_use_cpu_workers=should_use_cpu_workers,
             # Lever to explore tuning for CPU based inference

--- a/python/gigl/distributed/distributed_neighborloader.py
+++ b/python/gigl/distributed/distributed_neighborloader.py
@@ -109,8 +109,8 @@ class DistNeighborLoader(DistLoader):
         # https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_loader.py#L125C1-L126C1
         self._shutdowned = True
 
-        node_world_size: int
-        node_rank: int
+        machine_world_size: int
+        machine_rank: int
         rank: int
         world_size: int
         local_rank: int
@@ -128,13 +128,13 @@ class DistNeighborLoader(DistLoader):
             ), "context: DistributedContext provided, so local_process_rank must be provided."
 
             master_ip_address = context.main_worker_ip_address
-            node_world_size = context.global_world_size
-            node_rank = context.global_rank
+            machine_world_size = context.global_world_size
+            machine_rank = context.global_rank
             local_world_size = local_process_world_size
             local_rank = local_process_rank
 
-            rank = node_rank * local_world_size + local_rank
-            world_size = node_world_size * local_world_size
+            rank = machine_rank * local_world_size + local_rank
+            world_size = machine_world_size * local_world_size
 
             if not torch.distributed.is_initialized():
                 logger.info(
@@ -170,9 +170,9 @@ class DistNeighborLoader(DistLoader):
                         + f"count_ranks_per_ip_address = {count_ranks_per_ip_address}"
                     )
 
-            node_world_size = len(count_ranks_per_ip_address)
+            machine_world_size = len(count_ranks_per_ip_address)
             local_rank = rank % local_world_size
-            node_rank = rank // local_world_size
+            machine_rank = rank // local_world_size
 
         del (
             context,
@@ -188,7 +188,7 @@ class DistNeighborLoader(DistLoader):
             )
         )
         logger.info(
-            f"Dataset Building started on {node_rank} of {node_world_size} nodes, using following node as main: {master_ip_address}"
+            f"Dataset Building started on {machine_rank} of {machine_world_size} nodes, using following node as main: {master_ip_address}"
         )
 
         if input_nodes is None:
@@ -261,7 +261,7 @@ class DistNeighborLoader(DistLoader):
 
         input_data = NodeSamplerInput(node=curr_process_nodes, input_type=node_type)
 
-        # Sets up processes and torch device for initializing the GLT DistNeighborLoader, setting up RPC and worker groups to minimize
+        # Sets up processes for initializing the dataloader, setting up worker groups to minimize
         # the memory overhead and CPU contention.
         logger.info(
             f"Initializing neighbor loader worker in process: {local_rank}/{local_world_size} using device: {device}"
@@ -274,21 +274,14 @@ class DistNeighborLoader(DistLoader):
             )
             num_cpu_threads = DEFAULT_NUM_CPU_THREADS
 
-        neighbor_loader_ports = gigl.distributed.utils.get_free_ports_from_master_node(
-            num_ports=local_world_size
-        )
-        neighbor_loader_port_for_current_rank = neighbor_loader_ports[local_rank]
-
         gigl.distributed.utils.init_neighbor_loader_worker(
-            master_ip_address=master_ip_address,
             local_process_rank=local_rank,
             local_process_world_size=local_world_size,
-            rank=node_rank,
-            world_size=node_world_size,
-            master_worker_port=neighbor_loader_port_for_current_rank,
+            machine_rank=machine_rank,
+            machine_world_size=machine_world_size,
             device=device,
             should_use_cpu_workers=should_use_cpu_workers,
-            # Lever to explore tuning for CPU based inference
+            # Lever to explore tuning for CPU based training or inference
             num_cpu_threads=num_cpu_threads,
             process_start_gap_seconds=process_start_gap_seconds,
         )

--- a/python/gigl/distributed/utils/init_neighbor_loader_worker.py
+++ b/python/gigl/distributed/utils/init_neighbor_loader_worker.py
@@ -140,7 +140,7 @@ def init_neighbor_loader_worker(
             f"Machine {machine_rank} local rank {local_process_rank} uses device {torch.cuda.current_device()} by default"
         )
 
-    # Only initial the worker group if it is not already initialized
+    # Only initialize the worker group if it is not already set up
     if get_context() is None:
         # Group of workers. Each process is a worker. Each
         # worker will initiate one model and at least one data loader. Each data loader

--- a/python/gigl/distributed/utils/init_neighbor_loader_worker.py
+++ b/python/gigl/distributed/utils/init_neighbor_loader_worker.py
@@ -2,9 +2,9 @@ import time
 from functools import lru_cache
 from typing import Optional
 
+import graphlearn_torch as glt
 import psutil
 import torch
-from graphlearn_torch.distributed import get_context, init_worker_group
 
 from gigl.common.logger import Logger
 
@@ -45,8 +45,8 @@ def init_neighbor_loader_worker(
     Args:
         local_process_rank (int): Process number on the current machine
         local_process_world_size (int): Total number of processes on the current machine
-        rank (int): Rank of current machine
-        world_size (int): Total number of machines
+        machine_rank (int): Rank of current machine
+        machine_world_size (int): Total number of machines
         device (torch.device): The device where you want to load the data onto - i.e. where is your model?
         should_use_cpu_workers (bool): Whether we should do CPU training or inference.
         num_cpu_threads (Optional[int]): Number of cpu threads PyTorch should use for CPU training or inference.
@@ -141,7 +141,7 @@ def init_neighbor_loader_worker(
         )
 
     # Only initialize the worker group if it is not already set up
-    if get_context() is None:
+    if glt.distributed.get_context() is None:
         # Group of workers. Each process is a worker. Each
         # worker will initiate one model and at least one data loader. Each data loader
         # will spawn several sampling processes (a.k.a. sampling workers).
@@ -157,7 +157,7 @@ def init_neighbor_loader_worker(
         logger.info(
             f"Init worker group with: world_size={machine_world_size}, rank={machine_rank}, group_name={group_name}, "
         )
-        init_worker_group(
+        glt.distributed.init_worker_group(
             world_size=machine_world_size,
             rank=machine_rank,
             group_name=group_name,

--- a/python/gigl/distributed/utils/init_neighbor_loader_worker.py
+++ b/python/gigl/distributed/utils/init_neighbor_loader_worker.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import psutil
 import torch
+from graphlearn_torch.distributed import get_context, init_worker_group
 
 from gigl.common.logger import Logger
 
@@ -141,4 +142,16 @@ def init_neighbor_loader_worker(
         torch.cuda.empty_cache()
         logger.info(
             f"Machine {rank} local rank {local_process_rank} uses device {torch.cuda.current_device()} by default"
+        )
+
+    # Only initial the worker group if it is not already initialized
+    if get_context() is None:
+        group_name = get_process_group_name(local_process_rank)
+        logger.info(
+            f"Init worker group with: world_size={world_size}, rank={rank}, group_name={group_name}, "
+        )
+        init_worker_group(
+            world_size=world_size,
+            rank=rank,
+            group_name=group_name,
         )

--- a/python/gigl/distributed/utils/init_neighbor_loader_worker.py
+++ b/python/gigl/distributed/utils/init_neighbor_loader_worker.py
@@ -30,12 +30,10 @@ def get_process_group_name(process_rank: int) -> str:
 # That way the "side-effects" of the call are only executed once.
 @lru_cache(maxsize=1)
 def init_neighbor_loader_worker(
-    master_ip_address: str,
     local_process_rank: int,
     local_process_world_size: int,
-    rank: int,
-    world_size: int,
-    master_worker_port: int,
+    machine_rank: int,
+    machine_world_size: int,
     device: torch.device,
     should_use_cpu_workers: bool = False,
     num_cpu_threads: Optional[int] = None,
@@ -45,12 +43,10 @@ def init_neighbor_loader_worker(
     Sets up processes and torch device for initializing the GLT DistNeighborLoader, setting up RPC and worker groups to minimize
     the memory overhead and CPU contention. Returns the torch device which current worker is assigned to.
     Args:
-        master_ip_address (str): Master IP Address to manage processes
         local_process_rank (int): Process number on the current machine
         local_process_world_size (int): Total number of processes on the current machine
         rank (int): Rank of current machine
         world_size (int): Total number of machines
-        master_worker_port (int): Master port to use for communicating between workers during training or inference
         device (torch.device): The device where you want to load the data onto - i.e. where is your model?
         should_use_cpu_workers (bool): Whether we should do CPU training or inference.
         num_cpu_threads (Optional[int]): Number of cpu threads PyTorch should use for CPU training or inference.
@@ -58,8 +54,6 @@ def init_neighbor_loader_worker(
         process_start_gap_seconds (float): Delay between each process for initializing neighbor loader. At large scales, it is recommended to set
             this value to be between 60 and 120 seconds -- otherwise multiple processes may attempt to initialize dataloaders at overlapping timesß,
             which can cause CPU memory OOM.
-    Returns:
-        torch.device: Device which current worker is assigned to
     """
 
     global _is_cpu_env_initialized
@@ -70,10 +64,12 @@ def init_neighbor_loader_worker(
     # usage will add up and cause CPU memory OOM. Hence, we initiate the data loaders group by group
     # to smooth the memory usage. The definition of group is discussed below.
     logger.info(
-        f"---Machine {rank} local process number {local_process_rank} preparing to sleep for {process_start_gap_seconds * local_process_rank} seconds"
+        f"---Machine {machine_rank} local process number {local_process_rank} preparing to sleep for {process_start_gap_seconds * local_process_rank} seconds"
     )
     time.sleep(process_start_gap_seconds * local_process_rank)
-    logger.info(f"---Machine {rank} local process number {local_process_rank} started")
+    logger.info(
+        f"---Machine {machine_rank} local process number {local_process_rank} started"
+    )
     if not should_use_cpu_workers:
         assert (
             torch.cuda.device_count() > 0
@@ -141,17 +137,28 @@ def init_neighbor_loader_worker(
         torch.cuda.set_device(device)
         torch.cuda.empty_cache()
         logger.info(
-            f"Machine {rank} local rank {local_process_rank} uses device {torch.cuda.current_device()} by default"
+            f"Machine {machine_rank} local rank {local_process_rank} uses device {torch.cuda.current_device()} by default"
         )
 
     # Only initial the worker group if it is not already initialized
     if get_context() is None:
+        # Group of workers. Each process is a worker. Each
+        # worker will initiate one model and at least one data loader. Each data loader
+        # will spawn several sampling processes (a.k.a. sampling workers).
+        # Instead of combining all workers into one group, we define N groups where
+        # N is the number of processes on each machine. Specifically, we have
+        # Group 0: (Machine 0, process 0), (Machine 1, process 0),..., (Machine M, process 0)
+        # Group 1: (Machine 0, process 1), (Machine 1, process 1),..., (Machine M, process 1)
+        # ...
+        # Group N-1: (Machine 0, process N-1), (Machine 1, process N-1),..., (Machine M, process N-1)
+        # We do this as we want to start different groups in different times to smooth
+        # the spike of memory usage as mentioned above.
         group_name = get_process_group_name(local_process_rank)
         logger.info(
-            f"Init worker group with: world_size={world_size}, rank={rank}, group_name={group_name}, "
+            f"Init worker group with: world_size={machine_world_size}, rank={machine_rank}, group_name={group_name}, "
         )
         init_worker_group(
-            world_size=world_size,
-            rank=rank,
+            world_size=machine_world_size,
+            rank=machine_rank,
             group_name=group_name,
         )


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- Previously, we were calling `init_worker_group` once per dataloader, even in the case of trainer where we have multiple dataloaders. We should only need to call this once since the resulting `GLT.DistContext` is the same regardless of which dataloader is calling it on each machine, and update this code accordingly.
- Similarly, we were previously calling `init_rpc` inside of the dataloaders so that we could call `barrier()` in the inference loop. We should not be calling this `init_rpc` more times than necessary. Additionally, we no longer need this `init_rpc` call, since we are now using `torch.distributed.init_process_group` as part of both inference and training, and can use that instead to set up barriers at different points of the training/inference loop. The previous `init_rpc` wasn't actually being used at all in any of the training loops, and can be deprecated in the inference loops by swapping from `glt.distributed.barrier` to `torch.distributed.barrier`
- Also includes some naming updates `node_rank` -> `machine_rank` and `node_world_size` -> `machine_world_size`
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
