### PR TITLE
support copying from GCS blob to GCS blob

### DIFF
--- a/python/gigl/common/utils/gcs.py
+++ b/python/gigl/common/utils/gcs.py
@@ -366,7 +366,6 @@ class GcsUtils:
             gcs_path=src_gcs_blob
         )
         src_bucket = self.__storage_client.bucket(bucket_name=src_bucket_name)
-        src_bucket = self.__storage_client.bucket(bucket_name=src_bucket_name)
         dst_bucket_name, dst_blob_name = self.get_bucket_and_blob_path_from_gcs_path(
             gcs_path=dst_gcs_blob
         )

--- a/python/gigl/common/utils/gcs.py
+++ b/python/gigl/common/utils/gcs.py
@@ -361,6 +361,22 @@ class GcsUtils:
                 results
             )  # wait for all deletions to finish - also throws exceptions from threads, if any failed
 
+    def copy_gcs_blob(self, src_gcs_blob: GcsUri, dst_gcs_blob: GcsUri) -> None:
+        src_bucket_name, src_blob_name = self.get_bucket_and_blob_path_from_gcs_path(
+            gcs_path=src_gcs_blob
+        )
+        src_bucket = self.__storage_client.bucket(bucket_name=src_bucket_name)
+        src_bucket = self.__storage_client.bucket(bucket_name=src_bucket_name)
+        dst_bucket_name, dst_blob_name = self.get_bucket_and_blob_path_from_gcs_path(
+            gcs_path=dst_gcs_blob
+        )
+        dst_bucket = self.__storage_client.bucket(bucket_name=dst_bucket_name)
+        src_bucket.copy_blob(
+            blob=src_bucket.blob(src_blob_name),
+            destination_bucket=dst_bucket,
+            new_name=dst_blob_name,
+        )
+
     def copy_gcs_path(self, src_gcs_path: GcsUri, dst_gcs_path: GcsUri):
         src_bucket_name, src_prefix = self.get_bucket_and_blob_path_from_gcs_path(
             gcs_path=src_gcs_path

--- a/python/gigl/src/common/utils/file_loader.py
+++ b/python/gigl/src/common/utils/file_loader.py
@@ -192,7 +192,7 @@ class FileLoader:
                     should_overwrite=True,
                 )
         else:
-            logger.warning(
+            logger.error(
                 f"Unsupported src/dst combo: {type(file_uri_src)} -> {type(file_uri_dst)}"
             )
             raise TypeError(self.__unsupported_uri_message)

--- a/python/gigl/src/common/utils/file_loader.py
+++ b/python/gigl/src/common/utils/file_loader.py
@@ -163,43 +163,38 @@ class FileLoader:
         file_uri_dst: Uri,
         should_create_symlinks_if_possible: bool = True,
     ) -> None:
-        uri_map_schema = self.__get_uri_map_schema(uri_map={file_uri_src: file_uri_dst})
-        uri_map = {file_uri_src: file_uri_dst}
-
-        if uri_map_schema == (GcsUri, GcsUri):
+        if isinstance(file_uri_src, GcsUri) and isinstance(file_uri_dst, GcsUri):
             self.__gcs_utils.copy_gcs_blob(file_uri_src, file_uri_dst)
-        elif uri_map_schema == (GcsUri, LocalUri):
+        elif isinstance(file_uri_src, GcsUri) and isinstance(file_uri_dst, LocalUri):
             self.__gcs_utils.download_file_from_gcs(
-                gcs_path=cast(GcsUri, file_uri_src),
-                dest_file_path=cast(LocalUri, file_uri_dst),
+                gcs_path=file_uri_src,
+                dest_file_path=file_uri_dst,
             )
-        elif uri_map_schema == (HttpUri, LocalUri):
+        elif isinstance(file_uri_src, HttpUri) and isinstance(file_uri_dst, LocalUri):
             HttpUtils.download_files_from_http(
-                http_to_local_path_map=cast(dict[HttpUri, LocalUri], uri_map),
+                http_to_local_path_map={file_uri_src: file_uri_dst}
             )
-        elif uri_map_schema == (LocalUri, GcsUri):
+        elif isinstance(file_uri_src, LocalUri) and isinstance(file_uri_dst, GcsUri):
             self.__gcs_utils.upload_files_to_gcs(
-                local_file_path_to_gcs_path_map=cast(dict[LocalUri, GcsUri], uri_map),
+                local_file_path_to_gcs_path_map={file_uri_src: file_uri_dst},
                 parallel=False,
             )
