### PR TITLE
Revert "Remove unnecessary distributed calls in Dataloader setup (#140)"

### DIFF
--- a/examples/link_prediction/heterogeneous_inference.py
+++ b/examples/link_prediction/heterogeneous_inference.py
@@ -28,6 +28,7 @@ import torch
 import torch.distributed
 import torch.multiprocessing as mp
 from examples.link_prediction.models import init_example_gigl_heterogeneous_model
+from graphlearn_torch.distributed import barrier, shutdown_rpc
 
 import gigl.distributed
 import gigl.distributed.utils
@@ -200,7 +201,7 @@ def _inference_process(
     # We add a barrier here so that all machines and processes have initialized their dataloader at the start of the inference loop. Otherwise, on-the-fly subgraph
     # sampling may fail.
 
-    torch.distributed.barrier()
+    barrier()
 
     t = time.time()
     data_loading_start_time = time.time()
@@ -266,16 +267,17 @@ def _inference_process(
     # machine + process -- otherwise we may fail on processes which are still doing on-the-fly subgraph sampling. We then call `gc.collect()` to cleanup the memory
     # used by the data_loader on the current machine.
 
-    torch.distributed.barrier()
+    barrier()
 
     del data_loader
     gc.collect()
 
-    torch.distributed.destroy_process_group()
-
     logger.info(
         f"--- All machines local rank {local_rank} finished inference for node type {inference_node_type}. Deleted data loader"
     )
+
+    # Clean up for a graceful exit
+    shutdown_rpc()
 
 
 def _run_example_inference(

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -27,6 +27,7 @@ from typing import Dict
 import torch
 import torch.multiprocessing as mp
 from examples.link_prediction.models import init_example_gigl_homogeneous_model
+from graphlearn_torch.distributed import barrier, shutdown_rpc
 
 import gigl.distributed
 import gigl.distributed.utils
@@ -192,7 +193,7 @@ def _inference_process(
     # We add a barrier here so that all machines and processes have initialized their dataloader at the start of the inference loop. Otherwise, on-the-fly subgraph
     # sampling may fail.
 
-    torch.distributed.barrier()
+    barrier()
 
     t = time.time()
     data_loading_start_time = time.time()
@@ -254,16 +255,17 @@ def _inference_process(
     # machine + process -- otherwise we may fail on processes which are still doing on-the-fly subgraph sampling. We then call `gc.collect()` to cleanup the memory
     # used by the data_loader on the current machine.
 
-    torch.distributed.barrier()
+    barrier()
 
     del data_loader
     gc.collect()
 
-    torch.distributed.destroy_process_group()
-
     logger.info(
         f"--- All machines local rank {local_rank} finished inference. Deleted data loader"
     )
+
+    # Clean up for a graceful exit
+    shutdown_rpc()
 
 
 def _run_example_inference(

--- a/python/gigl/distributed/dist_ablp_neighborloader.py
+++ b/python/gigl/distributed/dist_ablp_neighborloader.py
@@ -159,8 +159,8 @@ class DistABLPLoader(DistLoader):
         # https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_loader.py#L125C1-L126C1
         self._shutdowned = True
 
-        machine_world_size: int
-        machine_rank: int
+        node_world_size: int
+        node_rank: int
         rank: int
         world_size: int
         local_rank: int
@@ -178,13 +178,13 @@ class DistABLPLoader(DistLoader):
             ), "context: DistributedContext provided, so local_process_rank must be provided."
 
             master_ip_address = context.main_worker_ip_address
-            machine_world_size = context.global_world_size
-            machine_rank = context.global_rank
+            node_world_size = context.global_world_size
+            node_rank = context.global_rank
             local_world_size = local_process_world_size
             local_rank = local_process_rank
 
-            rank = machine_rank * local_world_size + local_rank
-            world_size = machine_world_size * local_world_size
+            rank = node_rank * local_world_size + local_rank
+            world_size = node_world_size * local_world_size
 
             if not torch.distributed.is_initialized():
                 logger.info(
@@ -220,9 +220,9 @@ class DistABLPLoader(DistLoader):
                         + f"count_ranks_per_ip_address = {count_ranks_per_ip_address}"
                     )
 
-            machine_world_size = len(count_ranks_per_ip_address)
+            node_world_size = len(count_ranks_per_ip_address)
             local_rank = rank % local_world_size
-            machine_rank = rank // local_world_size
+            node_rank = rank // local_world_size
 
         del (
             context,
@@ -321,10 +321,14 @@ class DistABLPLoader(DistLoader):
             local_process_world_size=local_world_size,
         )
 
-        # Sets up processes for initializing the dataloader, setting up worker groups to minimize
+        # Sets up processes and torch device for initializing the GLT DistNeighborLoader, setting up RPC and worker groups to minimize
         # the memory overhead and CPU contention.
+        neighbor_loader_ports = gigl.distributed.utils.get_free_ports_from_master_node(
+            num_ports=local_world_size
+        )
+        neighbor_loader_port_for_current_rank = neighbor_loader_ports[local_rank]
         logger.info(
-            f"Initializing neighbor loader worker in process: {local_rank}/{local_world_size} using device: {self.to_device}"
+            f"Initializing neighbor loader worker in process: {local_rank}/{local_world_size} using device: {self.to_device} on port {neighbor_loader_port_for_current_rank}."
         )
         should_use_cpu_workers = self.to_device.type == "cpu"
         if should_use_cpu_workers and num_cpu_threads is None:
@@ -335,10 +339,12 @@ class DistABLPLoader(DistLoader):
             num_cpu_threads = DEFAULT_NUM_CPU_THREADS
 
         gigl.distributed.utils.init_neighbor_loader_worker(
+            master_ip_address=master_ip_address,
             local_process_rank=local_rank,
             local_process_world_size=local_world_size,
-            machine_rank=machine_rank,
-            machine_world_size=machine_world_size,
+            rank=node_rank,
+            world_size=node_world_size,
+            master_worker_port=neighbor_loader_port_for_current_rank,
             device=self.to_device,
             should_use_cpu_workers=should_use_cpu_workers,
             # Lever to explore tuning for CPU based inference

--- a/python/gigl/distributed/distributed_neighborloader.py
+++ b/python/gigl/distributed/distributed_neighborloader.py
@@ -109,8 +109,8 @@ class DistNeighborLoader(DistLoader):
         # https://github.com/alibaba/graphlearn-for-pytorch/blob/26fe3d4e050b081bc51a79dc9547f244f5d314da/graphlearn_torch/python/distributed/dist_loader.py#L125C1-L126C1
         self._shutdowned = True
 
-        machine_world_size: int
-        machine_rank: int
+        node_world_size: int
+        node_rank: int
         rank: int
         world_size: int
         local_rank: int
@@ -128,13 +128,13 @@ class DistNeighborLoader(DistLoader):
             ), "context: DistributedContext provided, so local_process_rank must be provided."
 
             master_ip_address = context.main_worker_ip_address
-            machine_world_size = context.global_world_size
-            machine_rank = context.global_rank
+            node_world_size = context.global_world_size
+            node_rank = context.global_rank
             local_world_size = local_process_world_size
             local_rank = local_process_rank
 
-            rank = machine_rank * local_world_size + local_rank
-            world_size = machine_world_size * local_world_size
+            rank = node_rank * local_world_size + local_rank
+            world_size = node_world_size * local_world_size
 
             if not torch.distributed.is_initialized():
                 logger.info(
@@ -170,9 +170,9 @@ class DistNeighborLoader(DistLoader):
                         + f"count_ranks_per_ip_address = {count_ranks_per_ip_address}"
                     )
 
-            machine_world_size = len(count_ranks_per_ip_address)
+            node_world_size = len(count_ranks_per_ip_address)
             local_rank = rank % local_world_size
-            machine_rank = rank // local_world_size
+            node_rank = rank // local_world_size
 
         del (
             context,
@@ -188,7 +188,7 @@ class DistNeighborLoader(DistLoader):
             )
         )
         logger.info(
-            f"Dataset Building started on {machine_rank} of {machine_world_size} nodes, using following node as main: {master_ip_address}"
+            f"Dataset Building started on {node_rank} of {node_world_size} nodes, using following node as main: {master_ip_address}"
         )
 
         if input_nodes is None:
@@ -240,7 +240,7 @@ class DistNeighborLoader(DistLoader):
 
         input_data = NodeSamplerInput(node=curr_process_nodes, input_type=node_type)
 
-        # Sets up processes for initializing the dataloader, setting up worker groups to minimize
+        # Sets up processes and torch device for initializing the GLT DistNeighborLoader, setting up RPC and worker groups to minimize
         # the memory overhead and CPU contention.
         logger.info(
             f"Initializing neighbor loader worker in process: {local_rank}/{local_world_size} using device: {device}"
@@ -253,14 +253,21 @@ class DistNeighborLoader(DistLoader):
             )
             num_cpu_threads = DEFAULT_NUM_CPU_THREADS
 
+        neighbor_loader_ports = gigl.distributed.utils.get_free_ports_from_master_node(
+            num_ports=local_world_size
+        )
+        neighbor_loader_port_for_current_rank = neighbor_loader_ports[local_rank]
+
         gigl.distributed.utils.init_neighbor_loader_worker(
+            master_ip_address=master_ip_address,
             local_process_rank=local_rank,
             local_process_world_size=local_world_size,
-            machine_rank=machine_rank,
-            machine_world_size=machine_world_size,
+            rank=node_rank,
+            world_size=node_world_size,
+            master_worker_port=neighbor_loader_port_for_current_rank,
             device=device,
             should_use_cpu_workers=should_use_cpu_workers,
-            # Lever to explore tuning for CPU based training or inference
+            # Lever to explore tuning for CPU based inference
             num_cpu_threads=num_cpu_threads,
             process_start_gap_seconds=process_start_gap_seconds,
         )


### PR DESCRIPTION
This reverts commit 460a82910b4c913a0698ea02198c117df6202638.

This breaks some internal pipelines which still rely on `glt.distributed.barrier`

Let's rollback and forward later with more fixes :)

cc: @mkolodner-sc 