### PR TITLE
Update HGT model to handle differently ordered edge types

### DIFF
--- a/python/gigl/src/common/models/pyg/heterogeneous.py
+++ b/python/gigl/src/common/models/pyg/heterogeneous.py
@@ -95,9 +95,9 @@ class HGT(nn.Module):
         # The HGTConv layer requires that the edge index dictionary during forward is in the same order
         # as the edge types that the were provided to the model during initialization. Otherwise, we may run into
         # indexing errors with the HeteroLinear layer inside of the HGTConv.
-        if sorted(self._edge_types) != sorted(data.edge_index_dict):
+        if sorted(self._edge_types) != sorted(data.edge_index_dic.keys()):
             raise ValueError(
-                f"Found mismatching edge types between HGTConv initialized edge types {self._edge_types} and HeteroData edge types {sorted(data.edge_index_dict)}"
+                f"Found mismatching edge types between HGTConv initialized edge types {self._edge_types} and HeteroData edge types {sorted(data.edge_index_dict)}. These must be the same."
             )
         edge_index_dict = {
             edge_type: data.edge_index_dict[edge_type] for edge_type in self._edge_types

--- a/python/gigl/src/common/models/pyg/heterogeneous.py
+++ b/python/gigl/src/common/models/pyg/heterogeneous.py
@@ -44,8 +44,8 @@ class HGT(nn.Module):
         **kwargs,
     ):
         super().__init__()
-        node_types = list(node_type_to_feat_dim_map.keys())
-        edge_types = list(edge_type_to_feat_dim_map.keys())
+        self._node_types = list(node_type_to_feat_dim_map.keys())
+        self._edge_types = list(edge_type_to_feat_dim_map.keys())
         self.lin_dict = torch.nn.ModuleDict()
         for node_type, in_dim in node_type_to_feat_dim_map.items():
             self.lin_dict[node_type] = Linear(in_channels=in_dim, out_channels=hid_dim)
@@ -55,7 +55,7 @@ class HGT(nn.Module):
             conv = HGTConv(
                 in_channels=hid_dim,
                 out_channels=hid_dim,
-                metadata=(node_types, edge_types),
+                metadata=(self._node_types, self._edge_types),
                 heads=num_heads,
             )
             self.convs.append(conv)
@@ -92,6 +92,17 @@ class HGT(nn.Module):
                 for node_type, x in node_type_to_features_dict.items()
             }
 