-        elif uri_map_schema == (LocalUri, LocalUri):
+        elif isinstance(file_uri_src, LocalUri) and isinstance(file_uri_dst, LocalUri):
             local_source_to_link_path_map = {file_uri_src: file_uri_dst}
             if should_create_symlinks_if_possible:
                 create_file_symlinks(
-                    local_source_to_link_path_map=cast(
-                        dict[LocalUri, LocalUri], local_source_to_link_path_map
-                    ),
+                    local_source_to_link_path_map=local_source_to_link_path_map,
                     should_overwrite=True,
                 )
             else:
                 copy_files(
-                    local_source_to_local_dst_path_map=cast(
-                        dict[LocalUri, LocalUri], local_source_to_link_path_map
-                    ),
+                    local_source_to_local_dst_path_map=local_source_to_link_path_map,
                     should_overwrite=True,
                 )
         else:
-            logger.warning(f"Unsupported uri_map_schema: {uri_map_schema}")
+            logger.warning(
+                f"Unsupported src/dst combo: {type(file_uri_src)} -> {type(file_uri_dst)}"
+            )
             raise TypeError(self.__unsupported_uri_message)
 
     def load_from_filelike(self, uri: Uri, filelike: IO[AnyStr]) -> None:

--- a/python/gigl/src/common/utils/file_loader.py
+++ b/python/gigl/src/common/utils/file_loader.py
@@ -166,10 +166,16 @@ class FileLoader:
         uri_map_schema = self.__get_uri_map_schema(uri_map={file_uri_src: file_uri_dst})
         uri_map = {file_uri_src: file_uri_dst}
 
-        if uri_map_schema == (GcsUri, LocalUri):
+        if uri_map_schema == (GcsUri, GcsUri):
+            self.__gcs_utils.copy_gcs_blob(file_uri_src, file_uri_dst)
+        elif uri_map_schema == (GcsUri, LocalUri):
             self.__gcs_utils.download_file_from_gcs(
                 gcs_path=cast(GcsUri, file_uri_src),
                 dest_file_path=cast(LocalUri, file_uri_dst),
+            )
+        elif uri_map_schema == (HttpUri, LocalUri):
+            HttpUtils.download_files_from_http(
+                http_to_local_path_map=cast(dict[HttpUri, LocalUri], uri_map),
             )
         elif uri_map_schema == (LocalUri, GcsUri):
             self.__gcs_utils.upload_files_to_gcs(
@@ -192,10 +198,6 @@ class FileLoader:
                     ),
                     should_overwrite=True,
                 )
-        elif uri_map_schema == (HttpUri, LocalUri):
-            HttpUtils.download_files_from_http(
-                http_to_local_path_map=cast(dict[HttpUri, LocalUri], uri_map),
-            )
         else:
             logger.warning(f"Unsupported uri_map_schema: {uri_map_schema}")
             raise TypeError(self.__unsupported_uri_message)

--- a/python/tests/integration/common/file_loader_test.py
+++ b/python/tests/integration/common/file_loader_test.py
@@ -175,10 +175,18 @@ class FileLoaderTest(unittest.TestCase):
         gcs_file_path_dst: GcsUri = GcsUri.join(
             self.gcs_test_asset_directory, "test_gcs_to_gcs_dst.txt"
         )
-        with self.assertRaises(TypeError):
-            self.file_loader.load_files(
-                source_to_dest_file_uri_map={gcs_file_path_src: gcs_file_path_dst}
-            )
+        # First upload the source file
+        self.file_loader.load_from_filelike(
+            gcs_file_path_src, io.BytesIO(b"Hello, world!")
+        )
+        self.file_loader.load_files(
+            source_to_dest_file_uri_map={gcs_file_path_src: gcs_file_path_dst}
+        )
+
+        f = self.file_loader.load_to_temp_file(file_uri_src=gcs_file_path_dst)
+        with open(f.name, "r") as file:
+            read_text = file.read()
+            self.assertEqual(read_text, "Hello, world!")
 
     def test_local_to_local_dir(self):
         local_files = ["a.txt", "b.txt", "c.txt", "d.txt"]

--- a/python/tests/integration/common/gcs_test.py
+++ b/python/tests/integration/common/gcs_test.py
@@ -1,11 +1,23 @@
 import unittest
+from uuid import uuid4
 
 from gigl.common import GcsUri
 from gigl.common.utils.gcs import GcsUtils
 from gigl.env import dep_constants
+from gigl.env.pipelines_config import get_resource_config
 
 
 class GcsUtilsTest(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self._scratch_gcs_path = GcsUri(
+            f"{get_resource_config().temp_assets_regional_bucket_path}/testing/gcs_utils/{uuid4().hex}/"
+        )
+
+    def tearDown(self):
+        gcs_utils = GcsUtils()
+        gcs_utils.delete_files_in_bucket_dir(self._scratch_gcs_path)
+
     def test_join_path(self):
         self.assertEquals(
             GcsUri.join("gs://bucket_name", "path", "file.txt"),
@@ -23,6 +35,32 @@ class GcsUtilsTest(unittest.TestCase):
                 f"gs://{dep_constants.GIGL_PUBLIC_BUCKET_NAME}/test_assets/sample_text.txt"
             )
         )
