### PR TITLE
Force conda forge channel only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ get_ver_hash:
 	$(eval GIT_COMMIT=$(shell git log -1 --pretty=format:"%H"))
 
 initialize_environment:
-	conda create -y -c conda-forge --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION} pip=${PIP_VERSION} pip-tools
+	conda create -y --override-channels --channel conda-forge --name ${CONDA_ENV_NAME} python=${PYTHON_VERSION} pip=${PIP_VERSION} pip-tools
 	@echo "If conda environment was successfully installed, ensure to activate it and run \`make install_dev_deps\` or \`make install_deps\` to complete setup"
 
 clean_environment:

--- a/containers/Dockerfile.builder
+++ b/containers/Dockerfile.builder
@@ -41,7 +41,7 @@ ENV JAVA_HOME="/usr/lib/jvm/java-1.11.0-openjdk-amd64"
 
 # Create the environment:
 # TODO: (svij) Build env using single entrypoint `make initialize_environment` for better maintainability
-RUN conda create -y -c conda-forge --name gigl python=3.9 pip
+RUN conda create -y --override-channels --channel conda-forge --name gigl python=3.9 pip
 
 # Update path so any call for python executables in the built image defaults to using the gnn conda environment
 ENV PATH=/opt/conda/envs/gigl/bin:$PATH

--- a/containers/Dockerfile.cpu.base
+++ b/containers/Dockerfile.cpu.base
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
 
 # Create the environment:
 # TODO: (svij) Build env using single entrypoint `make initialize_environment` for better maintainability
-RUN conda create -y -c conda-forge --name gnn python=3.9 pip
+RUN conda create -y --override-channels --channel conda-forge --name gnn python=3.9 pip
 
 # Update path so any call for python executables in the built image defaults to using the gnn conda environment
 ENV PATH=/opt/conda/envs/gnn/bin:$PATH

--- a/containers/Dockerfile.cuda.base
+++ b/containers/Dockerfile.cuda.base
@@ -21,7 +21,7 @@ ENV PATH=${CONDA_DIR}/bin:$PATH
 
 # Create the conda env environment:
 # TODO: (svij) Build env using single entrypoint `make initialize_environment` for better maintainability
-RUN conda create -y -c conda-forge --name gnn python=3.9 pip
+RUN conda create -y --override-channels --channel conda-forge --name gnn python=3.9 pip
 
 # Update path so any call for python executables in the built image defaults to using the gnn conda environment
 ENV PATH=${CONDA_DIR}/envs/gnn/bin:$PATH

--- a/docs/user_guide/getting_started/installation.md
+++ b/docs/user_guide/getting_started/installation.md
@@ -121,7 +121,7 @@ The instructions below are in development and are not recommended. We are workin
 1. Create a python environment
 
 ```bash
-conda create -y -c conda-forge --name gigl python=3.9
+conda create -y --override-channels --channel conda-forge --name gigl python=3.9
 conda activate gigl
 ```
 

--- a/requirements/install_py_deps.sh
+++ b/requirements/install_py_deps.sh
@@ -126,7 +126,7 @@ else
 fi
 
 
-conda install -c conda-forge gperftools # tcmalloc, ref: https://google.github.io/tcmalloc/overview.html
+conda install --override-channels --channel conda-forge gperftools # tcmalloc, ref: https://google.github.io/tcmalloc/overview.html
 
 if [[ $DEV -eq 1 ]]
 then


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

Noticed behaviour:
Terms of Service implicitly accepted for conda default channel - even though we don't want to use it.
This forces us not to use it this case. 

Will follow up w/ task where we can just do this at a global level i.e. reliance on `actions/setup-python@v4` which has a pre-installation of conda which uses default channel.


<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
