### PR TITLE
Add HashedNodeSplitter

### DIFF
--- a/.github/workflows/on-pr-comment.yml
+++ b/.github/workflows/on-pr-comment.yml
@@ -20,19 +20,19 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
+
     - name: Setup Python
       uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-        
+
     - name: Install PyYAML
       run: pip install PyYAML
-      
+
     - name: Generate help text
       id: parse_commands
       run: python .github/scripts/get_help_text.py
-    
+
     - name: Post help comment
       uses: snapchat/gigl/.github/actions/comment-on-pr@main
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support `URI / URI_LIKE`, similar to `pathlib.Path`.
 
 ### Added
+- Added support for NodeAnchorSplitter
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Support `URI / URI_LIKE`, similar to `pathlib.Path`.
 
 ### Added
+
 - Added support for NodeAnchorSplitter
 
 ### Changed

--- a/python/gigl/common/data/dataloaders.py
+++ b/python/gigl/common/data/dataloaders.py
@@ -99,10 +99,8 @@ def _concatenate_features_by_names(
         tensor = feature_key_to_tf_tensor[feature_key]
 
         # TODO(kmonte, xgao, zfan): We will need to add support for this if we're trying to scale up.
-        # Some features (e.g., home city, last city, etc.) are vocabulary
-        # ids and are stored as int type. We cast it to float here and convert
-        # it back to int before feeding it to the feature embedding layer.
-        # Note that this is ok for small int values (less than 2^24, or ~16 million).
+        # Features may be stored as int type. We cast it to float here and will need to subsequently convert
+        # it back to int. Note that this is ok for small int values (less than 2^24, or ~16 million).
         # For large int values, we will need to round it when converting back
         # from float, as otherwise there will be precision loss.
         if tensor.dtype != tf.float32:

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -79,24 +79,22 @@ def _create_distributed_splits_from_hash(
     global_max_hash_value = max_hash_value
     global_min_hash_value = min_hash_value
     for max_and_min in all_max_and_mins:
-        global_max_hash_value = max(
-            global_max_hash_value, max_and_min[0].item()
-        )
-        global_min_hash_value = min(
-            global_min_hash_value, max_and_min[1].item()
-        )
+        global_max_hash_value = max(global_max_hash_value, max_and_min[0].item())
+        global_min_hash_value = min(global_min_hash_value, max_and_min[1].item())
 
-    normalized_hash_values = (hash_values - global_min_hash_value) / global_max_hash_value
+    normalized_hash_values = (
+        hash_values - global_min_hash_value
+    ) / global_max_hash_value
 
     # Create splits from normalized hash values
-    test_inds = normalized_hash_values >= 1 - num_test # 1 x M
-    val_inds = (normalized_hash_values >= 1 - num_test - num_val) & ~test_inds # 1 x M
-    train_inds = ~test_inds & ~val_inds # 1 x M
+    test_inds = normalized_hash_values >= 1 - num_test  # 1 x M
+    val_inds = (normalized_hash_values >= 1 - num_test - num_val) & ~test_inds  # 1 x M
+    train_inds = ~test_inds & ~val_inds  # 1 x M
 
     # Apply masks to select nodes
-    train = nodes_to_select[train_inds] # 1 x num_train_nodes
-    val = nodes_to_select[val_inds] # 1 x num_val_nodes
-    test = nodes_to_select[test_inds] # 1 x num_test_nodes
+    train = nodes_to_select[train_inds]  # 1 x num_train_nodes
+    val = nodes_to_select[val_inds]  # 1 x num_val_nodes
+    test = nodes_to_select[test_inds]  # 1 x num_test_nodes
 
     return train, val, test
 
@@ -144,7 +142,7 @@ class NodeAnchorSplitter(Protocol):
     """Protocol that should be satisfied for anything that is used to split on nodes directly.
 
     Args:
-        node_ids: The node IDs to split on. 1D tensor for homogeneous or mapping for heterogeneous
+        node_ids: The node IDs to split on. 1D tensor for homogeneous or mapping for heterogeneous. 1 x N
     Returns:
         The train (1 x X), val (1 x Y), test (1 x Z) nodes. X + Y + Z = N
     """

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -160,6 +160,7 @@ class HashedNodeAnchorLinkSplitter:
     NOTE: This splitter must be called when a Torch distributed process group is initialized.
     e.g. `torch.distributed.init_process_group` must be called before using this splitter.
 
+    We need this communication between the processes for determining the maximum and minimum hashed node id across all machines.
 
     In node-based splitting, a node may only ever live in one split. E.g. if one
     node has two label edges, *both* of those edges will be placed into the same split.
@@ -515,8 +516,6 @@ def _create_distributed_splits_from_hash(
     Raises:
         RuntimeError: If no distributed process group is found.
     """
-
-    _assert_valid_split_ratios(num_val, num_test)
 
     # Ensure hash values and nodes_to_select are on the same device
     hash_values = hash_values.to(nodes_to_select.device)

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -386,6 +386,8 @@ class HashedNodeSplitter:
     NOTE: This splitter must be called when a Torch distributed process group is initialized.
     e.g. `torch.distributed.init_process_group` must be called before using this splitter.
 
+    We need this communication between the processes for determining the maximum and minimum hashed node id across all machines.
+
     In node-based splitting, each node will be placed into exactly one split based on its hash value.
     This is simpler than edge-based splitting as it doesn't require extracting anchor nodes from edges.
 

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -1,5 +1,6 @@
 import gc
-from collections import Mapping, defaultdict
+from collections import defaultdict
+from collections.abc import Mapping
 from typing import (
     Callable,
     Final,

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -11,7 +11,6 @@ from typing import (
     Tuple,
     Union,
     overload,
-    runtime_checkable,
 )
 
 import torch
@@ -102,7 +101,6 @@ def _create_distributed_splits_from_hash(
     return train, val, test
 
 
-@runtime_checkable
 class NodeAnchorLinkSplitter(Protocol):
     """Protocol that should be satisfied for anything that is used to split on edges.
 
@@ -142,7 +140,6 @@ class NodeAnchorLinkSplitter(Protocol):
         ...
 
 
-@runtime_checkable
 class NodeAnchorSplitter(Protocol):
     """Protocol that should be satisfied for anything that is used to split on nodes directly.
 

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -388,6 +388,12 @@ class HashedNodeSplitter:
     In node-based splitting, each node will be placed into exactly one split based on its hash value.
     This is simpler than edge-based splitting as it doesn't require extracting anchor nodes from edges.
 
+    Additionally, the HashedNodeSplitter does not de-dup repeated node ids. This means that if there are repeated node ids
+    which are passed in, the same number of repeated node ids are included in the output, all of which are put into the same split.
+    This differs from the HashedNodeAnchorLinkSplitter, which does de-dup the repeated source or destination nodes that appear from the
+    labeled edges.
+
+
     Args:
         node_ids: The node IDs to split. Either a 1D tensor for homogeneous graphs,
                  or a mapping from node types to 1D tensors for heterogeneous graphs.

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -70,7 +70,7 @@ class NodeAnchorLinkSplitter(Protocol):
         ...
 
 
-class NodeAnchorSplitter(Protocol):
+class NodeSplitter(Protocol):
     """Protocol that should be satisfied for anything that is used to split on nodes directly.
 
     Args:

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -782,6 +782,8 @@ class TestDataSplitters(unittest.TestCase):
                 ),
                 val_num=0.2,
                 test_num=0.2,
+                # Val is empty in this case because, with the identity hash, we expect 1-120 to be in train,
+                # 120-160 to be in val, and 160-200 to be in test, and thus have no IDs which fall in the val range.
                 expected_train=torch.tensor(
                     [1, 1, 2, 2, 5, 5, 20, 20], dtype=torch.int64
                 ),

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -781,9 +781,11 @@ class TestDataSplitters(unittest.TestCase):
                 ),
                 val_num=0.2,
                 test_num=0.2,
-                expected_train=torch.tensor([1, 2, 5, 20], dtype=torch.int64),
+                expected_train=torch.tensor(
+                    [1, 1, 2, 2, 5, 5, 20, 20], dtype=torch.int64
+                ),
                 expected_val=torch.tensor([], dtype=torch.int64),
-                expected_test=torch.tensor([200], dtype=torch.int64),
+                expected_test=torch.tensor([200, 200], dtype=torch.int64),
             ),
         ]
     )
