### PR TITLE
Allow EmbeddingExporter to export locally

### DIFF
--- a/python/gigl/src/common/utils/file_loader.py
+++ b/python/gigl/src/common/utils/file_loader.py
@@ -1,7 +1,8 @@
+import shutil
 import tempfile
 from collections.abc import Mapping
 from tempfile import _TemporaryFileWrapper as TemporaryFileWrapper  # type: ignore
-from typing import Dict, Optional, Sequence, Tuple, Type, Union, cast
+from typing import IO, AnyStr, Dict, Optional, Sequence, Tuple, Type, Union, cast
 
 from gigl.common import GcsUri, HttpUri, LocalUri, Uri, UriFactory
 from gigl.common.logger import Logger
@@ -198,6 +199,32 @@ class FileLoader:
         else:
             logger.warning(f"Unsupported uri_map_schema: {uri_map_schema}")
             raise TypeError(self.__unsupported_uri_message)
+
+    def load_from_filelike(self, uri: Uri, filelike: IO[AnyStr]) -> None:
+        """
+        Load a file from a file-like object into the specified URI.
+
+        Args:
+            uri (Uri): The URI to load the file into.
+            filelike (IO[AnyStr]): A file-like object containing the data to be loaded.
+        """
+        if isinstance(uri, GcsUri):
+            self.__gcs_utils.upload_from_filelike(gcs_path=uri, filelike=filelike)
+        elif isinstance(uri, LocalUri):
+            ptr = filelike.tell()
+            first = filelike.read(1)
+            filelike.seek(ptr)  # Reset the file pointer after reading
+            if isinstance(first, bytes):
+                with open(uri.uri, "wb") as dest:
+                    shutil.copyfileobj(filelike, dest)
+            else:
+                with open(uri.uri, "w", encoding="utf-8") as dest:
+                    shutil.copyfileobj(filelike, dest)
+
+        else:
+            raise NotImplementedError(
+                f"Cannot load file from buffer to URI {uri.uri} of type {type(uri)}; {self.__unsupported_uri_message}"
+            )
 
     def load_to_temp_file(
         self,

--- a/python/tests/integration/common/file_loader_test.py
+++ b/python/tests/integration/common/file_loader_test.py
@@ -1,7 +1,11 @@
+import io
 import os
+import tempfile
 import unittest
 import uuid
 from typing import Dict
+
+from parameterized import param, parameterized
 
 import gigl.common.utils.local_fs as local_fs
 from gigl.common import GcsUri, HttpUri, LocalUri, Uri
@@ -322,3 +326,64 @@ class FileLoaderTest(unittest.TestCase):
         # Ensure both files are deleted
         self.assertFalse(file_loader.does_uri_exist(uri=tmp_local_file))
         self.assertFalse(file_loader.does_uri_exist(uri=tmp_gcs_file))
+
+    @parameterized.expand(
+        [
+            param(
+                "local_bytesio_buffer",
+                filelike=io.BytesIO(b"hello world"),
+                expected_content=b"world",
+                expected_mode="rb",
+            ),
+            param(
+                "local_stringio_buffer",
+                filelike=io.StringIO("hello world"),
+                expected_content="world",
+                expected_mode="r",
+            ),
+        ]
+    )
+    def test_load_from_filelike_local(
+        self, _, filelike, expected_content, expected_mode
+    ):
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            tmp_path = tmp.name
+            uri = LocalUri(tmp_path)
+            loader = FileLoader()
+            # Move pointer to middle, write from there, check only written from pointer
+            filelike.seek(6)
+            loader.load_from_filelike(uri, filelike)
+            with open(
+                tmp_path,
+                expected_mode,
+                encoding=None if expected_mode == "rb" else "utf-8",
+            ) as f:
+                result = f.read()
+            self.assertEqual(result, expected_content)
+
+    @parameterized.expand(
+        [
+            param(
+                "gcs_bytesio_buffer",
+                io.BytesIO(b"gcs test bytes"),
+                "gcs test bytes",  # Note our tests just check that this is a string...
+            ),
+            param(
+                "gcs_stringio_buffer",
+                io.StringIO("gcs test string"),
+                "gcs test string",
+            ),
+        ]
+    )
+    def test_load_from_filelike_gcs(self, _, filelike, expected_content):
+        uri = GcsUri.join(
+            self.gcs_test_asset_directory,
+            f"upload_from_likelike/{uuid.uuid4().hex}/test_file.txt",
+        )
+        loader = FileLoader()
+        loader.load_from_filelike(uri, filelike)
+
+        gcs_utils = GcsUtils()
+        # Read the content back from GCS
+        content = gcs_utils.read_from_gcs(uri)
+        self.assertEqual(content, expected_content)

--- a/python/tests/unit/common/data/export_test.py
+++ b/python/tests/unit/common/data/export_test.py
@@ -20,6 +20,7 @@ from gigl.common.utils.retry import RetriesFailedException
 class TestEmbeddingExporter(unittest.TestCase):
     def setUp(self):
         super().setUp()
+        self.maxDiff = 1_000  # Set a high maxDiff to see full error messages
         self._temp_dir = tempfile.TemporaryDirectory()
         self.local_export_dir = Path(self._temp_dir.name) / uuid4().hex / "local-export"
         self.local_export_dir.mkdir(parents=True, exist_ok=True)
@@ -116,8 +117,8 @@ class TestEmbeddingExporter(unittest.TestCase):
         exporter.flush_embeddings()
 
         # Assertions
-        written_files = list(
-            map(UriFactory.create_uri, self.local_export_dir.glob("*"))
+        written_files = sorted(
+            list(map(UriFactory.create_uri, self.local_export_dir.glob("*")))
         )
         self.assertEqual(
             written_files,
@@ -160,8 +161,8 @@ class TestEmbeddingExporter(unittest.TestCase):
                 exporter.add_embedding(id_batch, embedding_batch, embedding_type)
 
         # Assertions
-        written_files = list(
-            map(UriFactory.create_uri, self.local_export_dir.glob("*"))
+        written_files = sorted(
+            list(map(UriFactory.create_uri, self.local_export_dir.glob("*")))
         )
         self.assertEqual(
             written_files,

--- a/python/tests/unit/common/data/export_test.py
+++ b/python/tests/unit/common/data/export_test.py
@@ -118,7 +118,8 @@ class TestEmbeddingExporter(unittest.TestCase):
 
         # Assertions
         written_files = sorted(
-            list(map(UriFactory.create_uri, self.local_export_dir.glob("*")))
+            list(map(UriFactory.create_uri, self.local_export_dir.glob("*"))),
+            key=lambda x: x.uri,
         )
         self.assertEqual(
             written_files,
@@ -162,7 +163,8 @@ class TestEmbeddingExporter(unittest.TestCase):
 
         # Assertions
         written_files = sorted(
-            list(map(UriFactory.create_uri, self.local_export_dir.glob("*")))
+            list(map(UriFactory.create_uri, self.local_export_dir.glob("*"))),
+            key=lambda x: x.uri,
         )
         self.assertEqual(
             written_files,


### PR DESCRIPTION
Enable `EmbeddingExporter` to take in any type of URI for exporting to.

Doing this so our KDD walkthrough minimally requires GCP.

Also made the unit tests have a lot less mocks now that we can test against local files :)

The GCS path should still be tested in `python/tests/integration/common/data/export_test.py`.

Note that `load_embeddings_to_bigquery` requires a GCS uri so we can't migrate that, so we can just dump to dataframe or something for our examples.