### PR TITLE
Enable specifying larger disks for vai training

### DIFF
--- a/python/gigl/common/services/vertex_ai.py
+++ b/python/gigl/common/services/vertex_ai.py
@@ -99,7 +99,7 @@ class VertexAiJobConfig:
     accelerator_count: int = 0
     replica_count: int = 1
     boot_disk_type: str = "pd-ssd"  # Persistent Disk SSD
-    boot_disk_size_gb: int = 500  # Default disk size in GB
+    boot_disk_size_gb: int = 100  # Default disk size in GB
     labels: Optional[Dict[str, str]] = None
     timeout_s: Optional[
         int

--- a/python/gigl/common/services/vertex_ai.py
+++ b/python/gigl/common/services/vertex_ai.py
@@ -67,9 +67,9 @@ from typing import Dict, Final, List, Optional
 from google.cloud import aiplatform
 from google.cloud.aiplatform_v1.types import (
     ContainerSpec,
+    DiskSpec,
     MachineSpec,
     WorkerPoolSpec,
-    DiskSpec,
     env_var,
 )
 
@@ -195,7 +195,7 @@ class VertexAIService:
             machine_spec=machine_spec,
             container_spec=container_spec,
             disk_spec=disk_spec,
-            replica_count=1
+            replica_count=1,
         )
 
         worker_pool_specs: List[WorkerPoolSpec] = [leader_worker_spec]


### PR DESCRIPTION
Some ongoing efforts require training workers to have ample disk space such that local model checkpoints / assets can be saved.  Current VAI job config doesn't support this, hence this change. We can't flexibly specify this resource in configs today, hence making the change here.

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