@@ -814,9 +816,9 @@ class TestDataSplitters(unittest.TestCase):
 
         train, val, test = splitter(node_ids)
 
-        assert_close(train, expected_train, rtol=0, atol=0)
-        assert_close(val, expected_val, rtol=0, atol=0)
-        assert_close(test, expected_test, rtol=0, atol=0)
+        assert_tensor_equality(train, expected_train, dim=0)
+        assert_tensor_equality(val, expected_val, dim=0)
+        assert_tensor_equality(test, expected_test, dim=0)
 
     @parameterized.expand(
         [
@@ -916,9 +918,9 @@ class TestDataSplitters(unittest.TestCase):
             expected_test,
         ) in expected.items():
             train, val, test = split[node_type]
-            assert_close(train, expected_train, rtol=0, atol=0)
-            assert_close(val, expected_val, rtol=0, atol=0)
-            assert_close(test, expected_test, rtol=0, atol=0)
+            assert_tensor_equality(train, expected_train, dim=0)
+            assert_tensor_equality(val, expected_val, dim=0)
+            assert_tensor_equality(test, expected_test, dim=0)
 
     def test_hashed_node_splitter_requires_process_group(self):
         node_ids = torch.arange(10, dtype=torch.int64)

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -12,8 +12,8 @@ from gigl.types.graph import DEFAULT_HOMOGENEOUS_EDGE_TYPE, to_heterogeneous_edg
 from gigl.utils.data_splitters import (
     HashedNodeAnchorLinkSplitter,
     HashedNodeSplitter,
+    _assert_valid_split_ratios,
     _check_edge_index,
-    _check_val_test_percentage,
     _fast_hash,
     _get_padded_labels,
     get_labels_for_anchor_nodes,
@@ -187,6 +187,24 @@ class TestDataSplitters(unittest.TestCase):
                 expected_train=torch.tensor([1, 2, 5, 20], dtype=torch.int64),
                 expected_val=torch.tensor([], dtype=torch.int64),
                 expected_test=torch.tensor([200], dtype=torch.int64),
+            ),
+            param(
+                "One source node id",
+                edges=torch.stack(
+                    [
+                        torch.zeros(10, dtype=torch.int64),
+                        torch.ones(10, dtype=torch.int64),
+                    ]
+                ),
+                sampling_direction="out",
+                val_num=0.1,
+                test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0 to be train and val and test to be empty.
+                expected_train=torch.tensor(
+                    [0], dtype=torch.int64
+                ),
+                expected_val=torch.tensor([], dtype=torch.int64),
+                expected_test=torch.tensor([], dtype=torch.int64),
             ),
         ]
     )
