### PR TITLE
Add ability to push to a new branch in `commit-and-push` github action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -63,3 +63,6 @@ scripts/
 graphlearn_torch/
 graphlearn_torch.egg-info/
 do_not_open_source
+
+# https://github.com/google-github-actions/auth/issues/497
+gha-creds-*.json

--- a/.github/actions/commit-and-push/action.yml
+++ b/.github/actions/commit-and-push/action.yml
@@ -1,5 +1,12 @@
 name: "Commit and Push Changes"
-description: "Commits and pushes changes to the current or specified branch with a customizable commit message, including changes the workflow has made"
+description: |
+  Commits and pushes changes to the current or specified branch with a customizable commit message.
+  Includes changes the workflow has made.
+  Only commits changes to files that have been modified or deleted, without adding new files.
+  If a new branch is specified, the action will create a new branch and push the changes to it.
+  If no new branch is specified, the action will push the changes to the current branch.
+
+
 inputs:
   commit_message:
     description: "Commit message for the changes"
@@ -29,7 +36,7 @@ runs:
           git push --set-upstream origin $TO_NEW_BRANCH_NAMED
         fi
 
-        git add --all
+        git add --update
 
         # If no changes, exit gracefully. If not done, git commit will fail.
         if git diff --cached --exit-code; then

--- a/.github/actions/commit-and-push/action.yml
+++ b/.github/actions/commit-and-push/action.yml
@@ -26,6 +26,7 @@ runs:
         if [ "$TO_NEW_BRANCH_NAMED" != "false" ]; then
           echo "Creating a new branch, named $TO_NEW_BRANCH_NAMED, and pushing the changes to it"
           git checkout -b $TO_NEW_BRANCH_NAMED
+          git push --set-upstream origin $TO_NEW_BRANCH_NAMED
         fi
 
         git add .

--- a/.github/actions/commit-and-push/action.yml
+++ b/.github/actions/commit-and-push/action.yml
@@ -4,7 +4,7 @@ description: |
   Includes changes the workflow has made.
   Only commits changes to files that have been modified or deleted, without adding new files.
   If a new branch is specified, the action will create a new branch and push the changes to it.
-  If no new branch is specified, the action will push the changes to the current branch.
+  Otherwise, the action will push the changes to the current branch.
 
 
 inputs:

--- a/.github/actions/commit-and-push/action.yml
+++ b/.github/actions/commit-and-push/action.yml
@@ -36,6 +36,9 @@ runs:
           git push --set-upstream origin $TO_NEW_BRANCH_NAMED
         fi
 
+        # Stages changes (modifications and deletions) to tracked files, but ignores new untracked files.
+        # This is to ensure that workflows are not staging any files that might have been created
+        # temporarily and have not been cleaned up.
         git add --update
 
         # If no changes, exit gracefully. If not done, git commit will fail.

--- a/.github/actions/commit-and-push/action.yml
+++ b/.github/actions/commit-and-push/action.yml
@@ -1,5 +1,5 @@
 name: "Commit and Push Changes"
-description: "Commits and pushes changes with a customizable commit message"
+description: "Commits and pushes changes to the current or specified branch with a customizable commit message, including changes the workflow has made"
 inputs:
   commit_message:
     description: "Commit message for the changes"
@@ -9,9 +9,9 @@ inputs:
     description: "GitHub token to authenticate and push the changes"
     required: true
   to_new_branch_named:
-    description: "Create a new branch and push the changes to it"
+    description: "Name of the branch to push the changes to. If not provided, the changes will be pushed to the current branch."
     required: false
-    default: "false"
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -23,19 +23,18 @@ runs:
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        if [ "$TO_NEW_BRANCH_NAMED" != "false" ]; then
+        if [ "$TO_NEW_BRANCH_NAMED" != "" ]; then
           echo "Creating a new branch, named $TO_NEW_BRANCH_NAMED, and pushing the changes to it"
           git checkout -b $TO_NEW_BRANCH_NAMED
           git push --set-upstream origin $TO_NEW_BRANCH_NAMED
         fi
 
-        git add .
-        # Check if there are any changes
-        if [ "$TO_NEW_BRANCH_NAMED" == "false" ]; then
-          if git diff --cached --exit-code; then
-            echo "No changes to commit."
-            exit 0
-          fi
+        git add --all
+
+        # If no changes, exit gracefully. If not done, git commit will fail.
+        if git diff --cached --exit-code; then
+          echo "No changes to commit."
+          exit 0
         fi
 
         git commit -m "$COMMIT_MESSAGE"

--- a/.github/actions/commit-and-push/action.yml
+++ b/.github/actions/commit-and-push/action.yml
@@ -8,6 +8,10 @@ inputs:
   github_token:
     description: "GitHub token to authenticate and push the changes"
     required: true
+  to_new_branch_named:
+    description: "Create a new branch and push the changes to it"
+    required: false
+    default: "false"
 runs:
   using: "composite"
   steps:
@@ -15,17 +19,24 @@ runs:
       env:
         COMMIT_MESSAGE: ${{ inputs.commit_message }}
         GITHUB_TOKEN: ${{ inputs.github_token }}
+        TO_NEW_BRANCH_NAMED: ${{ inputs.to_new_branch_named }}
       run: |
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        git add .
-        
-        # Check if there are any changes
-        if git diff --cached --exit-code; then
-          echo "No changes to commit."
-          exit 0
+        if [ "$TO_NEW_BRANCH_NAMED" != "false" ]; then
+          echo "Creating a new branch, named $TO_NEW_BRANCH_NAMED, and pushing the changes to it"
+          git checkout -b $TO_NEW_BRANCH_NAMED
         fi
-        
+
+        git add .
+        # Check if there are any changes
+        if [ "$TO_NEW_BRANCH_NAMED" == "false" ]; then
+          if git diff --cached --exit-code; then
+            echo "No changes to commit."
+            exit 0
+          fi
+        fi
+
         git commit -m "$COMMIT_MESSAGE"
         git push
       shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@ fossa*.zip
 
 # Ignore *all* pickled files, we should *never* put these in git.
 *.pkl
+
+
+# https://github.com/google-github-actions/auth/issues/497
+gha-creds-*.json


### PR DESCRIPTION
**Scope of work done**

Needed for: https://github.com/Snapchat/GiGL/pull/141

Providing ability for the `commit-and-push` action to have a new param `to_new_branch_named` specific.
If specific, it will push the changes to this new branch.

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

This was tested on the following branch: https://github.com/Snapchat/GiGL/pull/141
w/ resulting branch push here: https://github.com/Snapchat/GiGL/pull/150

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
