### PR TITLE
Add instructions for setting up resource config

### DIFF
--- a/examples/tutorial/KDD_2025/README.md
+++ b/examples/tutorial/KDD_2025/README.md
@@ -68,6 +68,30 @@ Thinking about integrating Graph Neural Networks into your applications? Here's 
 - **Customization Potential:** We'll explore the possibilities for customizing GIGL to adapt it to specific research or
   application needs.
 
+
+## Setup Resource Config.
+The tutorial requires you to setup a [resource config](../../../docs/user_guide/config_guides/resource_config_guide.md) in order to launch jobs on GCP.
+
+You may run the below from GiGL root to generate an appropriate resource config.
+You may find the Project and User on the left hand panel on the qwiklabs page.
+
+
+```bash
+PROJECT=$QWIK_LABS_PROJECT # Ex, qwiklabs-gcp-01-40f6ccb540f3
+QL_USER=$QWIK_LABS_USER # Ex, student-02-5e0049fb83ce
+
+python -m scripts.bootstrap_resource_config \
+  --project=$PROJECT \
+  --gcp_service_account_email=gigl-dev@$PROJECT.iam.gserviceaccount.com \
+  --docker_artifact_registry_path=us-central1-docker.pkg.dev/$PROJECT/gigl-images \
+  --temp_assets_bq_dataset_name="gigl_temp_assets" \
+  --embedding_bq_dataset_name="gigl_temp_assets" \
+  --temp_assets_bucket="gs://gigl_temp_assets_$QL_USER" \
+  --perm_assets_bucket="gs://gigl_perm_assets_$QL_USER"
+```
+
+It's accept the default region `us-central1` and output the resource config somewhere locally, like `examples/tutorial/KDD_2025/resource_config.yaml`.
+
 ## Resources
 
 - **GiGL KDD '25 paper:** [GiGL: Large-Scale Graph Neural Networks at Snapchat](https://arxiv.org/abs/2502.15054)

--- a/scripts/bootstrap_resource_config.py
+++ b/scripts/bootstrap_resource_config.py
@@ -271,9 +271,6 @@ if __name__ == "__main__":
         ).strip()
         or default_resource_config_dest_path
     )
-    assert destination_file_path and destination_file_path.startswith(
-        "gs://"
-    ), "Destination file path must be a GCS path starting with 'gs://'"
 
     print("=======================================================")
     print(f"Will now create the resource config file @ {destination_file_path}.")


### PR DESCRIPTION
I tested this on qwiklabs with:

```
(gnn) jupyter@vertex-ai-jupyterlab:~/GiGL$ PROJECT=qwiklabs-gcp-01-40f6ccb540f3
QL_USER=student-02-5e0049fb83ce

python -m scripts.bootstrap_resource_config \
  --project=$PROJECT \
  --gcp_service_account_email=gigl-dev@$PROJECT.iam.gserviceaccount.com \
  --docker_artifact_registry_path=us-central1-docker.pkg.dev/$PROJECT/gigl-images \
  --temp_assets_bq_dataset_name="gigl_temp_assets" \
  --embedding_bq_dataset_name="gigl_temp_assets" \
  --temp_assets_bucket="gs://gigl_temp_assets_$QL_USER" \
  --perm_assets_bucket="gs://gigl_perm_assets_$QL_USER"
Welcome to the GiGL Cloud Environment Configuration Script!
This script will help you set up your cloud environment for GiGL.
Before running this script, please ensure you have followed the GiGL Cloud Setup Guide:
https://snapchat.github.io/GiGL/docs/user_guide/getting_started/cloud_setup_guide
======================================================
Using local development template resource config: /home/jupyter/GiGL/deployment/configs/unittest_resource_config.yaml
-> The GCP region where you created your resources
Defaults to: [us-central1]: 
createTime: '2025-07-21T09:27:53.239794Z'
labels:
  fleet: medium_extra
lifecycleState: ACTIVE
name: qwiklabs-gcp-01-40f6ccb540f3
parent:
  id: '459633559525'
  type: folder
projectId: qwiklabs-gcp-01-40f6ccb540f3
projectNumber: '893630665860'

Confirmed BigQuery dataset 'gigl_temp_assets' exists.
Confirmed BigQuery dataset 'gigl_temp_assets' exists.
Confirmed GCS bucket 'gs://gigl_temp_assets_student-02-5e0049fb83ce' exists.
Confirmed GCS bucket 'gs://gigl_perm_assets_student-02-5e0049fb83ce' exists.
Output path for resource config (default: gs://gigl_perm_assets_student-02-5e0049fb83ce/jupyter/20250724_164023/gigl_test_default_resource_config.yaml); can be GCS or Local path: examples/tutorial/KDD_2025/resource_config.yaml
=======================================================
Will now create the resource config file @ examples/tutorial/KDD_2025/resource_config.yaml.
Using the following values:
  project: qwiklabs-gcp-01-40f6ccb540f3
  region: us-central1
  gcp_service_account_email: gigl-dev@qwiklabs-gcp-01-40f6ccb540f3.iam.gserviceaccount.com
  temp_assets_bucket: gs://gigl_temp_assets_student-02-5e0049fb83ce
  temp_regional_assets_bucket: gs://gigl_temp_assets_student-02-5e0049fb83ce
  perm_assets_bucket: gs://gigl_perm_assets_student-02-5e0049fb83ce
  temp_assets_bq_dataset_name: gigl_temp_assets
  embedding_bq_dataset_name: gigl_temp_assets
2025-07-24 16:40 [INFO] : Creating symlink /home/jupyter/GiGL/examples/tutorial/KDD_2025/resource_config.yaml -> /var/tmp/tmpcugqil4b (local_fs.py:create_file_symlinks:231)
2025-07-24 16:40 [INFO] : Deleted local file at /home/jupyter/GiGL/examples/tutorial/KDD_2025/resource_config.yaml (local_fs.py:remove_file_if_exist:64)
Updated YAML file saved at 'examples/tutorial/KDD_2025/resource_config.yaml'
Do you want to update your shell configuration file so you can use this new resource config for tests? [y/n] (Default: y): 
Detected shell: bash. Using config file: ~/.bashrc
Updated /home/jupyter/.bashrc with:
['# ====== GiGL ENV Config - Begin =====\n', '# This section is auto-generated by GiGL/scripts/bootstrap_resource_config.py.\n', 'export GIGL_TEST_DEFAULT_RESOURCE_CONFIG="examples/tutorial/KDD_2025/resource_config.yaml"\n', 'export GIGL_PROJECT="qwiklabs-gcp-01-40f6ccb540f3"\n', 'export GIGL_DOCKER_ARTIFACT_REGISTRY="us-central1-docker.pkg.dev/qwiklabs-gcp-01-40f6ccb540f3/gigl-images"\n', '# ====== GiGL ENV Config - End =====\n'].
Please restart your shell or run `source ~/.bashrc` to apply the changes.
```