### PR TITLE
Migrate GCP_PROJECT_ID to be pulled from workflow vars

### DIFF
--- a/.github/workflows/build-base-docker-images.yml
+++ b/.github/workflows/build-base-docker-images.yml
@@ -8,10 +8,10 @@ on:
         required: true
 env:
   DOCKER_BUILDKIT: 1
-  GIGL_BASE_CUDA_IMAGE: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/public-gigl/gigl-cuda-base:${{ github.sha }}.${{ github.run_number }}.${{ github.run_attempt }}
-  GIGL_BASE_CPU_IMAGE: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/public-gigl/gigl-cpu-base:${{ github.sha }}.${{ github.run_number }}.${{ github.run_attempt }}
-  GIGL_BASE_DATAFLOW_IMAGE: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/public-gigl/gigl-dataflow-base:${{ github.sha }}.${{ github.run_number }}.${{ github.run_attempt }}
-  GIGL_BUILDER_IMAGE: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/gigl-base-images/gigl-builder:${{ github.sha }}.${{ github.run_number }}.${{ github.run_attempt }}
+  GIGL_BASE_CUDA_IMAGE: us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/public-gigl/gigl-cuda-base:${{ github.sha }}.${{ github.run_number }}.${{ github.run_attempt }}
+  GIGL_BASE_CPU_IMAGE: us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/public-gigl/gigl-cpu-base:${{ github.sha }}.${{ github.run_number }}.${{ github.run_attempt }}
+  GIGL_BASE_DATAFLOW_IMAGE: us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/public-gigl/gigl-dataflow-base:${{ github.sha }}.${{ github.run_number }}.${{ github.run_attempt }}
+  GIGL_BUILDER_IMAGE: us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/gigl-base-images/gigl-builder:${{ github.sha }}.${{ github.run_number }}.${{ github.run_attempt }}
   WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
@@ -45,7 +45,7 @@ jobs:
       with:
         setup_gcloud: "true"
         try_cleaning_disk_space: "true"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
@@ -73,7 +73,7 @@ jobs:
       with:
         setup_gcloud: "true"
         try_cleaning_disk_space: "true"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
@@ -107,7 +107,7 @@ jobs:
       with:
         setup_gcloud: "true"
         try_cleaning_disk_space: "true"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         setup_gcloud: "true"
         install_dev_deps: "true"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
@@ -68,7 +68,7 @@ jobs:
       run: |
         python -m scripts.bump_version \
           --bump_type ${{ steps.set_vars.outputs.bump_type }} \
-          --project ${{ secrets.GCP_PROJECT_ID }}
+          --project ${{ vars.GCP_PROJECT_ID }}
 
     # Capture new version and create release branch name
     - name: Get new version
@@ -110,7 +110,7 @@ jobs:
       with:
         setup_gcloud: "true"
         install_dev_deps: "false"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
@@ -125,7 +125,7 @@ jobs:
             compiled_pipeline_path=\$DEFAULT_GIGL_RELEASE_KFP_PIPELINE_PATH \
             compile_gigl_kubeflow_pipeline
         service_account:  ${{ secrets.gcp_service_account_email }}
-        project:  ${{ secrets.gcp_project_id }}
+        project:  ${{ vars.GCP_PROJECT_ID }}
 
   release_dev_workbench_image:
     needs: bump_version
@@ -146,7 +146,7 @@ jobs:
       with:
         setup_gcloud: "true"
         install_dev_deps: "false"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 
@@ -157,7 +157,7 @@ jobs:
           bash ./requirements/install_scala_deps.sh --download-only
           make push_dev_workbench_docker_image
         service_account:  ${{ secrets.gcp_service_account_email }}
-        project:  ${{ secrets.gcp_project_id }}
+        project:  ${{ vars.GCP_PROJECT_ID }}
 
 
   # TODO: (svij) Also release the dev image

--- a/.github/workflows/fossa-analyze.yml
+++ b/.github/workflows/fossa-analyze.yml
@@ -37,7 +37,7 @@ jobs:
         with:
             install_dev_deps: "true"
             setup_gcloud: "true"
-            gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+            gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
             workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
             gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
 

--- a/.github/workflows/on-pr-comment.yml
+++ b/.github/workflows/on-pr-comment.yml
@@ -31,7 +31,7 @@ jobs:
         # how to leverage Workload Identity Federation to read assets from GCS, et al. See:
         # https://github.com/tensorflow/tensorflow/issues/57104
         use_cloud_run: "true"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
         command: |
@@ -50,7 +50,7 @@ jobs:
         descriptive_workflow_name: "Integration Test"
         setup_gcloud: "true"
         use_cloud_run: "true"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
         command: |
@@ -69,7 +69,7 @@ jobs:
         descriptive_workflow_name: "E2E Test"
         setup_gcloud: "true"
         use_cloud_run: "true"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
         command: |
@@ -89,7 +89,7 @@ jobs:
         descriptive_workflow_name: "Example Notebooks Test"
         setup_gcloud: "true"
         use_cloud_run: "true"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
         command: |
