### PR TITLE
Type ACT_MAP

### DIFF
--- a/python/gigl/src/common/constants/training.py
+++ b/python/gigl/src/common/constants/training.py
@@ -1,6 +1,8 @@
+from typing import Callable, Final
+
 from torch.nn import functional as F
 
-ACT_MAP = {
+ACT_MAP: Final[dict[str, Callable]] = {
     "relu": F.relu,
     "elu": F.elu,
     "leakyrelu": F.leaky_relu,
@@ -9,4 +11,5 @@ ACT_MAP = {
     "gelu": F.gelu,
     "silu": F.silu,
 }
-DEFAULT_NUM_GNN_HOPS = 2
+
+DEFAULT_NUM_GNN_HOPS: Final[int] = 2


### PR DESCRIPTION
Doing this so that we can correctly infer the types downstream. 

Prior to this change mypy saw this as a `builtins.dict[builtins.str, builtins.function]` which somehow would make `LinkPredictionDecoder` [`1] unhappy because it wants a `Callable`, not a `function`, whatever the difference there actually is.

[1]: https://github.com/Snapchat/GiGL/blob/kmonte/type-act/python/gigl/src/common/models/layers/decoder.py#L24-L25