+        # The HGTConv layer requires that the edge index dictionary during forward is in the same order
+        # as the edge types that the were provided to the model during initialization. Otherwise, we may run into
+        # indexing errors with the HeteroLinear layer inside of the HGTConv.
+        if sorted(self._edge_types) != sorted(data.edge_index_dict):
+            raise ValueError(
+                f"Found mismatching edge types between HGTConv initialized edge types {self._edge_types} and HeteroData edge types {sorted(data.edge_index_dict)}"
+            )
+        edge_index_dict = {
+            edge_type: data.edge_index_dict[edge_type] for edge_type in self._edge_types
+        }
+
         node_type_to_features_dict = {
             node_type: self.lin_dict[node_type](x).relu_()
             for node_type, x in node_type_to_features_dict.items()
@@ -99,7 +110,7 @@ class HGT(nn.Module):
 
         for conv in self.convs:
             node_type_to_features_dict = conv(
-                node_type_to_features_dict, data.edge_index_dict
+                node_type_to_features_dict, edge_index_dict
             )
 
         node_typed_embeddings: Dict[NodeType, torch.Tensor] = {}

--- a/python/tests/unit/module/models_test.py
+++ b/python/tests/unit/module/models_test.py
@@ -3,10 +3,12 @@ from typing import Optional, Union
 
 import torch
 import torch.nn as nn
+import torch_geometric
 from torch_geometric.data import Data, HeteroData
 
 from gigl.module.models import LinkPredictionGNN
-from gigl.src.common.types.graph_data import NodeType
+from gigl.src.common.models.pyg.heterogeneous import HGT
+from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
 from tests.test_assets.distributed.utils import (
     assert_tensor_equality,
     get_process_group_init_method,
@@ -134,6 +136,73 @@ class TestLinkPredictionGNN(unittest.TestCase):
         unwrapped = ddp_model.unwrap_from_ddp()
         self.assertIs(unwrapped.encoder, encoder)
         self.assertIs(unwrapped.decoder, decoder)
+
+
+class TestHGT(unittest.TestCase):
+    def setUp(self):
+        # Set this field to True so that it will be able to raise error if the HGTConv forward pass does not behave as expected
+        torch_geometric.backend.use_segment_matmul = True
+
+    def test_hgt_forward(self):
+        user_node_type = NodeType("user")
+        item_node_type = NodeType("item")
+        location_node_type = NodeType("location")
+        user_to_user_edge_type = EdgeType(
+            user_node_type, Relation("to"), user_node_type
+        )
+        item_to_user_edge_type = EdgeType(
+            item_node_type, Relation("to"), user_node_type
+        )
+        location_to_item_edge_type = EdgeType(
+            location_node_type, Relation("to"), item_node_type
+        )
+
+        node_type_to_feat_dim_map = {
+            user_node_type: 2,
+            item_node_type: 3,
+            location_node_type: 4,
+        }
+        edge_type_to_feat_dim_map = {
+            user_to_user_edge_type: 0,
+            item_to_user_edge_type: 0,
+            location_to_item_edge_type: 0,
+        }
+        encoder = HGT(
+            node_type_to_feat_dim_map=node_type_to_feat_dim_map,
+            edge_type_to_feat_dim_map=edge_type_to_feat_dim_map,
+            hid_dim=16,
+            out_dim=16,
+            num_layers=2,
+            num_heads=2,
+            should_l2_normalize_embedding_layer_output=True,
+            feature_embedding_layers=None,
+        )
+        data = HeteroData()
+        # We intentionally initialize the data in the HeteroData object in different orders than the `node_type_to_feat_dim_map` and `edge_type_to_feat_dim_map` to
+        # ensure that we can still forward pass in this scenario
+
+        data.x_dict = {
+            item_node_type: torch.rand((3, 3)),
+            user_node_type: torch.rand((2, 2)),
+            location_node_type: torch.rand((4, 4)),
+        }
+        data.edge_index_dict = {
+            location_to_item_edge_type: torch.tensor([[0, 1, 2, 3], [0, 1, 2, 0]]),
+            user_to_user_edge_type: torch.tensor([[0, 1], [1, 0]]),
+            item_to_user_edge_type: torch.tensor([[0, 1, 2], [0, 1, 0]]),
+        }
+
+        # Validate that we can forward pass using the mocked data
+        result = encoder(
+            data=data,
+            output_node_types=[user_node_type, item_node_type, location_node_type],
+            device=torch.device("cpu"),
+        )
+
+        # Assert all requested node types are in the output
+        self.assertIn(user_node_type, result)
+        self.assertIn(item_node_type, result)
+        self.assertIn(location_node_type, result)
 
 
 if __name__ == "__main__":

--- a/python/tests/unit/module/models_test.py
+++ b/python/tests/unit/module/models_test.py
@@ -3,12 +3,10 @@ from typing import Optional, Union
 
 import torch
 import torch.nn as nn
-import torch_geometric
 from torch_geometric.data import Data, HeteroData
 
 from gigl.module.models import LinkPredictionGNN
-from gigl.src.common.models.pyg.heterogeneous import HGT
-from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
+from gigl.src.common.types.graph_data import NodeType
 from tests.test_assets.distributed.utils import (
     assert_tensor_equality,
     get_process_group_init_method,
@@ -136,73 +134,6 @@ class TestLinkPredictionGNN(unittest.TestCase):
         unwrapped = ddp_model.unwrap_from_ddp()
         self.assertIs(unwrapped.encoder, encoder)
         self.assertIs(unwrapped.decoder, decoder)
-
-
-class TestHGT(unittest.TestCase):
-    def setUp(self):
-        # Set this field to True so that it will be able to raise error if the HGTConv forward pass does not behave as expected
-        torch_geometric.backend.use_segment_matmul = True
-
-    def test_hgt_forward(self):
-        user_node_type = NodeType("user")
-        item_node_type = NodeType("item")
-        location_node_type = NodeType("location")
-        user_to_user_edge_type = EdgeType(
-            user_node_type, Relation("to"), user_node_type
-        )
-        item_to_user_edge_type = EdgeType(
-            item_node_type, Relation("to"), user_node_type
-        )
-        location_to_item_edge_type = EdgeType(
-            location_node_type, Relation("to"), item_node_type
-        )
-
-        node_type_to_feat_dim_map = {
-            user_node_type: 2,
-            item_node_type: 3,
-            location_node_type: 4,
-        }
-        edge_type_to_feat_dim_map = {
-            user_to_user_edge_type: 0,
-            item_to_user_edge_type: 0,
-            location_to_item_edge_type: 0,
-        }
-        encoder = HGT(
-            node_type_to_feat_dim_map=node_type_to_feat_dim_map,
-            edge_type_to_feat_dim_map=edge_type_to_feat_dim_map,
-            hid_dim=16,
-            out_dim=16,
-            num_layers=2,
-            num_heads=2,
-            should_l2_normalize_embedding_layer_output=True,
-            feature_embedding_layers=None,
-        )
-        data = HeteroData()
-        # We intentionally initialize the data in the HeteroData object in different orders than the `node_type_to_feat_dim_map` and `edge_type_to_feat_dim_map` to
-        # ensure that we can still forward pass in this scenario
-
-        data.x_dict = {
-            item_node_type: torch.rand((3, 3)),
-            user_node_type: torch.rand((2, 2)),
-            location_node_type: torch.rand((4, 4)),
-        }
-        data.edge_index_dict = {
-            location_to_item_edge_type: torch.tensor([[0, 1, 2, 3], [0, 1, 2, 0]]),
-            user_to_user_edge_type: torch.tensor([[0, 1], [1, 0]]),
-            item_to_user_edge_type: torch.tensor([[0, 1, 2], [0, 1, 0]]),
-        }
-
-        # Validate that we can forward pass using the mocked data
-        result = encoder(
-            data=data,
-            output_node_types=[user_node_type, item_node_type, location_node_type],
-            device=torch.device("cpu"),
-        )
-
-        # Assert all requested node types are in the output
-        self.assertIn(user_node_type, result)
-        self.assertIn(item_node_type, result)
-        self.assertIn(location_node_type, result)
 
 
 if __name__ == "__main__":

--- a/python/tests/unit/src/common/models/pyg/heterogeneous_test.py
+++ b/python/tests/unit/src/common/models/pyg/heterogeneous_test.py
@@ -1,0 +1,93 @@
+import unittest
+
+import torch
+import torch_geometric
+from torch_geometric.data import HeteroData
+
+from gigl.src.common.models.pyg.heterogeneous import HGT
+from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
+
+
+class TestHGT(unittest.TestCase):
+    def setUp(self):
+        self._default_use_segment_matmul = torch_geometric.backend.use_segment_matmul
+        # Set this field to True so that it will be able to raise error if the HGTConv forward pass does not behave as expected
+        torch_geometric.backend.use_segment_matmul = True
+        return super().setUp()
+
+    def tearDown(self):
+        torch_geometric.backend.use_segment_matmul = self._default_use_segment_matmul
+        return super().tearDown()
+
+    def test_hgt_forward(self):
+        user_node_type = NodeType("user")
+        item_node_type = NodeType("item")
+        location_node_type = NodeType("location")
+        user_to_user_edge_type = EdgeType(
+            user_node_type, Relation("to"), user_node_type
+        )
+        item_to_user_edge_type = EdgeType(
+            item_node_type, Relation("to"), user_node_type
+        )
+        location_to_item_edge_type = EdgeType(
+            location_node_type, Relation("to"), item_node_type
+        )
+
+        node_type_to_feat_dim_map = {
+            user_node_type: 2,
+            item_node_type: 3,
+            location_node_type: 4,
+        }
+        edge_type_to_feat_dim_map = {
+            user_to_user_edge_type: 0,
+            item_to_user_edge_type: 0,
+            location_to_item_edge_type: 0,
+        }
+        encoder = HGT(
+            node_type_to_feat_dim_map=node_type_to_feat_dim_map,
+            edge_type_to_feat_dim_map=edge_type_to_feat_dim_map,
+            hid_dim=16,
+            out_dim=16,
+            num_layers=2,
+            num_heads=2,
+            should_l2_normalize_embedding_layer_output=True,
+            feature_embedding_layers=None,
+        )
+        data = HeteroData()
+        # We intentionally initialize the data in the HeteroData object in different orders than the `node_type_to_feat_dim_map` and `edge_type_to_feat_dim_map` to
+        # ensure that we can still forward pass in this scenario
+
+        data.x_dict = {
+            item_node_type: torch.rand((3, 3)),
+            user_node_type: torch.rand((2, 2)),
+            location_node_type: torch.rand((4, 4)),
+        }
+        data.edge_index_dict = {
+            location_to_item_edge_type: torch.tensor([[0, 1, 2, 3], [0, 1, 2, 0]]),
+            user_to_user_edge_type: torch.tensor([[0, 1], [1, 0]]),
+            item_to_user_edge_type: torch.tensor([[0, 1, 2], [0, 1, 0]]),
+        }
+
+        # Validate that we can forward pass using the mocked data
+        result = encoder(
+            data=data,
+            output_node_types=[user_node_type, item_node_type, location_node_type],
+            device=torch.device("cpu"),
+        )
+
+        # Assert all requested node types are in the output
+        self.assertIn(user_node_type, result)
+        self.assertIn(item_node_type, result)
+        self.assertIn(location_node_type, result)
+
+        # Assert error if we forward with an edge index dictionary which has different keys than the HGT constructor
+        with self.assertRaises(ValueError):
+            data.edge_index_dict = {
+                location_to_item_edge_type: torch.tensor([[0, 1, 2, 3], [0, 1, 2, 0]]),
+                user_to_user_edge_type: torch.tensor([[0, 1], [1, 0]]),
+            }
+            encoder(
+                data=data,
+                output_node_types=[user_node_type, item_node_type, location_node_type],
+                device=torch.device("cpu"),
+            )


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

This was a tricky one. When we initialize a HGTConv layer, we provide some edge types, which it uses to create an offset mapping for each edge type. When we forward some `data.edge_index_dict` through this layer, we require that the edge types there have the same order as the edge types in the constructor, otherwise the offsets will be off. For large graphs, this will lead to indexing errors during segmented matrix multiplication [[1](https://pyg-lib.readthedocs.io/en/stable/_modules/pyg_lib/ops.html#segment_matmul)] as such
```
split_with_sizes expects split_sizes have only non-negative entries, but got split_sizes=[66491, -41288, 41288, 66491, 0, 0]
```

which is caused by the `ptr` tensor being in a non-ascending order` 

For smaller graphs, segmented matrix multiplication is not used (based on some heuristic in PyG, see torch_geometric.backend.use_segment_matmul in [[2](https://pytorch-geometric.readthedocs.io/en/2.5.1/_modules/torch_geometric/nn/dense/linear.html#HeteroLinear)]) and we don't observe the above error when the indexing is incorrect, which is why we haven't observed this error prior and only instead when we were using MAG240M with larger batch sizes. Even in the small graph case though, the indices are still wrong and likely lead to incorrect forward passes, hurting the model performance.

[[3](https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/nn/conv/hgt_conv.html#HGTConv)]

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

This fix was validated on a MAG240M run which was previously failing due to the above issue. 

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
