### PR TITLE
Fix Fanout in Dataloaders

### DIFF
--- a/python/gigl/distributed/dist_ablp_neighborloader.py
+++ b/python/gigl/distributed/dist_ablp_neighborloader.py
@@ -311,20 +311,9 @@ class DistABLPLoader(DistLoader):
             )
         )
 
-        if dataset.get_edge_types() is not None:
-            num_neighbors = patch_fanout_for_sampling(
-                dataset.get_edge_types(), num_neighbors
-            )
-            hops = len(next(iter(num_neighbors.values())))
-            if not all(len(fanout) == hops for fanout in num_neighbors.values()):
-                raise ValueError(
-                    f"num_neighbors must be a dict of edge types with the same number of hops. Received: {num_neighbors}"
-                )
-        else:
-            if isinstance(num_neighbors, abc.Mapping):
-                raise ValueError(
-                    "When dataset is homogeneous, the num_neighbors field cannot be a dictionary."
-                )
+        num_neighbors = patch_fanout_for_sampling(
+            dataset.get_edge_types(), num_neighbors
+        )
 
         curr_process_nodes = shard_nodes_by_process(
             input_nodes=anchor_node_ids,

--- a/python/gigl/distributed/dist_ablp_neighborloader.py
+++ b/python/gigl/distributed/dist_ablp_neighborloader.py
@@ -311,20 +311,20 @@ class DistABLPLoader(DistLoader):
             )
         )
 
-        # TODO(kmonte): stop setting fanout for positive/negative once GLT sampling is fixed.
-        num_neighbors = patch_fanout_for_sampling(
-            dataset.get_edge_types(), num_neighbors
-        )
-
-        if num_neighbors.keys() != dataset.graph.keys():
-            raise ValueError(
-                f"num_neighbors must have all edge types in the graph, received: {num_neighbors.keys()} with for graph with edge types {dataset.graph.keys()}"
+        if dataset.get_edge_types() is not None:
+            num_neighbors = patch_fanout_for_sampling(
+                dataset.get_edge_types(), num_neighbors
             )
-        hops = len(next(iter(num_neighbors.values())))
-        if not all(len(fanout) == hops for fanout in num_neighbors.values()):
-            raise ValueError(
-                f"num_neighbors must be a dict of edge types with the same number of hops. Received: {num_neighbors}"
-            )
+            hops = len(next(iter(num_neighbors.values())))
+            if not all(len(fanout) == hops for fanout in num_neighbors.values()):
+                raise ValueError(
+                    f"num_neighbors must be a dict of edge types with the same number of hops. Received: {num_neighbors}"
+                )
+        else:
+            if isinstance(num_neighbors, abc.Mapping):
+                raise ValueError(
+                    "When dataset is homogeneous, the num_neighbors field cannot be a dictionary."
+                )
 
         curr_process_nodes = shard_nodes_by_process(
             input_nodes=anchor_node_ids,

--- a/python/gigl/distributed/distributed_neighborloader.py
+++ b/python/gigl/distributed/distributed_neighborloader.py
@@ -202,25 +202,6 @@ class DistNeighborLoader(DistLoader):
                 )
             input_nodes = dataset.node_ids
 
-        if isinstance(num_neighbors, abc.Mapping):
-            # TODO(kmonte): We should enable this. We have two blockers:
-            # 1. We need to treat `EdgeType` as a proper tuple, not the GiGL`EdgeType`.
-            # 2. There are (likely) some GLT bugs around https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_neighbor_sampler.py#L317-L318
-            # Where if num_neighbors is a dict then we index into it improperly.
-            if not isinstance(dataset.graph, abc.Mapping):
-                raise ValueError(
-                    "When num_neighbors is a dict, the dataset must be heterogeneous."
-                )
-            if num_neighbors.keys() != dataset.graph.keys():
-                raise ValueError(
-                    f"num_neighbors must have all edge types in the graph, received: {num_neighbors.keys()} with for graph with edge types {dataset.graph.keys()}"
-                )
-            hops = len(next(iter(num_neighbors.values())))
-            if not all(len(fanout) == hops for fanout in num_neighbors.values()):
-                raise ValueError(
-                    f"num_neighbors must be a dict of edge types with the same number of hops. Received: {num_neighbors}"
-                )
-
         # Determines if the node ids passed in are heterogeneous or homogeneous.
         self._is_labeled_heterogeneous = False
         if isinstance(input_nodes, torch.Tensor):
@@ -235,9 +216,6 @@ class DistNeighborLoader(DistLoader):
                 ):
                     node_type = DEFAULT_HOMOGENEOUS_NODE_TYPE
                     self._is_labeled_heterogeneous = True
