### PR TITLE
Add tutorial notebook to our test suite

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,4 @@
+## Test scripts for GiGL as a project.
+
+This folder is intended for tests at a GiGL *project* level, e.g. lint tests, or "e2e tests".
+Unit tests and integration tests should go in their respective directories e.g. Python [unit](../python/tests/unit/) and [integration](../python/tests/integration/) tests.

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,4 +1,5 @@
 ## Test scripts for GiGL as a project.
 
-This folder is intended for tests at a GiGL *project* level, e.g. lint tests, or "e2e tests".
-Unit tests and integration tests should go in their respective directories e.g. Python [unit](../python/tests/unit/) and [integration](../python/tests/integration/) tests.
+This folder is intended for tests at a GiGL *project* level, e.g. lint tests, or "e2e tests". Unit tests and integration
+tests should go in their respective directories e.g. Python [unit](../python/tests/unit/) and
+[integration](../python/tests/integration/) tests.

--- a/testing/notebooks_test.py
+++ b/testing/notebooks_test.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from unittest import mock
 from uuid import uuid4
 
@@ -22,7 +22,7 @@ logger = Logger()
 class _NoteBookTestConfig:
     name: str
     notebook_path: str
-    env_overrides: dict[str, str]
+    env_overrides: dict[str, str] = field(default_factory=dict)
     timeout: int = 60 * 60
 
 

--- a/testing/notebooks_test.py
+++ b/testing/notebooks_test.py
@@ -91,6 +91,13 @@ class TestExampleNotebooks(unittest.TestCase):
                     "GIGL_TEST_DEFAULT_RESOURCE_CONFIG": gcs_uri.uri,
                 },
             ),
+            _NoteBookTestConfig(
+                "kdd_2025_heterogeneous_inference",
+                notebook_path=str(
+                    GIGL_ROOT_DIR
+                    / "examples/tutorial/KDD_2025/heterogeneous_inference.ipynb"
+                ),
+            ),
         ]
 
     def test_notebooks(self):

--- a/testing/notebooks_test.py
+++ b/testing/notebooks_test.py
@@ -95,7 +95,7 @@ class TestExampleNotebooks(unittest.TestCase):
                 "kdd_2025_heterogeneous",
                 notebook_path=str(
                     GIGL_ROOT_DIR
-                    / "examples/tutorial/KDD_2025/heterogeneous_walkthrough.ipynb"
+                    / "examples/tutorial/KDD_2025/heteregeneous_walkthrough.ipynb"
                 ),
             ),
         ]

--- a/testing/notebooks_test.py
+++ b/testing/notebooks_test.py
@@ -92,10 +92,10 @@ class TestExampleNotebooks(unittest.TestCase):
                 },
             ),
             _NoteBookTestConfig(
-                "kdd_2025_heterogeneous_inference",
+                "kdd_2025_heterogeneous",
                 notebook_path=str(
                     GIGL_ROOT_DIR
-                    / "examples/tutorial/KDD_2025/heterogeneous_inference.ipynb"
+                    / "examples/tutorial/KDD_2025/heterogeneous_walkthrough.ipynb"
                 ),
             ),
         ]


### PR DESCRIPTION
I recently added `testing/notebooks_test.py` as a way to ensure our notebooks are actually working.

Since the tutorial is important, we should also test it :P

You can run these tests with `/notebook_tests` as a comment