### PR TITLE
Add dataflow job timeout

### DIFF
--- a/python/gigl/src/common/utils/dataflow.py
+++ b/python/gigl/src/common/utils/dataflow.py
@@ -20,7 +20,7 @@ from gigl.src.common.types.dataflow_job_options import CommonOptions
 
 logger = Logger()
 
-MAX_WORKFLOW_RUNTIME_WALLTIME_SECONDS = 60 # 24 * 60 * 60 # 24 hours
+MAX_WORKFLOW_RUNTIME_WALLTIME_SECONDS = 24 * 60 * 60 # 24 hours
 
 def get_sanitized_dataflow_job_name(name: str) -> str:
     name = name.lower()

--- a/python/gigl/src/common/utils/dataflow.py
+++ b/python/gigl/src/common/utils/dataflow.py
@@ -20,6 +20,7 @@ from gigl.src.common.types.dataflow_job_options import CommonOptions
 
 logger = Logger()
 
+MAX_WORKFLOW_RUNTIME_WALLTIME_SECONDS = 60 # 24 * 60 * 60 # 24 hours
 
 def get_sanitized_dataflow_job_name(name: str) -> str:
     name = name.lower()
@@ -113,14 +114,16 @@ def init_beam_pipeline_options(
     # i.e. simply setting `num_workers` in `PipelineOptions`, the dataflow service still may downscale to 1 worker.
     # vs. setting `min_num_workers` in `dataflow_service_options` explicitly will ensure that the service will not downscale below
     # that number.
+    dataflow_service_options = google_cloud_options.dataflow_service_options or []
     if kwargs.get("num_workers"):
         num_workers = kwargs.get("num_workers")
         logger.info(
             f"Setting `min_num_workers` for Dataflow explicitly to {num_workers}"
         )
-        dataflow_service_options = google_cloud_options.dataflow_service_options or []
         dataflow_service_options.append(f"min_num_workers={num_workers}")
-        google_cloud_options.dataflow_service_options = dataflow_service_options
+
+    dataflow_service_options.append(f"max_workflow_runtime_walltime_seconds={MAX_WORKFLOW_RUNTIME_WALLTIME_SECONDS}")
+    google_cloud_options.dataflow_service_options = dataflow_service_options
 
     google_cloud_options.service_account_email = (
         google_cloud_options.service_account_email

--- a/python/gigl/src/common/utils/dataflow.py
+++ b/python/gigl/src/common/utils/dataflow.py
@@ -20,7 +20,8 @@ from gigl.src.common.types.dataflow_job_options import CommonOptions
 
 logger = Logger()
 
-MAX_WORKFLOW_RUNTIME_WALLTIME_SECONDS = 24 * 60 * 60 # 24 hours
+MAX_WORKFLOW_RUNTIME_WALLTIME_SECONDS = 24 * 60 * 60  # 24 hours
+
 
 def get_sanitized_dataflow_job_name(name: str) -> str:
     name = name.lower()
@@ -122,7 +123,9 @@ def init_beam_pipeline_options(
         )
         dataflow_service_options.append(f"min_num_workers={num_workers}")
 
-    dataflow_service_options.append(f"max_workflow_runtime_walltime_seconds={MAX_WORKFLOW_RUNTIME_WALLTIME_SECONDS}")
+    dataflow_service_options.append(
+        f"max_workflow_runtime_walltime_seconds={MAX_WORKFLOW_RUNTIME_WALLTIME_SECONDS}"
+    )
     google_cloud_options.dataflow_service_options = dataflow_service_options
 
     google_cloud_options.service_account_email = (


### PR DESCRIPTION
**Scope of work done**

Dataflow jobs can sometimes run indefinitely due to some issues, this guards against it by adding a shorter max TTL on jobs.

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

Ran a [manual test](https://console.cloud.google.com/dataflow/jobs/us-central1/2025-07-17_14_55_28-27828424271130329;mainTab=JOB_METRICS;bottomTab=JOB_LOGS;expandBottomPanel=true;logsSeverity=ERROR;graphView=0?project=external-snap-ci-github-gigl&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22))&inv=1&invt=Ab3G5A) w/  `MAX_WORKFLOW_RUNTIME_WALLTIME_SECONDS = 60`

Notably, the job started @ 
July 17, 2025 at 2:55:28 PM PDT

Starting 1 workers in us-central1... @
2025-07-17 14:55:35.053 PDT 

And the job cancelled itself @
2025-07-17 2:59:03.386 PDT

The extra 3 minute delta can be allotted to provisioning instance, setting up the instance, et al.


***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