-                    num_neighbors = patch_fanout_for_sampling(
-                        dataset.get_edge_types(), num_neighbors
-                    )
                 else:
                     raise ValueError(
                         f"For heterogeneous datasets, input_nodes must be a tuple of (node_type, node_ids) OR if it is a labeled homogeneous dataset, input_nodes may be a torch.Tensor. Received node types: {dataset.node_ids.keys()}"
@@ -249,9 +227,21 @@ class DistNeighborLoader(DistLoader):
             assert isinstance(
                 dataset.node_ids, abc.Mapping
             ), "Dataset must be heterogeneous if provided input nodes are a tuple."
+
+        if dataset.get_edge_types() is not None:
             num_neighbors = patch_fanout_for_sampling(
                 dataset.get_edge_types(), num_neighbors
             )
+            hops = len(next(iter(num_neighbors.values())))
+            if not all(len(fanout) == hops for fanout in num_neighbors.values()):
+                raise ValueError(
+                    f"num_neighbors must be a dict of edge types with the same number of hops. Received: {num_neighbors}"
+                )
+        else:
+            if isinstance(num_neighbors, abc.Mapping):
+                raise ValueError(
+                    "When dataset is homogeneous, the num_neighbors field cannot be a dictionary."
+                )
 
         curr_process_nodes = shard_nodes_by_process(
             input_nodes=node_ids,

--- a/python/gigl/distributed/distributed_neighborloader.py
+++ b/python/gigl/distributed/distributed_neighborloader.py
@@ -228,20 +228,9 @@ class DistNeighborLoader(DistLoader):
                 dataset.node_ids, abc.Mapping
             ), "Dataset must be heterogeneous if provided input nodes are a tuple."
 
-        if dataset.get_edge_types() is not None:
-            num_neighbors = patch_fanout_for_sampling(
-                dataset.get_edge_types(), num_neighbors
-            )
-            hops = len(next(iter(num_neighbors.values())))
-            if not all(len(fanout) == hops for fanout in num_neighbors.values()):
-                raise ValueError(
-                    f"num_neighbors must be a dict of edge types with the same number of hops. Received: {num_neighbors}"
-                )
-        else:
-            if isinstance(num_neighbors, abc.Mapping):
-                raise ValueError(
-                    "When dataset is homogeneous, the num_neighbors field cannot be a dictionary."
-                )
+        num_neighbors = patch_fanout_for_sampling(
+            dataset.get_edge_types(), num_neighbors
+        )
 
         curr_process_nodes = shard_nodes_by_process(
             input_nodes=node_ids,

--- a/python/gigl/distributed/utils/neighborloader.py
+++ b/python/gigl/distributed/utils/neighborloader.py
@@ -47,10 +47,10 @@ def patch_fanout_for_sampling(
         should_broadcast_fanout = True
         num_neighbors = {}
     else:
-        missing_edge_types = set(num_neighbors.keys()) - set(edge_types)
-        if missing_edge_types:
+        extra_edge_types = set(num_neighbors.keys()) - set(edge_types)
+        if extra_edge_types:
             raise ValueError(
-                f"Found extra edge types {missing_edge_types} in fanout which is not in dataset edge types {edge_types}."
+                f"Found extra edge types {extra_edge_types} in fanout which is not in dataset edge types {edge_types}."
             )
         original_fanout = next(iter(num_neighbors.values()))
         should_broadcast_fanout = False

--- a/python/gigl/distributed/utils/neighborloader.py
+++ b/python/gigl/distributed/utils/neighborloader.py
@@ -24,7 +24,7 @@ def patch_fanout_for_sampling(
     - For all label edge types, sets the fanout to be zero.
     - For all other edge types, if the fanout is not specified, uses the original fanout.
 
-    Note that if fanout is provided as a dict, all edges must be present.
+    Note that if fanout is provided as a dict, the keys (edges) in the fanout must be in `edge_types`.
 
     We add this because the existing sampling logic (below) makes strict assumptions that we need to conform to.
     https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_neighbor_sampler.py#L317-L318

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -759,8 +759,8 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
                 fanout=[2, 2],
             ),
             param(
-                "Range-based partitioning, list fanout",
-                partitioner_class=DistPartitioner,
+                "Range-based partitioning, dict fanout",
+                partitioner_class=DistRangePartitioner,
                 fanout={
                     EdgeType(NodeType("user"), Relation("to"), NodeType("story")): [
                         2,

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -1,6 +1,6 @@
 import unittest
 from collections import abc
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 import torch.multiprocessing as mp
@@ -365,6 +365,7 @@ def _run_toy_heterogeneous_ablp(
     dataset: DistLinkPredictionDataset,
     context: DistributedContext,
     supervision_edge_types: list[EdgeType],
+    fanout: Union[list[int], dict[EdgeType, list[int]]],
 ):
     anchor_node_type = NodeType("user")
     supervision_node_type = NodeType("story")
@@ -374,17 +375,15 @@ def _run_toy_heterogeneous_ablp(
     supervision_edge_type = supervision_edge_types[0]
     assert isinstance(dataset.train_node_ids, dict)
     assert isinstance(dataset.graph, dict)
-    fanout = [2, 2]
     labeled_edge_type = EdgeType(
         supervision_node_type, Relation("to_gigl_positive"), anchor_node_type
     )
-    num_neighbors = {edge_type: fanout for edge_type in dataset.graph.keys()}
     all_positive_supervision_nodes, all_anchor_nodes, _, _ = dataset.graph[
         labeled_edge_type
     ].topo.to_coo()
     loader = DistABLPLoader(
         dataset=dataset,
-        num_neighbors=num_neighbors,
+        num_neighbors=fanout,
         input_nodes=(anchor_node_type, dataset.train_node_ids[anchor_node_type]),
         context=context,
         local_process_rank=0,
@@ -749,11 +748,38 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
 
     @parameterized.expand(
         [
-            param("Tensor-based partitioning", partitioner_class=DistPartitioner),
-            param("Range-based partitioning", partitioner_class=DistRangePartitioner),
+            param(
+                "Tensor-based partitioning, list fanout",
+                partitioner_class=DistPartitioner,
+                fanout=[2, 2],
+            ),
+            param(
+                "Range-based partitioning, list fanout",
+                partitioner_class=DistRangePartitioner,
+                fanout=[2, 2],
+            ),
+            param(
+                "Range-based partitioning, list fanout",
+                partitioner_class=DistPartitioner,
+                fanout={
+                    EdgeType(NodeType("user"), Relation("to"), NodeType("story")): [
+                        2,
+                        2,
+                    ],
+                    EdgeType(NodeType("story"), Relation("to"), NodeType("user")): [
+                        2,
+                        2,
+                    ],
+                },
+            ),
         ]
     )
-    def test_toy_heterogeneous_ablp(self, _, partitioner_class: type[DistPartitioner]):
+    def test_toy_heterogeneous_ablp(
+        self,
+        _,
+        partitioner_class: type[DistPartitioner],
+        fanout: Union[list[int], dict[EdgeType, list[int]]],
+    ):
         toy_heterogeneous_supervised_info = get_mocked_dataset_artifact_metadata()[
             HETEROGENEOUS_TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO.name
         ]
@@ -791,7 +817,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
 
         mp.spawn(
             fn=_run_toy_heterogeneous_ablp,
-            args=(dataset, self._context, supervision_edge_types),
+            args=(dataset, self._context, supervision_edge_types, fanout),
         )
 
 

--- a/python/tests/unit/distributed/utils/neighborloader_test.py
+++ b/python/tests/unit/distributed/utils/neighborloader_test.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Optional, Union
 
 import torch
 from parameterized import param, parameterized
@@ -53,7 +54,7 @@ class LoaderUtilsTest(unittest.TestCase):
     @parameterized.expand(
         [
             param(
-                "Test set_labeled_edge_type on num_neighbors dict with labeled edge type",
+                "Test patch_fanout_for_sampling on num_neighbors dict with labeled edge type",
                 edge_types=[_U2I_EDGE_TYPE, _I2U_EDGE_TYPE, _LABELED_EDGE_TYPE],
                 num_neighbors={
                     _U2I_EDGE_TYPE: [2, 7],
@@ -66,16 +67,7 @@ class LoaderUtilsTest(unittest.TestCase):
                 },
             ),
             param(
-                "Test set_labeled_edge_type on num_neighbors dict with no labeled edge type",
-                edge_types=[_U2I_EDGE_TYPE, _I2U_EDGE_TYPE],
-                num_neighbors={_U2I_EDGE_TYPE: [2, 7]},
-                expected_num_neighbors={
-                    _U2I_EDGE_TYPE: [2, 7],
-                    _I2U_EDGE_TYPE: [2, 7],
-                },
-            ),
-            param(
-                "Test set_labeled_edge_type on num_neighbors list",
+                "Test patch_fanout_for_sampling on num_neighbors list",
                 edge_types=[_U2I_EDGE_TYPE, _I2U_EDGE_TYPE, _LABELED_EDGE_TYPE],
                 num_neighbors=[1, 3],
                 expected_num_neighbors={
@@ -84,17 +76,62 @@ class LoaderUtilsTest(unittest.TestCase):
                     _LABELED_EDGE_TYPE: [0, 0],
                 },
             ),
+            param(
+                "Test patch_fanout_for_sampling on homogeneous dataset",
+                edge_types=None,
+                num_neighbors=[1, 3],
+                expected_num_neighbors=[1, 3],
+            ),
         ]
     )
     def test_patch_neighbors_with_zero_fanout(
         self,
         _,
-        edge_types: list[EdgeType],
-        num_neighbors: dict[EdgeType, list[int]],
-        expected_num_neighbors: dict[EdgeType, list[int]],
+        edge_types: Optional[list[EdgeType]],
+        num_neighbors: Union[list[int], dict[EdgeType, list[int]]],
+        expected_num_neighbors: Union[list[int], dict[EdgeType, list[int]]],
     ):
         num_neighbors = patch_fanout_for_sampling(edge_types, num_neighbors)
         self.assertEqual(num_neighbors, expected_num_neighbors)
+
+    @parameterized.expand(
+        [
+            param(
+                "Test failure when homogeneous dataset has heterogeneous num_neighbors",
+                edge_types=None,
+                num_neighbors={_U2I_EDGE_TYPE: [2, 7]},
+            ),
+            param(
+                "Test failure when heterogeneous dataset and num_neighbors has different number of hops per edge type",
+                edge_types=[_U2I_EDGE_TYPE, _I2U_EDGE_TYPE],
+                num_neighbors={
+                    _U2I_EDGE_TYPE: [2, 7, 10],
+                    _I2U_EDGE_TYPE: [3, 4],
+                },
+            ),
+            param(
+                "Test failure for heterogeneous dataset and num_neighbors when there is a missing edge type in num_neighbors from the dataset",
+                edge_types=[_U2I_EDGE_TYPE, _I2U_EDGE_TYPE],
+                num_neighbors={_U2I_EDGE_TYPE: [2, 7]},
+            ),
+            param(
+                "Test failure for heterogeneous dataset and num_neighbors when there is an extra edge type in num_neighbors from the dataset",
+                edge_types=[_I2U_EDGE_TYPE],
+                num_neighbors={
+                    _U2I_EDGE_TYPE: [2, 7, 10],
+                    _I2U_EDGE_TYPE: [3, 4],
+                },
+            ),
+        ]
+    )
+    def test_patch_neighbors_failure(
+        self,
+        _,
+        edge_types: Optional[list[EdgeType]],
+        num_neighbors: Union[list[int], dict[EdgeType, list[int]]],
+    ):
+        with self.assertRaises(ValueError):
+            num_neighbors = patch_fanout_for_sampling(edge_types, num_neighbors)
 
     def test_pyg_to_homogeneous(self):
         data = HeteroData()

--- a/python/tests/unit/distributed/utils/neighborloader_test.py
+++ b/python/tests/unit/distributed/utils/neighborloader_test.py
@@ -54,11 +54,27 @@ class LoaderUtilsTest(unittest.TestCase):
     @parameterized.expand(
         [
             param(
-                "Test patch_fanout_for_sampling on num_neighbors dict with labeled edge type",
+                "Test patch_fanout_for_sampling on num_neighbors dict with labeled edge type in dataset",
                 edge_types=[_U2I_EDGE_TYPE, _I2U_EDGE_TYPE, _LABELED_EDGE_TYPE],
                 num_neighbors={
                     _U2I_EDGE_TYPE: [2, 7],
                     _I2U_EDGE_TYPE: [3, 4],
+                },
+                expected_num_neighbors={
+                    _U2I_EDGE_TYPE: [2, 7],
+                    _I2U_EDGE_TYPE: [3, 4],
+                    _LABELED_EDGE_TYPE: [0, 0],
+                },
+            ),
+            param(
+                "Test patch_fanout_for_sampling on num_neighbors dict with labeled edge type in dataset and fanout",
+                edge_types=[_U2I_EDGE_TYPE, _I2U_EDGE_TYPE, _LABELED_EDGE_TYPE],
+                num_neighbors={
+                    _U2I_EDGE_TYPE: [2, 7],
+                    _I2U_EDGE_TYPE: [3, 4],
+                    # If labeled edge type fanout is provided by the user, we assume it was by accident, since users shouldn't be aware of this injected edge type,
+                    # and still set the fanout of it to be 0.
+                    _LABELED_EDGE_TYPE: [2, 2],
                 },
                 expected_num_neighbors={
                     _U2I_EDGE_TYPE: [2, 7],
@@ -97,12 +113,12 @@ class LoaderUtilsTest(unittest.TestCase):
     @parameterized.expand(
         [
             param(
-                "Test failure when homogeneous dataset has heterogeneous num_neighbors",
+                "Test when homogeneous dataset has heterogeneous num_neighbors",
                 edge_types=None,
                 num_neighbors={_U2I_EDGE_TYPE: [2, 7]},
             ),
             param(
-                "Test failure when heterogeneous dataset and num_neighbors has different number of hops per edge type",
+                "Test when heterogeneous dataset and num_neighbors has different number of hops per edge type",
                 edge_types=[_U2I_EDGE_TYPE, _I2U_EDGE_TYPE],
                 num_neighbors={
                     _U2I_EDGE_TYPE: [2, 7, 10],
@@ -110,12 +126,12 @@ class LoaderUtilsTest(unittest.TestCase):
                 },
             ),
             param(
-                "Test failure for heterogeneous dataset and num_neighbors when there is a missing edge type in num_neighbors from the dataset",
+                "Test for heterogeneous dataset and num_neighbors when there is a missing edge type in num_neighbors from the dataset",
                 edge_types=[_U2I_EDGE_TYPE, _I2U_EDGE_TYPE],
                 num_neighbors={_U2I_EDGE_TYPE: [2, 7]},
             ),
             param(
-                "Test failure for heterogeneous dataset and num_neighbors when there is an extra edge type in num_neighbors from the dataset",
+                "Test for heterogeneous dataset and num_neighbors when there is an extra edge type in num_neighbors from the dataset",
                 edge_types=[_I2U_EDGE_TYPE],
                 num_neighbors={
                     _U2I_EDGE_TYPE: [2, 7, 10],


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- In the case where num_neighbors is a dict, we were previously checking if the edge types of the dataset is equal to the edge types of num_neighbors **before** patching it with the positive label edge types, resulting in failure. This order should be switched, which is patched in this PR
- Additionally, we don't call patching if dataset.get_edge_types() is None, indicating a homogeneous dataset.
- Also restructures the ABLPNeighborLoader and DistNeighborLoader to be more similar in the order where they patch fanout.
- Update `patch_subgraph_from_fanout` to not infer fanout for non-label edge types if provided fanout is a dictionary
- Update tests for `patch_subgraph_from_fanout` utility
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
