### PR TITLE
make README prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,10 @@
 
 GiGL is an open-source library for training and inference of Graph Neural Networks at very large (billion) scale.
 
-```{only}
-::not html
 
 For best experience in reading GiGL documentation, visit our website:
-https://snapchat.github.io/GiGL/
+<a href="https://snapchat.github.io/GiGL"/>https://snapchat.github.io/GiGL/</a>
 
-```
 
 ## Key Features 🌟
 

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,8 +1,0 @@
-.. only:: not html
-
-   This is a placeholder for GiGL's API documentation:
-   https://snapchat.github.io/GiGL/docs/api/
-
-   The documentation will get generated automatically from the source code
-   when the documentation is published.
-   See `conf.py` for more doc configuration.


### PR DESCRIPTION
It's quite inconvenient that you can't get directly to the docs by clicking from the README...

Docs self-linking is ok, so I exposed the link and now people can click it easily :) And it makes the README (which is the first thing people see when they lookup GiGL) look nicer too. 