@@ -597,9 +615,9 @@ class TestDataSplitters(unittest.TestCase):
             param("Negative val percentage", train_percentage=0.8, val_percentage=-1.0),
         ]
     )
-    def test_check_val_test_percentage(self, _, train_percentage, val_percentage):
+    def test_assert_valid_split_ratios(self, _, train_percentage, val_percentage):
         with self.assertRaises(ValueError):
-            _check_val_test_percentage(train_percentage, val_percentage)
+            _assert_valid_split_ratios(train_percentage, val_percentage)
 
     @parameterized.expand(
         [

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -159,11 +159,9 @@ class TestDataSplitters(unittest.TestCase):
                 sampling_direction="out",
                 val_num=0.2,
                 test_num=0.2,
-                expected_train=torch.tensor(
-                    [1, 1, 2, 2, 5, 5, 20, 20], dtype=torch.int64
-                ),
+                expected_train=torch.tensor([1, 2, 5, 20], dtype=torch.int64),
                 expected_val=torch.tensor([], dtype=torch.int64),
-                expected_test=torch.tensor([200, 200], dtype=torch.int64),
+                expected_test=torch.tensor([200], dtype=torch.int64),
             ),
             param(
                 "One source node id",
@@ -783,11 +781,9 @@ class TestDataSplitters(unittest.TestCase):
                 ),
                 val_num=0.2,
                 test_num=0.2,
-                expected_train=torch.tensor(
-                    [1, 1, 2, 2, 5, 5, 20, 20], dtype=torch.int64
-                ),
+                expected_train=torch.tensor([1, 2, 5, 20], dtype=torch.int64),
                 expected_val=torch.tensor([], dtype=torch.int64),
-                expected_test=torch.tensor([200, 200], dtype=torch.int64),
+                expected_test=torch.tensor([200], dtype=torch.int64),
             ),
         ]
     )

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -118,6 +118,7 @@ class TestDataSplitters(unittest.TestCase):
                 sampling_direction="out",
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-7 to be train, 8 to be val, and 9 to be test
                 expected_train=torch.tensor(
                     [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.int64
                 ),
@@ -155,6 +156,9 @@ class TestDataSplitters(unittest.TestCase):
                 sampling_direction="out",
                 val_num=0.2,
                 test_num=0.2,
+                # Since we are using the identity hash with 0.6-0.2-0.2 split, we'd expect values 1-159 to be train, 160-179 to be val, 180 - 200 to be test.
+                # Since there no value between 160-179, val is empty.
+                # Since there is one value between 180-199, test has one item.
                 expected_train=torch.tensor([1, 2, 5, 20], dtype=torch.int64),
                 expected_val=torch.tensor([], dtype=torch.int64),
                 expected_test=torch.tensor([200], dtype=torch.int64),
@@ -170,6 +174,7 @@ class TestDataSplitters(unittest.TestCase):
                 sampling_direction="out",
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0 to be train and val and test to be empty.
                 expected_train=torch.tensor([0], dtype=torch.int64),
                 expected_val=torch.tensor([], dtype=torch.int64),
                 expected_test=torch.tensor([], dtype=torch.int64),
@@ -224,6 +229,7 @@ class TestDataSplitters(unittest.TestCase):
                 edge_types_to_split=[EdgeType(_NODE_A, _TO, _NODE_B)],
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-7 to be train, 8 to be val, and 9 to be test for _NODE_B
                 expected={
                     _NODE_B: (
                         torch.arange(8, dtype=torch.int64),
@@ -253,6 +259,7 @@ class TestDataSplitters(unittest.TestCase):
                 ],
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-7 to be train, 8 to be val, and 9 to be test for _NODE_B
                 expected={
                     _NODE_B: (
                         torch.arange(8, dtype=torch.int64),
@@ -283,6 +290,8 @@ class TestDataSplitters(unittest.TestCase):
                 ],
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-7 to be train, 8 to be val, and 9 to be test for _NODE_B
+                # We'd expect values 0-15 to be train, 16-17 to be val, and 18-19 to be test for _NODE_C
                 expected={
                     _NODE_B: (
                         torch.arange(8, dtype=torch.int64),
@@ -318,6 +327,7 @@ class TestDataSplitters(unittest.TestCase):
                 ],
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-15 to be train, 16-17 to be val, and 18-19 to be test for NODE_A
                 expected={
                     _NODE_A: (
                         torch.arange(16, dtype=torch.int64),
@@ -348,6 +358,7 @@ class TestDataSplitters(unittest.TestCase):
                 ],
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-7 to be train, 8 to be val, and 9 to be test for _NODE_A
                 expected={
                     _NODE_A: (
                         torch.arange(8, dtype=torch.int64),
@@ -378,6 +389,7 @@ class TestDataSplitters(unittest.TestCase):
                 ],
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-8 to be train, 9 to be val, and 10-11 to be test for _NODE_A
                 expected={
                     _NODE_A: (
                         torch.arange(9, dtype=torch.int64),
@@ -771,6 +783,7 @@ class TestDataSplitters(unittest.TestCase):
                 node_ids=torch.arange(10, dtype=torch.int64),
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-7 to be train, 8 to be val, and 9 to be test
                 expected_train=torch.arange(8, dtype=torch.int64),
                 expected_val=torch.tensor([8], dtype=torch.int64),
                 expected_test=torch.tensor([9], dtype=torch.int64),
@@ -830,6 +843,7 @@ class TestDataSplitters(unittest.TestCase):
                 node_ids={_NODE_A: torch.arange(10, dtype=torch.int64)},
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-7 to be train, 8 to be val, and 9 to be test for _NODE_A
                 expected={
                     _NODE_A: (
                         torch.arange(8, dtype=torch.int64),
@@ -846,6 +860,8 @@ class TestDataSplitters(unittest.TestCase):
                 },
                 val_num=0.1,
                 test_num=0.1,
+                # Since we are using the identity hash with 0.8-0.1-0.1 split, we'd expect values 0-7 to be train, 8 to be val, and 9 to be test for _NODE_A
+                # We'd expect values 0-15 to be train, 16-17 to be val, and 18-19 to be test for _NODE_B
                 expected={
                     _NODE_A: (
                         torch.arange(8, dtype=torch.int64),
@@ -868,6 +884,9 @@ class TestDataSplitters(unittest.TestCase):
                 },
                 val_num=0.2,
                 test_num=0.2,
+                # Since we are using the identity hash with 0.6-0.2-0.2 split, we'd expect values 0-2 to be train, 3 to be val, and 4 to be test for _NODE_A
+                # We'd expect values 0-71 to be train, 72-95 to be val, and 96-119 to be test for _NODE_B
+                # We'd expect values 0-5 to be train, 6-7 to be val, and 8-9 to be test
                 expected={
                     _NODE_A: (
                         torch.arange(3, dtype=torch.int64),

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -12,7 +12,7 @@ from gigl.types.graph import DEFAULT_HOMOGENEOUS_EDGE_TYPE, to_heterogeneous_edg
 from gigl.utils.data_splitters import (
     HashedNodeAnchorLinkSplitter,
     HashedNodeSplitter,
-    _check_edge_index,
+    _check_edge_index_is_valid,
     _check_val_test_percentage,
     _fast_hash,
     _get_padded_labels,
@@ -568,9 +568,9 @@ class TestDataSplitters(unittest.TestCase):
             param("Sparse tensor", edges=torch.zeros(2, 2).to_sparse()),
         ]
     )
-    def test_check_edge_index(self, _, edges):
+    def test_check_edge_index_is_valid(self, _, edges):
         with self.assertRaises(ValueError):
-            _check_edge_index(edges)
+            _check_edge_index_is_valid(edges)
 
     def test_hashed_node_anchor_link_splitter_requires_process_group(self):
         edges = torch.stack(

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -12,7 +12,7 @@ from gigl.types.graph import DEFAULT_HOMOGENEOUS_EDGE_TYPE, to_heterogeneous_edg
 from gigl.utils.data_splitters import (
     HashedNodeAnchorLinkSplitter,
     HashedNodeSplitter,
-    _check_edge_index_is_valid,
+    _check_edge_index,
     _check_val_test_percentage,
     _fast_hash,
     _get_padded_labels,
@@ -618,9 +618,9 @@ class TestDataSplitters(unittest.TestCase):
             param("Sparse tensor", edges=torch.zeros(2, 2).to_sparse()),
         ]
     )
-    def test_check_edge_index_is_valid(self, _, edges):
+    def test_check_edge_index(self, _, edges):
         with self.assertRaises(ValueError):
-            _check_edge_index_is_valid(edges)
+            _check_edge_index(edges)
 
     def test_hashed_node_anchor_link_splitter_requires_process_group(self):
         edges = torch.stack(

--- a/python/tests/unit/utils/data_splitters_test.py
+++ b/python/tests/unit/utils/data_splitters_test.py
@@ -147,41 +147,23 @@ class TestDataSplitters(unittest.TestCase):
                 expected_test=torch.tensor([9], dtype=torch.int64),
             ),
             param(
-                "With dups",
+                "Non-contiguous and duplicated source node ids",
                 edges=torch.stack(
                     [
-                        torch.cat(
-                            [
-                                torch.arange(10, dtype=torch.int64),
-                                torch.arange(10, dtype=torch.int64),
-                            ]
+                        torch.tensor(
+                            [1, 2, 20, 5, 200, 1, 5, 20, 200, 2], dtype=torch.int64
                         ),
-                        torch.zeros(20, dtype=torch.int64),
-                    ]
-                ),
-                sampling_direction="out",
-                val_num=0.1,
-                test_num=0.1,
-                expected_train=torch.tensor(
-                    [0, 1, 2, 3, 4, 5, 6, 7], dtype=torch.int64
-                ),
-                expected_val=torch.tensor([8], dtype=torch.int64),
-                expected_test=torch.tensor([9], dtype=torch.int64),
-            ),
-            param(
-                "Non-contiguous source node ids",
-                edges=torch.stack(
-                    [
-                        torch.tensor([1, 20, 2, 5, 200], dtype=torch.int64),
-                        torch.zeros(5, dtype=torch.int64),
+                        torch.zeros(10, dtype=torch.int64),
                     ]
                 ),
                 sampling_direction="out",
                 val_num=0.2,
                 test_num=0.2,
-                expected_train=torch.tensor([1, 2, 5, 20], dtype=torch.int64),
+                expected_train=torch.tensor(
+                    [1, 1, 2, 2, 5, 5, 20, 20], dtype=torch.int64
+                ),
                 expected_val=torch.tensor([], dtype=torch.int64),
-                expected_test=torch.tensor([200], dtype=torch.int64),
+                expected_test=torch.tensor([200, 200], dtype=torch.int64),
             ),
             param(
                 "One source node id",
@@ -786,7 +768,7 @@ class TestDataSplitters(unittest.TestCase):
     @parameterized.expand(
         [
             param(
-                "Basic node splitting with identity hash",
+                "Basic node splitting",
                 node_ids=torch.arange(10, dtype=torch.int64),
                 val_num=0.1,
                 test_num=0.1,
@@ -795,27 +777,17 @@ class TestDataSplitters(unittest.TestCase):
                 expected_test=torch.tensor([9], dtype=torch.int64),
             ),
             param(
-                "Node splitting with duplicates",
-                node_ids=torch.cat(
-                    [
-                        torch.arange(10, dtype=torch.int64),
-                        torch.arange(10, dtype=torch.int64),
-                    ]
+                "Node splitting with non-contiguous and duplicate IDs",
+                node_ids=torch.tensor(
+                    [1, 2, 20, 5, 200, 1, 5, 20, 200, 2], dtype=torch.int64
                 ),
-                val_num=0.1,
-                test_num=0.1,
-                expected_train=torch.arange(8, dtype=torch.int64),
-                expected_val=torch.tensor([8], dtype=torch.int64),
-                expected_test=torch.tensor([9], dtype=torch.int64),
-            ),
-            param(
-                "Node splitting with non-contiguous IDs",
-                node_ids=torch.tensor([1, 20, 2, 5, 200], dtype=torch.int64),
                 val_num=0.2,
                 test_num=0.2,
-                expected_train=torch.tensor([1, 2, 5, 20], dtype=torch.int64),
+                expected_train=torch.tensor(
+                    [1, 1, 2, 2, 5, 5, 20, 20], dtype=torch.int64
+                ),
                 expected_val=torch.tensor([], dtype=torch.int64),
-                expected_test=torch.tensor([200], dtype=torch.int64),
+                expected_test=torch.tensor([200, 200], dtype=torch.int64),
             ),
         ]
     )


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- Adds the NodeAnchorSplitter/HashedNodeAnchorSplitter classes which aims to split node ids instead of edge indices, which the HashedNodeAnchorLinkSplitter is responsible for.
- Re-uses constructs of the HashedNodeLinkSplitter where possible
- Adds relevant tests

This implementation provides additional value over the [GLT splitting implementation](https://github.com/alibaba/graphlearn-for-pytorch/blob/main/graphlearn_torch/python/data/dataset.py#L504-L515) by making less rigorous assumptions about the node ids that are provided to the splitter, such as not requiring every node to be split upon (by requiring as an argument the total number of nodes N and splitting the ids from 0 to N). This may be useful in cases where we may only want to provide a subset of nodes to the splitter when we have an imbalanced dataset. Additionally, if we want to include a node id multiple times, it ensures that it will be hashed to the same split each time.
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