+        with open(f.name) as file:
+            read_text = file.read()
+            self.assertEqual(read_text, "This is a test")
+
+    def test_upload_from_string(self):
+        gcs_utils = GcsUtils()
+        gcs_path = GcsUri.join(
+            self._scratch_gcs_path, "test_upload_from_string/sample_text.txt"
+        )
+        gcs_utils.upload_from_string(gcs_path, "This is a test")
+        f = gcs_utils.download_file_from_gcs_to_temp_file(gcs_path)
+        with open(f.name) as file:
+            read_text = file.read()
+            self.assertEqual(read_text, "This is a test")
+
+    def test_copy_from_gcs_to_gcs(self):
+        gcs_utils = GcsUtils()
+        source_gcs_path = GcsUri(
+            f"gs://{dep_constants.GIGL_PUBLIC_BUCKET_NAME}/test_assets/sample_text.txt"
+        )
+        destination_gcs_path = GcsUri.join(
+            self._scratch_gcs_path, "test_copy_from_gcs_to_gcs/copied_sample_text.txt"
+        )
+
+        gcs_utils.copy_gcs_blob(source_gcs_path, destination_gcs_path)
+        f = gcs_utils.download_file_from_gcs_to_temp_file(destination_gcs_path)
         with open(f.name) as file:
             read_text = file.read()
             self.assertEqual(read_text, "This is a test")

--- a/python/tests/integration/common/gcs_test.py
+++ b/python/tests/integration/common/gcs_test.py
@@ -50,11 +50,30 @@ class GcsUtilsTest(unittest.TestCase):
             read_text = file.read()
             self.assertEqual(read_text, "This is a test")
 
+    def test_upload_from_str_overwrites(self):
+        gcs_utils = GcsUtils()
+        gcs_path = GcsUri.join(
+            self._scratch_gcs_path, "test_upload_from_str_overwrites/sample_text.txt"
+        )
+        gcs_utils.upload_from_string(gcs_path, "This is a test")
+        f = gcs_utils.download_file_from_gcs_to_temp_file(gcs_path)
+        with open(f.name) as file:
+            read_text = file.read()
+            self.assertEqual(read_text, "This is a test")
+
+        # Overwrite the content
+        gcs_utils.upload_from_string(gcs_path, "Updated test content")
+        f = gcs_utils.download_file_from_gcs_to_temp_file(gcs_path)
+        with open(f.name) as file:
+            read_text = file.read()
+            self.assertEqual(read_text, "Updated test content")
+
     def test_copy_from_gcs_to_gcs(self):
         gcs_utils = GcsUtils()
-        source_gcs_path = GcsUri(
-            f"gs://{dep_constants.GIGL_PUBLIC_BUCKET_NAME}/test_assets/sample_text.txt"
+        source_gcs_path = GcsUri.join(
+            self._scratch_gcs_path, "test_copy_from_gcs_to_gcs/sample_text.txt"
         )
+        gcs_utils.upload_from_string(source_gcs_path, "This is a test")
         destination_gcs_path = GcsUri.join(
             self._scratch_gcs_path, "test_copy_from_gcs_to_gcs/copied_sample_text.txt"
         )
@@ -65,24 +84,6 @@ class GcsUtilsTest(unittest.TestCase):
             read_text = file.read()
             self.assertEqual(read_text, "This is a test")
 
-    # TODO: (svij) Follow up PR to fix this test
-    # def test_upload_from_string(self):
-    #     # TODO, ensure cleanup and files dont conflict with each other if multiple tests simultaneously
-    #     test_str = "This is a test"
-    #     test_str_overwrite = "This is a test overwrite"
 
-    #     gcs_utils = GcsUtils()
-    #     gcs_path = GcsUri(
-    #         f"gs://{dep_constants.GIGL_PUBLIC_BUCKET_NAME}/test_assets/test_upload_from_string.txt"
-    #     )
-    #     gcs_utils.upload_from_string(gcs_path, test_str)
-    #     f = gcs_utils.download_file_from_gcs_to_temp_file(gcs_path)
-    #     with open(f.name) as file:
-    #         read_text = file.read()
-    #         self.assertEqual(read_text, test_str)
-
-    #     gcs_utils.upload_from_string(gcs_path, test_str_overwrite)
-    #     f = gcs_utils.download_file_from_gcs_to_temp_file(gcs_path)
-    #     with open(f.name) as file:
-    #         read_text = file.read()
-    #         self.assertEqual(read_text, test_str_overwrite)
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
* Support copying `GCSURI -> GCSURI` in FileLoader.load_file.
* Added `GcsUtils.copy_gcs_blob` to support this.
* Updated some typing stuff in `FileLoader. load_file` so we can avoid `cast`.

Added tests for both use cases.