@@ -110,7 +110,7 @@ jobs:
         descriptive_workflow_name: "Lint Test"
         install_dev_deps: "true"
         setup_gcloud: "true"
-        gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+        gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
         workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
         gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
         command: |

--- a/.github/workflows/on-pr-merge.yml
+++ b/.github/workflows/on-pr-merge.yml
@@ -29,7 +29,7 @@ jobs:
       uses: snapchat/gigl/.github/actions/setup-python-tools@main
       with:
           setup_gcloud: "true"
-          gcp_project_id: ${{ secrets.gcp_project_id }}
+          gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.workload_identity_provider }}
           gcp_service_account_email: ${{ secrets.gcp_service_account_email }}
     - name: Run Unit Tests
@@ -41,7 +41,7 @@ jobs:
       with:
         cmd: "make unit_test"
         service_account:  ${{ secrets.gcp_service_account_email }}
-        project:  ${{ secrets.gcp_project_id }}
+        project:  ${{ vars.GCP_PROJECT_ID }}
 
   ci-integration-test:
     if: github.event_name == 'merge_group'
@@ -52,7 +52,7 @@ jobs:
       uses: snapchat/gigl/.github/actions/setup-python-tools@main
       with:
           setup_gcloud: "true"
-          gcp_project_id: ${{ secrets.gcp_project_id }}
+          gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.workload_identity_provider }}
           gcp_service_account_email: ${{ secrets.gcp_service_account_email }}
     - name: Run Integration Tests
@@ -60,7 +60,7 @@ jobs:
       with:
         cmd: "make integration_test"
         service_account:  ${{ secrets.gcp_service_account_email }}
-        project:  ${{ secrets.gcp_project_id }}
+        project:  ${{ vars.GCP_PROJECT_ID }}
 
   ci-integration-e2e-test:
     if: github.event_name == 'merge_group'
@@ -71,7 +71,7 @@ jobs:
       uses: snapchat/gigl/.github/actions/setup-python-tools@main
       with:
           setup_gcloud: "true"
-          gcp_project_id: ${{ secrets.gcp_project_id }}
+          gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.workload_identity_provider }}
           gcp_service_account_email: ${{ secrets.gcp_service_account_email }}
     - name: Run E2E Tests
@@ -79,7 +79,7 @@ jobs:
       with:
         cmd: "make run_all_e2e_tests"
         service_account:  ${{ secrets.gcp_service_account_email }}
-        project:  ${{ secrets.gcp_project_id }}
+        project:  ${{ vars.GCP_PROJECT_ID }}
 
   ci-integration-example-notebooks-test:
     if: github.event_name == 'merge_group'
@@ -90,7 +90,7 @@ jobs:
       uses: snapchat/gigl/.github/actions/setup-python-tools@main
       with:
           setup_gcloud: "true"
-          gcp_project_id: ${{ secrets.gcp_project_id }}
+          gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.workload_identity_provider }}
           gcp_service_account_email: ${{ secrets.gcp_service_account_email }}
     - name: Run Example Notebook E2E Tests
@@ -98,7 +98,7 @@ jobs:
       with:
         cmd: "make notebooks_test"
         service_account:  ${{ secrets.gcp_service_account_email }}
-        project:  ${{ secrets.gcp_project_id }}
+        project:  ${{ vars.GCP_PROJECT_ID }}
 
   ci-lint-test:
     if: github.event_name == 'merge_group'
@@ -110,7 +110,7 @@ jobs:
       with:
           install_dev_deps: "true"
           setup_gcloud: "true"
-          gcp_project_id: ${{ secrets.gcp_project_id }}
+          gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.workload_identity_provider }}
           gcp_service_account_email: ${{ secrets.gcp_service_account_email }}
     - name: Run Lint Tests

--- a/.github/workflows/release-documentation.yml
+++ b/.github/workflows/release-documentation.yml
@@ -38,7 +38,7 @@ jobs:
         with:
             install_dev_deps: "true"
             setup_gcloud: "true"
-            gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+            gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
             workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
             gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
       # We also make gigl available w/ editable install `-e` so that autodoc can find it.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build and release pip whl
     runs-on: ubuntu-latest
     env:
-      PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+      PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
     environment:
       # This CI environment contains relevant pip.conf and pyprci information to
       name: release
@@ -29,7 +29,7 @@ jobs:
       with:
           install_dev_deps: "true"
           setup_gcloud: "true"
-          gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
           workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
           gcp_service_account_email: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
     # We need build and twine to build the whl and upload it to Google Artifact Registry.


### PR DESCRIPTION
**Scope of work done**

The project name is not confidential as it is exposed in our artifact registry paths, and all out resource configs for CI/CD.  Since its housed as a workflow secret, we run into issues where we cannot print these or have the image names be outputted by our CD in the release PRs that get generated.



<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

I added the `GCP_PROJECT_ID` as an env variable; if the merge goes through, we should be good here.

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
