### PR TITLE
Revert "Replace typing.Dict with dict (#183)"

### DIFF
--- a/examples/MAG240M/preprocessor_config.py
+++ b/examples/MAG240M/preprocessor_config.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Dict
 
 import tensorflow as tf
 import tensorflow_transform as tft
@@ -261,7 +261,7 @@ class Mag240DataPreprocessorConfig(DataPreprocessorConfig):
 
     def get_nodes_preprocessing_spec(
         self,
-    ) -> dict[NodeDataReference, NodeDataPreprocessingSpec]:
+    ) -> Dict[NodeDataReference, NodeDataPreprocessingSpec]:
         # We specify where the input data is located using NodeDataReference
         # In this case, we are reading from BigQuery, thus make use off BigqueryNodeDataReference
         paper_node_data_reference: NodeDataReference = BigqueryNodeDataReference(
@@ -292,7 +292,7 @@ class Mag240DataPreprocessorConfig(DataPreprocessorConfig):
 
     def get_edges_preprocessing_spec(
         self,
-    ) -> dict[EdgeDataReference, EdgeDataPreprocessingSpec]:
+    ) -> Dict[EdgeDataReference, EdgeDataPreprocessingSpec]:
         main_edge_type = EdgeType(
             src_node_type=NodeType(self.node_type_paper_or_author),
             relation=Relation(self.relation_references),

--- a/examples/link_prediction/heterogeneous_inference.py
+++ b/examples/link_prediction/heterogeneous_inference.py
@@ -22,7 +22,7 @@ You can run this example in a full pipeline with `make run_het_dblp_sup_test` fr
 import argparse
 import gc
 import time
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import torch
 import torch.distributed
@@ -68,10 +68,10 @@ def _inference_process(
     hid_dim: int,
     out_dim: int,
     dataset: DistLinkPredictionDataset,
-    inferencer_args: dict[str, str],
+    inferencer_args: Dict[str, str],
     inference_node_type: NodeType,
-    node_type_to_feature_dim: dict[NodeType, int],
-    edge_type_to_feature_dim: dict[EdgeType, int],
+    node_type_to_feature_dim: Dict[NodeType, int],
+    edge_type_to_feature_dim: Dict[EdgeType, int],
 ):
     """
     This function is spawned by multiple processes per machine and is responsible for:
@@ -92,11 +92,11 @@ def _inference_process(
         hid_dim (int): Hidden dimension of the model
         out_dim (int): Output dimension of the model
         dataset (DistLinkPredictionDataset): Link prediction dataset built on current machine
-        inferencer_args (dict[str, str]): Additional arguments for inferencer
+        inferencer_args (Dict[str, str]): Additional arguments for inferencer
         inference_node_type (NodeType): Node Type that embeddings should be generated for in current inference process. This is used to
             tag the embeddings written to GCS.
-        node_type_to_feature_dim (dict[NodeType, int]): Input node feature dimension per node type for the model
-        edge_type_to_feature_dim (dict[EdgeType, int]): Input edge feature dimension per edge type for the model
+        node_type_to_feature_dim (Dict[NodeType, int]): Input node feature dimension per node type for the model
+        edge_type_to_feature_dim (Dict[EdgeType, int]): Input edge feature dimension per edge type for the model
     """
 
     # Parses the fanout as a string.
@@ -146,7 +146,7 @@ def _inference_process(
 
     # Get the node ids on the current machine for the current node type
     node_type_to_input_node_ids: Optional[
-        Union[torch.Tensor, dict[NodeType, torch.Tensor]]
+        Union[torch.Tensor, Dict[NodeType, torch.Tensor]]
     ] = dataset.node_ids
     assert isinstance(
         node_type_to_input_node_ids, dict
@@ -330,14 +330,14 @@ def _run_example_inference(
 
     graph_metadata = gbml_config_pb_wrapper.graph_metadata_pb_wrapper
 
-    node_type_to_feature_dim: dict[NodeType, int] = {
+    node_type_to_feature_dim: Dict[NodeType, int] = {
         graph_metadata.condensed_node_type_to_node_type_map[
             condensed_node_type
         ]: node_feature_dim
         for condensed_node_type, node_feature_dim in gbml_config_pb_wrapper.preprocessed_metadata_pb_wrapper.condensed_node_type_to_feature_dim_map.items()
     }
 
-    edge_type_to_feature_dim: dict[EdgeType, int] = {
+    edge_type_to_feature_dim: Dict[EdgeType, int] = {
         graph_metadata.condensed_edge_type_to_edge_type_map[
             condensed_edge_type
         ]: edge_feature_dim

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -22,6 +22,7 @@ You can run this example in a full pipeline with `make run_hom_cora_sup_test` fr
 import argparse
 import gc
 import time
+from typing import Dict
 
 import torch
 import torch.multiprocessing as mp
@@ -72,7 +73,7 @@ def _inference_process(
     hid_dim: int,
     out_dim: int,
     dataset: DistLinkPredictionDataset,
-    inferencer_args: dict[str, str],
+    inferencer_args: Dict[str, str],
     inference_node_type: NodeType,
     node_feature_dim: int,
     edge_feature_dim: int,
@@ -93,7 +94,7 @@ def _inference_process(
         hid_dim (int): Hidden dimension of the model
         out_dim (int): Output dimension of the model
         dataset (DistLinkPredictionDataset): Link prediction dataset built on current machine
-        inferencer_args (dict[str, str]): Additional arguments for inferencer
+        inferencer_args (Dict[str, str]): Additional arguments for inferencer
         inference_node_type (NodeType): Node Type that embeddings should be generated for. This is used to
             tag the embeddings written to GCS.
         node_feature_dim (int): Input node feature dimension for the model

--- a/examples/toy_visual_example/toy_data_preprocessor_config.py
+++ b/examples/toy_visual_example/toy_data_preprocessor_config.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from gigl.common.logger import Logger
 from gigl.src.common.types import AppliedTaskIdentifier
 from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
@@ -54,7 +56,7 @@ class ToyDataPreprocessorConfig(DataPreprocessorConfig):
 
     def get_nodes_preprocessing_spec(
         self,
-    ) -> dict[NodeDataReference, NodeDataPreprocessingSpec]:
+    ) -> Dict[NodeDataReference, NodeDataPreprocessingSpec]:
         node_data_ref = BigqueryNodeDataReference(
             reference_uri=self._bq_nodes_table_name,
             node_type=NodeType(self._node_type),
@@ -80,7 +82,7 @@ class ToyDataPreprocessorConfig(DataPreprocessorConfig):
 
     def get_edges_preprocessing_spec(
         self,
-    ) -> dict[EdgeDataReference, EdgeDataPreprocessingSpec]:
+    ) -> Dict[EdgeDataReference, EdgeDataPreprocessingSpec]:
         edge_data_ref = BigqueryEdgeDataReference(
             reference_uri=self._bq_edges_table_name,
             edge_type=EdgeType(

--- a/python/gigl/analytics/graph_validation/bq_graph_validator.py
+++ b/python/gigl/analytics/graph_validation/bq_graph_validator.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 from google.cloud.bigquery.table import RowIterator
 
@@ -14,7 +14,7 @@ class BQGraphValidator:
         edge_table: str,
         src_node_column_name: str,
         dst_node_column_name: str,
-        query_labels: dict[str, str] = {},
+        query_labels: Dict[str, str] = {},
         bq_gcp_project: Optional[str] = None,
     ) -> bool:
         """
@@ -25,7 +25,7 @@ class BQGraphValidator:
             edge_table (str): The edge table to validate
             src_node_column_name (str): The column name in the table that contains the source node ids
             dst_node_column_name (str): The column name in the table that contains the destination node ids
-            query_labels (dict[str, str], optional): Cloud Provider Labels to add to the Query. Defaults to {}.
+            query_labels (Dict[str, str], optional): Cloud Provider Labels to add to the Query. Defaults to {}.
             bq_gcp_project (Optional[str], optional): The GCP project to run the query in. If None the BQ
                 client will usse the default project inferred from the environment. Defaults to None.
 

--- a/python/gigl/common/beam/coders.py
+++ b/python/gigl/common/beam/coders.py
@@ -1,4 +1,4 @@
-from typing import Any, Iterable
+from typing import Any, Dict, Iterable
 
 import apache_beam as beam
 import pyarrow as pa
@@ -30,7 +30,7 @@ class RuntimeTFExampleProtoCoderFn(beam.DoFn):
 
     def process(
         self,
-        element: dict[str, common_types.TensorType],
+        element: Dict[str, common_types.TensorType],
         transformed_metadata: tensorflow_transform.tf_metadata.dataset_metadata.DatasetMetadata,
         *args,
         **kwargs,
@@ -40,7 +40,7 @@ class RuntimeTFExampleProtoCoderFn(beam.DoFn):
         which only materializes as the true transformed-metadata when passed in as part of process.
 
         Args:
-            sample (dict[str, common_types.TensorType]): TfExample Instance Dict
+            sample (Dict[str, common_types.TensorType]): TfExample Instance Dict
             transformed_metadata (tensorflow_transform.tf_metadata.dataset_metadata.DatasetMetadata):
                 Used to generate the ExampleProtoCoder
 

--- a/python/gigl/common/constants.py
+++ b/python/gigl/common/constants.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Final
+from typing import Dict, Final
 
 # TODO: (svij) https://github.com/Snapchat/GiGL/issues/125
 # common -> gigl -> python (or root dir in Docker container)
@@ -19,7 +19,7 @@ PATH_BASE_IMAGES_VARIABLE_FILE: Final[Path] = Path.joinpath(
 ).absolute()
 
 
-def parse_makefile_vars(makefile_path: Path) -> dict[str, str]:
+def parse_makefile_vars(makefile_path: Path) -> Dict[str, str]:
     """
     Parse variables from a Makefile-like file.
 
@@ -27,9 +27,9 @@ def parse_makefile_vars(makefile_path: Path) -> dict[str, str]:
         makefile_path (Path): The path to the Makefile-like file.
 
     Returns:
-        dict[str, str]: A dictionary containing key-value pairs of variables defined in the file.
+        Dict[str, str]: A dictionary containing key-value pairs of variables defined in the file.
     """
-    vars_dict: dict[str, str] = {}
+    vars_dict: Dict[str, str] = {}
     with open(makefile_path, "r") as f:
         for line in f.readlines():
             if line.strip().startswith("#") or not line.strip():
@@ -40,7 +40,7 @@ def parse_makefile_vars(makefile_path: Path) -> dict[str, str]:
     return vars_dict
 
 
-_make_file_vars: dict[str, str] = parse_makefile_vars(PATH_BASE_IMAGES_VARIABLE_FILE)
+_make_file_vars: Dict[str, str] = parse_makefile_vars(PATH_BASE_IMAGES_VARIABLE_FILE)
 
 DOCKER_LATEST_BASE_CUDA_IMAGE_NAME_WITH_TAG: Final[str] = _make_file_vars[
     "DOCKER_LATEST_BASE_CUDA_IMAGE_NAME_WITH_TAG"

--- a/python/gigl/common/data/dataloaders.py
+++ b/python/gigl/common/data/dataloaders.py
@@ -2,7 +2,7 @@ import time
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Optional, Sequence, Tuple, Union
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 import psutil
 import tensorflow as tf
@@ -77,7 +77,7 @@ class TFDatasetOptions:
 
 
 def _concatenate_features_by_names(
-    feature_key_to_tf_tensor: dict[str, tf.Tensor],
+    feature_key_to_tf_tensor: Dict[str, tf.Tensor],
     feature_keys: Sequence[str],
 ) -> tf.Tensor:
     """
@@ -86,7 +86,7 @@ def _concatenate_features_by_names(
     It is assumed that feature_names is a subset of the keys in feature_name_to_tf_tensor.
 
     Args:
-        feature_key_to_tf_tensor (dict[str, tf.Tensor]): A dictionary mapping feature names to their corresponding tf tensors.
+        feature_key_to_tf_tensor (Dict[str, tf.Tensor]): A dictionary mapping feature names to their corresponding tf tensors.
         feature_keys (list[str]): A list of feature names specifying the order in which tensors should be concatenated.
 
     Returns:
@@ -131,13 +131,13 @@ def _tf_tensor_to_torch_tensor(tf_tensor: tf.Tensor) -> torch.Tensor:
 def _build_example_parser(
     *,
     feature_spec: FeatureSpecDict,
-) -> Callable[[bytes], dict[str, tf.Tensor]]:
+) -> Callable[[bytes], Dict[str, tf.Tensor]]:
     # Wrapping this partial with tf.function gives us a speedup.
     # https://www.tensorflow.org/guide/function
     @tf.function
     def _parse_example(
         example_proto: bytes, spec: FeatureSpecDict
-    ) -> dict[str, tf.Tensor]:
+    ) -> Dict[str, tf.Tensor]:
         return tf.io.parse_example(example_proto, spec)
 
     return partial(_parse_example, spec=feature_spec)

--- a/python/gigl/common/data/load_torch_tensors.py
+++ b/python/gigl/common/data/load_torch_tensors.py
@@ -1,7 +1,7 @@
 import time
 import traceback
 from dataclasses import dataclass
-from typing import MutableMapping, Optional, Union
+from typing import Dict, MutableMapping, Optional, Union
 
 import torch
 import torch.multiprocessing as mp
@@ -38,36 +38,36 @@ class SerializedGraphMetadata:
     Stores information for all entities. If homogeneous, all types are of type SerializedTFRecordInfo. Otherwise, they are dictionaries with the corresponding mapping.
     """
 
-    # Node Entity Info for loading node tensors, a SerializedTFRecordInfo for homogeneous and dict[NodeType, SerializedTFRecordInfo] for heterogeneous cases
+    # Node Entity Info for loading node tensors, a SerializedTFRecordInfo for homogeneous and Dict[NodeType, SerializedTFRecordInfo] for heterogeneous cases
     node_entity_info: Union[
-        SerializedTFRecordInfo, dict[NodeType, SerializedTFRecordInfo]
+        SerializedTFRecordInfo, Dict[NodeType, SerializedTFRecordInfo]
     ]
-    # Edge Entity Info for loading edge tensors, a SerializedTFRecordInfo for homogeneous and dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases
+    # Edge Entity Info for loading edge tensors, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases
     edge_entity_info: Union[
-        SerializedTFRecordInfo, dict[EdgeType, SerializedTFRecordInfo]
+        SerializedTFRecordInfo, Dict[EdgeType, SerializedTFRecordInfo]
     ]
-    # Positive Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases.
+    # Positive Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases.
     # If there are no positive labels for any edge type, this value is None
     positive_label_entity_info: Optional[
-        Union[SerializedTFRecordInfo, dict[EdgeType, SerializedTFRecordInfo]]
+        Union[SerializedTFRecordInfo, Dict[EdgeType, SerializedTFRecordInfo]]
     ] = None
-    # Negative Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases.
+    # Negative Label Entity Info, if present, a SerializedTFRecordInfo for homogeneous and Dict[EdgeType, SerializedTFRecordInfo] for heterogeneous cases.
     # If there are no negative labels for any edge type, this value is None.
     negative_label_entity_info: Optional[
-        Union[SerializedTFRecordInfo, dict[EdgeType, SerializedTFRecordInfo]]
+        Union[SerializedTFRecordInfo, Dict[EdgeType, SerializedTFRecordInfo]]
     ] = None
 
 
 def _data_loading_process(
     tf_record_dataloader: TFRecordDataLoader,
     output_dict: MutableMapping[
-        str, Union[torch.Tensor, dict[Union[NodeType, EdgeType], torch.Tensor]]
+        str, Union[torch.Tensor, Dict[Union[NodeType, EdgeType], torch.Tensor]]
     ],
     error_dict: MutableMapping[str, str],
     entity_type: str,
     serialized_tf_record_info: Union[
         SerializedTFRecordInfo,
-        dict[Union[NodeType, EdgeType], SerializedTFRecordInfo],
+        Dict[Union[NodeType, EdgeType], SerializedTFRecordInfo],
     ],
     rank: int,
     tf_dataset_options: TFDatasetOptions = TFDatasetOptions(),
@@ -79,12 +79,12 @@ def _data_loading_process(
 
     Args:
         tf_record_dataloader (TFRecordDataLoader): TFRecordDataloader used for loading tensors from serialized tfrecords
-        output_dict (MutableMapping[str, Union[torch.Tensor, dict[Union[NodeType, EdgeType], torch.Tensor]]]):
+        output_dict (MutableMapping[str, Union[torch.Tensor, Dict[Union[NodeType, EdgeType], torch.Tensor]]]):
             Dictionary initialized by mp.Manager().dict() in which outputs of tensor loading will be written to
         error_dict (MutableMapping[str, str]): Dictionary initialized by mp.Manager().dict() in which error of errors in current process will be written to
         entity_type (str): Entity type to prefix ids, features, and error keys with when
             writing to the output_dict and error_dict fields
-        serialized_tf_record_info (Union[SerializedTFRecordInfo, dict[NodeType, SerializedTFRecordInfo], dict[EdgeType, SerializedTFRecordInfo]]):
+        serialized_tf_record_info (Union[SerializedTFRecordInfo, Dict[NodeType, SerializedTFRecordInfo], Dict[EdgeType, SerializedTFRecordInfo]]):
             Serialized information for current entity
         rank (int): Rank of the current machine
         tf_dataset_options (TFDatasetOptions): The options to use when building the dataset.
@@ -113,8 +113,8 @@ def _data_loading_process(
             f"Rank {rank} has begun to load data from tfrecord directories: {all_tf_record_uris}"
         )
 
-        ids: dict[Union[NodeType, EdgeType], torch.Tensor] = {}
-        features: dict[Union[NodeType, EdgeType], torch.Tensor] = {}
+        ids: Dict[Union[NodeType, EdgeType], torch.Tensor] = {}
+        features: Dict[Union[NodeType, EdgeType], torch.Tensor] = {}
         for (
             graph_type,
             serialized_entity_tf_record_info,
@@ -206,11 +206,11 @@ def load_torch_tensors_from_tf_record(
     ctx = mp.get_context("spawn")
 
     node_output_dict: MutableMapping[
-        str, Union[torch.Tensor, dict[NodeType, torch.Tensor]]
+        str, Union[torch.Tensor, Dict[NodeType, torch.Tensor]]
     ] = manager.dict()
 
     edge_output_dict: MutableMapping[
-        str, Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
+        str, Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
     ] = manager.dict()
 
     error_dict: MutableMapping[str, str] = manager.dict()

--- a/python/gigl/common/logger.py
+++ b/python/gigl/common/logger.py
@@ -2,7 +2,7 @@ import logging
 import os
 import pathlib
 from datetime import datetime
-from typing import Any, MutableMapping, Optional
+from typing import Any, Dict, MutableMapping, Optional
 
 from google.cloud import logging as google_cloud_logging
 
@@ -16,7 +16,7 @@ class Logger(logging.LoggerAdapter):
         logger (Optional[logging.Logger]): A custom logger to use. If not provided, the default logger will be created.
         name (Optional[str]): The name to be used for the logger. By default uses "root".
         log_to_file (bool): If True, logs will be written to a file. If False, logs will be written to the console.
-        extra (Optional[dict[str, Any]]): Extra information to be added to the log message.
+        extra (Optional[Dict[str, Any]]): Extra information to be added to the log message.
     """
 
     def __init__(
@@ -24,7 +24,7 @@ class Logger(logging.LoggerAdapter):
         logger: Optional[logging.Logger] = None,
         name: Optional[str] = None,
         log_to_file: bool = False,
-        extra: Optional[dict[str, Any]] = None,
+        extra: Optional[Dict[str, Any]] = None,
     ):
         if logger is None:
             logger = logging.getLogger(name)

--- a/python/gigl/common/services/vertex_ai.py
+++ b/python/gigl/common/services/vertex_ai.py
@@ -62,7 +62,7 @@ print(f"{job.name=}") # job.name='get-pipeline-20250226170755' # NOTE: by defaul
 import datetime
 import time
 from dataclasses import dataclass
-from typing import Final, Optional
+from typing import Dict, Final, Optional
 
 from google.cloud import aiplatform
 from google.cloud.aiplatform_v1.types import (
@@ -93,14 +93,14 @@ class VertexAiJobConfig:
     container_uri: str
     command: list[str]
     args: Optional[list[str]] = None
-    environment_variables: Optional[list[dict[str, str]]] = None
+    environment_variables: Optional[list[Dict[str, str]]] = None
     machine_type: str = "n1-standard-4"
     accelerator_type: str = "ACCELERATOR_TYPE_UNSPECIFIED"
     accelerator_count: int = 0
     replica_count: int = 1
     boot_disk_type: str = "pd-ssd"  # Persistent Disk SSD
     boot_disk_size_gb: int = 100  # Default disk size in GB
-    labels: Optional[dict[str, str]] = None
+    labels: Optional[Dict[str, str]] = None
     timeout_s: Optional[
         int
     ] = None  # Will default to DEFAULT_CUSTOM_JOB_TIMEOUT_S if not provided
@@ -250,7 +250,7 @@ class VertexAIService:
         self,
         display_name: str,
         template_path: Uri,
-        run_keyword_args: dict[str, str],
+        run_keyword_args: Dict[str, str],
         job_id: Optional[str] = None,
         experiment: Optional[str] = None,
     ) -> aiplatform.PipelineJob:
@@ -262,7 +262,7 @@ class VertexAIService:
         Args:
             display_name (str): The display of the pipeline.
             template_path (Uri): The path to the compiled pipeline YAML.
-            run_keyword_args (dict[str, str]): Runtime arguements passed to your pipeline.
+            run_keyword_args (Dict[str, str]): Runtime arguements passed to your pipeline.
             job_id (Optional[str]): The ID of the job. If not provided will be the *pipeline_name* + datetime.
                                     Note: The pipeline_name and display_name are *not* the same.
                                     Note: pipeline_name comes is defined in the `template_path` and ultimately comes from Python pipeline definition.

--- a/python/gigl/common/types/wrappers/kfp_api.py
+++ b/python/gigl/common/types/wrappers/kfp_api.py
@@ -2,7 +2,7 @@
 Marked for deprecation
 """
 import datetime
-from typing import Optional
+from typing import Dict, Optional
 
 import kfp_server_api
 from kfp_server_api.models.v2beta1_pipeline_task_detail import V2beta1PipelineTaskDetail
@@ -74,8 +74,8 @@ class ApiRunDetailWrapper:
 
     @property
     @lru_cache(maxsize=1)
-    def job_parameters(self) -> dict[str, str]:
-        parameters_dict: dict[str, str] = {}
+    def job_parameters(self) -> Dict[str, str]:
+        parameters_dict: Dict[str, str] = {}
 
         runtime_config: V2beta1RuntimeConfig = self.api_run.runtime_config
         for name, val in runtime_config.parameters.items():
@@ -87,13 +87,13 @@ class ApiRunDetailWrapper:
     @lru_cache(maxsize=1)
     def task_details_map(
         self,
-    ) -> dict[str, KfpTaskDetails]:
+    ) -> Dict[str, KfpTaskDetails]:
         """
 
         Returns:
-            dict[str, KfpTaskDetails]: Note that the keys are the display name of the KFP component
+            Dict[str, KfpTaskDetails]: Note that the keys are the display name of the KFP component
         """
-        task_details_dict: dict[str, KfpTaskDetails] = {}
+        task_details_dict: Dict[str, KfpTaskDetails] = {}
         run_details: V2beta1RunDetails = self.api_run.run_details
         task: V2beta1PipelineTaskDetail
         for task in run_details.task_details:

--- a/python/gigl/common/utils/gcs.py
+++ b/python/gigl/common/utils/gcs.py
@@ -4,7 +4,7 @@ import tempfile
 import typing
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from tempfile import _TemporaryFileWrapper as TemporaryFileWrapper  # type: ignore
-from typing import IO, AnyStr, Iterable, Optional, Tuple, Union
+from typing import IO, AnyStr, Dict, Iterable, Optional, Tuple, Union
 
 import google.cloud.exceptions as google_exceptions
 import google.cloud.storage as storage
@@ -58,7 +58,7 @@ def _pickling_safe_upload_file_to_gcs(obj: Tuple[Tuple[LocalUri, GcsUri], str]):
 
 
 def _upload_files_to_gcs_parallel(
-    project: str, local_file_path_to_gcs_path_map: dict[LocalUri, GcsUri]
+    project: str, local_file_path_to_gcs_path_map: Dict[LocalUri, GcsUri]
 ):
     with ProcessPoolExecutor(max_workers=None) as executor:
         results = executor.map(
@@ -121,14 +121,14 @@ class GcsUtils:
 
     def upload_files_to_gcs(
         self,
-        local_file_path_to_gcs_path_map: dict[LocalUri, GcsUri],
+        local_file_path_to_gcs_path_map: Dict[LocalUri, GcsUri],
         parallel: bool = True,
     ) -> None:
         """
         Upload files from local paths to their subsequent provided GCS paths.
 
         Args:
-            local_file_path_to_gcs_path_map (dict[LocalUri, GcsUri]): A dictionary mapping local file paths to GCS paths.
+            local_file_path_to_gcs_path_map (Dict[LocalUri, GcsUri]): A dictionary mapping local file paths to GCS paths.
             parallel (bool): Flag indicating whether to upload files in parallel. Defaults to True.
         """
         if parallel:
@@ -224,7 +224,7 @@ class GcsUtils:
         return file_blobs
 
     def download_files_from_gcs_paths_to_local_paths(
-        self, file_map: dict[GcsUri, LocalUri]
+        self, file_map: Dict[GcsUri, LocalUri]
     ):
         """
         Downloads files from GCS path to local path.

--- a/python/gigl/common/utils/http.py
+++ b/python/gigl/common/utils/http.py
@@ -1,5 +1,6 @@
 import pathlib
 from concurrent.futures import ThreadPoolExecutor
+from typing import Dict
 
 import requests
 
@@ -36,12 +37,12 @@ class HttpUtils:
             f.write(response.content)
 
     @staticmethod
-    def download_files_from_http(http_to_local_path_map: dict[HttpUri, LocalUri]):
+    def download_files_from_http(http_to_local_path_map: Dict[HttpUri, LocalUri]):
         """
         Downloads a list of files from an HTTP(S) URL to a list of local file paths.
 
         Args:
-            http_to_local_path_map (dict[HttpUri, LocalUri]): A dictionary mapping HTTP(S) URLs to local file paths.
+            http_to_local_path_map (Dict[HttpUri, LocalUri]): A dictionary mapping HTTP(S) URLs to local file paths.
         """
         with ThreadPoolExecutor() as executor:
             results = executor.map(

--- a/python/gigl/common/utils/kfp.py
+++ b/python/gigl/common/utils/kfp.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import numpy as np
 import pandas as pd
@@ -46,7 +46,7 @@ class KfpOutputViewers:
 
         https://www.kubeflow.org/docs/components/pipelines/sdk/output-viewer/
         """
-        self.__outputs_list: list[dict[str, Any]] = []
+        self.__outputs_list: list[Dict[str, Any]] = []
 
     def add_confusion_matrix(
         self, confusion_matrix: np.ndarray, vocab: Optional[list[str]] = None

--- a/python/gigl/common/utils/local_fs.py
+++ b/python/gigl/common/utils/local_fs.py
@@ -4,7 +4,7 @@ import os
 import pathlib
 import re
 import shutil
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional
 
 from gigl.common import LocalUri
 from gigl.common.logger import Logger
@@ -181,14 +181,14 @@ def create_empty_file_if_none_exists(local_path: LocalUri) -> None:
 
 
 def copy_files(
-    local_source_to_local_dst_path_map: dict[LocalUri, LocalUri],
+    local_source_to_local_dst_path_map: Dict[LocalUri, LocalUri],
     should_overwrite: Optional[bool] = False,
 ) -> None:
     """
     Copy files from source paths to destination paths.
 
     Args:
-        local_source_to_local_dst_path_map (dict[LocalUri, LocalUri]): A dictionary mapping source paths to destination paths.
+        local_source_to_local_dst_path_map (Dict[LocalUri, LocalUri]): A dictionary mapping source paths to destination paths.
         should_overwrite (Optional[bool]): If True, overwrite existing files at the destination paths. Defaults to False.
 
     Returns:
@@ -211,14 +211,14 @@ def copy_files(
 
 
 def create_file_symlinks(
-    local_source_to_link_path_map: dict[LocalUri, LocalUri],
+    local_source_to_link_path_map: Dict[LocalUri, LocalUri],
     should_overwrite: Optional[bool] = False,
 ) -> None:
     """
     Create symlinks between source paths and link paths.
 
     Args:
-        local_source_to_link_path_map (dict[LocalUri, LocalUri]): A dictionary mapping source paths to link paths.
+        local_source_to_link_path_map (Dict[LocalUri, LocalUri]): A dictionary mapping source paths to link paths.
         should_overwrite (Optional[bool]): If True, overwrite existing links at the link paths. Defaults to False.
 
     Returns:

--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -5,7 +5,7 @@ process which initializes rpc + worker group, loads and builds a partitioned dat
 import time
 from collections import abc
 from distutils.util import strtobool
-from typing import Literal, MutableMapping, Optional, Tuple, Type, Union
+from typing import Dict, Literal, MutableMapping, Optional, Tuple, Type, Union
 
 import torch
 import torch.multiprocessing as mp
@@ -111,7 +111,7 @@ def _load_and_build_partitioned_dataset(
             raise ValueError(
                 "Cannot have loaded positive and negative labels when attempting to select self-supervised positive edges from edge index."
             )
-        positive_label_edges: Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
+        positive_label_edges: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
         if isinstance(loaded_graph_tensors.edge_index, abc.Mapping):
             # This assert is required while `select_ssl_positive_label_edges` exists out of any splitter. Once this is in transductive splitter,
             # we can remove this assert.

--- a/python/gigl/distributed/dist_ablp_neighborloader.py
+++ b/python/gigl/distributed/dist_ablp_neighborloader.py
@@ -77,9 +77,9 @@ class DistABLPLoader(DistLoader):
         but will return a {py:class}`torch_geometric.data.Data` (homogeneous) object if the dataset is "labeled homogeneous".
 
         The following fields may also be present:
-        - `y_positive`: `dict[int, torch.Tensor]` mapping from local anchor node id to a tensor of positive
+        - `y_positive`: `Dict[int, torch.Tensor]` mapping from local anchor node id to a tensor of positive
                 label node ids.
-        - `y_negative`: (Optional) `dict[int, torch.Tensor]` mapping from local anchor node id to a tensor of negative
+        - `y_negative`: (Optional) `Dict[int, torch.Tensor]` mapping from local anchor node id to a tensor of negative
                 label node ids. This will only be present if the supervision edge type has negative labels.
 
 
@@ -111,7 +111,7 @@ class DistABLPLoader(DistLoader):
 
         Args:
             dataset (DistLinkPredictionDataset): The dataset to sample from.
-            num_neighbors (list[int] or dict[tuple[str, str, str], list[int]]):
+            num_neighbors (list[int] or Dict[tuple[str, str, str], list[int]]):
                 The number of neighbors to sample for each node in each iteration.
                 If an entry is set to `-1`, all neighbors will be included.
                 In heterogeneous graphs, may also take in a dictionary denoting

--- a/python/gigl/distributed/dist_link_prediction_dataset.py
+++ b/python/gigl/distributed/dist_link_prediction_dataset.py
@@ -4,7 +4,7 @@ import gc
 import time
 from collections import abc
 from multiprocessing.reduction import ForkingPickler
-from typing import Literal, Optional, Tuple, Union
+from typing import Dict, Literal, Optional, Tuple, Union
 
 import torch
 from graphlearn_torch.data import Feature, Graph
@@ -43,34 +43,34 @@ class DistLinkPredictionDataset(DistDataset):
         rank: int,
         world_size: int,
         edge_dir: Literal["in", "out"],
-        graph_partition: Optional[Union[Graph, dict[EdgeType, Graph]]] = None,
+        graph_partition: Optional[Union[Graph, Dict[EdgeType, Graph]]] = None,
         node_feature_partition: Optional[
-            Union[Feature, dict[NodeType, Feature]]
+            Union[Feature, Dict[NodeType, Feature]]
         ] = None,
         edge_feature_partition: Optional[
-            Union[Feature, dict[EdgeType, Feature]]
+            Union[Feature, Dict[EdgeType, Feature]]
         ] = None,
         node_partition_book: Optional[
-            Union[PartitionBook, dict[NodeType, PartitionBook]]
+            Union[PartitionBook, Dict[NodeType, PartitionBook]]
         ] = None,
         edge_partition_book: Optional[
-            Union[PartitionBook, dict[EdgeType, PartitionBook]]
+            Union[PartitionBook, Dict[EdgeType, PartitionBook]]
         ] = None,
         positive_edge_label: Optional[
-            Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
+            Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
         ] = None,
         negative_edge_label: Optional[
-            Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
+            Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
         ] = None,
         node_ids: Optional[Union[torch.Tensor, dict[NodeType, torch.Tensor]]] = None,
         num_train: Optional[Union[int, dict[NodeType, int]]] = None,
         num_val: Optional[Union[int, dict[NodeType, int]]] = None,
         num_test: Optional[Union[int, dict[NodeType, int]]] = None,
         node_feature_info: Optional[
-            Union[FeatureInfo, dict[NodeType, FeatureInfo]]
+            Union[FeatureInfo, Dict[NodeType, FeatureInfo]]
         ] = None,
         edge_feature_info: Optional[
-            Union[FeatureInfo, dict[EdgeType, FeatureInfo]]
+            Union[FeatureInfo, Dict[EdgeType, FeatureInfo]]
         ] = None,
     ) -> None:
         """
@@ -111,14 +111,14 @@ class DistLinkPredictionDataset(DistDataset):
             edge_dir=edge_dir,
         )
         self._positive_edge_label: Optional[
-            Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
+            Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
         ] = positive_edge_label
         self._negative_edge_label: Optional[
-            Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
+            Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
         ] = negative_edge_label
 
         self._node_ids: Optional[
-            Union[torch.Tensor, dict[NodeType, torch.Tensor]]
+            Union[torch.Tensor, Dict[NodeType, torch.Tensor]]
         ] = node_ids
 
         self._num_train = num_train
@@ -157,15 +157,15 @@ class DistLinkPredictionDataset(DistDataset):
         self._edge_dir = new_edge_dir
 
     @property
-    def graph(self) -> Optional[Union[Graph, dict[EdgeType, Graph]]]:
+    def graph(self) -> Optional[Union[Graph, Dict[EdgeType, Graph]]]:
         return self._graph
 
     @graph.setter
-    def graph(self, new_graph: Optional[Union[Graph, dict[EdgeType, Graph]]]):
+    def graph(self, new_graph: Optional[Union[Graph, Dict[EdgeType, Graph]]]):
         self._graph = new_graph
 
     @property
-    def node_features(self) -> Optional[Union[Feature, dict[NodeType, Feature]]]:
+    def node_features(self) -> Optional[Union[Feature, Dict[NodeType, Feature]]]:
         """
         During serializiation, the initialized `Feature` type does not immediately contain the feature and id2index tensors. These
         fields are initially set to None, and are only populated when we retrieve the size, retrieve the shape, or index into one of these tensors.
@@ -175,12 +175,12 @@ class DistLinkPredictionDataset(DistDataset):
 
     @node_features.setter
     def node_features(
-        self, new_node_features: Optional[Union[Feature, dict[NodeType, Feature]]]
+        self, new_node_features: Optional[Union[Feature, Dict[NodeType, Feature]]]
     ):
         self._node_features = new_node_features
 
     @property
-    def edge_features(self) -> Optional[Union[Feature, dict[EdgeType, Feature]]]:
+    def edge_features(self) -> Optional[Union[Feature, Dict[EdgeType, Feature]]]:
         """
         During serializiation, the initialized `Feature` type does not immediately contain the feature and id2index tensors. These
         fields are initially set to None, and are only populated when we retrieve the size, retrieve the shape, or index into one of these tensors.
@@ -190,50 +190,50 @@ class DistLinkPredictionDataset(DistDataset):
 
     @edge_features.setter
     def edge_features(
-        self, new_edge_features: Optional[Union[Feature, dict[EdgeType, Feature]]]
+        self, new_edge_features: Optional[Union[Feature, Dict[EdgeType, Feature]]]
     ):
         self._edge_features = new_edge_features
 
     @property
     def node_pb(
         self,
-    ) -> Optional[Union[PartitionBook, dict[NodeType, PartitionBook]]]:
+    ) -> Optional[Union[PartitionBook, Dict[NodeType, PartitionBook]]]:
         return self._node_partition_book
 
     @node_pb.setter
     def node_pb(
         self,
-        new_node_pb: Optional[Union[PartitionBook, dict[NodeType, PartitionBook]]],
+        new_node_pb: Optional[Union[PartitionBook, Dict[NodeType, PartitionBook]]],
     ):
         self._node_partition_book = new_node_pb
 
     @property
     def edge_pb(
         self,
-    ) -> Optional[Union[PartitionBook, dict[EdgeType, PartitionBook]]]:
+    ) -> Optional[Union[PartitionBook, Dict[EdgeType, PartitionBook]]]:
         return self._edge_partition_book
 
     @edge_pb.setter
     def edge_pb(
         self,
-        new_edge_pb: Optional[Union[PartitionBook, dict[EdgeType, PartitionBook]]],
+        new_edge_pb: Optional[Union[PartitionBook, Dict[EdgeType, PartitionBook]]],
     ):
         self._edge_partition_book = new_edge_pb
 
     @property
     def positive_edge_label(
         self,
-    ) -> Optional[Union[torch.Tensor, dict[EdgeType, torch.Tensor]]]:
+    ) -> Optional[Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]]:
         return self._positive_edge_label
 
     @property
     def negative_edge_label(
         self,
-    ) -> Optional[Union[torch.Tensor, dict[EdgeType, torch.Tensor]]]:
+    ) -> Optional[Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]]:
         return self._negative_edge_label
 
     @property
-    def node_ids(self) -> Optional[Union[torch.Tensor, dict[NodeType, torch.Tensor]]]:
+    def node_ids(self) -> Optional[Union[torch.Tensor, Dict[NodeType, torch.Tensor]]]:
         return self._node_ids
 
     @property
@@ -396,9 +396,9 @@ class DistLinkPredictionDataset(DistDataset):
 
         # Edge Index refers to the [2, num_edges] tensor representing pairs of nodes connecting each edge
         # Edge IDs refers to the [num_edges] tensor representing the unique integer assigned to each edge
-        partitioned_edge_index: Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
+        partitioned_edge_index: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
         partitioned_edge_ids: Union[
-            Optional[torch.Tensor], dict[EdgeType, Optional[torch.Tensor]]
+            Optional[torch.Tensor], Dict[EdgeType, Optional[torch.Tensor]]
         ]
         if isinstance(partition_output.partitioned_edge_index, GraphPartitionData):
             partitioned_edge_index = partition_output.partitioned_edge_index.edge_index

--- a/python/gigl/distributed/distributed_neighborloader.py
+++ b/python/gigl/distributed/distributed_neighborloader.py
@@ -1,5 +1,5 @@
 from collections import Counter, abc
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 from graphlearn_torch.channel import SampleMessage
@@ -38,7 +38,7 @@ class DistNeighborLoader(DistLoader):
     def __init__(
         self,
         dataset: DistLinkPredictionDataset,
-        num_neighbors: Union[list[int], dict[EdgeType, list[int]]],
+        num_neighbors: Union[list[int], Dict[EdgeType, list[int]]],
         input_nodes: Optional[
             Union[torch.Tensor, Tuple[NodeType, torch.Tensor]]
         ] = None,
@@ -63,7 +63,7 @@ class DistNeighborLoader(DistLoader):
 
         Args:
             dataset (DistLinkPredictionDataset): The dataset to sample from.
-            num_neighbors (list[int] or dict[Tuple[str, str, str], list[int]]):
+            num_neighbors (list[int] or Dict[Tuple[str, str, str], list[int]]):
                 The number of neighbors to sample for each node in each iteration.
                 If an entry is set to `-1`, all neighbors will be included.
                 In heterogeneous graphs, may also take in a dictionary denoting

--- a/python/gigl/distributed/utils/serialized_graph_metadata_translator.py
+++ b/python/gigl/distributed/utils/serialized_graph_metadata_translator.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Union
+from typing import Dict, Tuple, Union
 
 from gigl.common import UriFactory
 from gigl.common.data.dataloaders import SerializedTFRecordInfo
@@ -60,10 +60,10 @@ def convert_pb_to_serialized_graph_metadata(
         SerializedGraphMetadata: Dataset Metadata for all entity and node/edge types.
     """
 
-    node_entity_info: dict[NodeType, SerializedTFRecordInfo] = {}
-    edge_entity_info: dict[EdgeType, SerializedTFRecordInfo] = {}
-    positive_label_entity_info: dict[EdgeType, SerializedTFRecordInfo] = {}
-    negative_label_entity_info: dict[EdgeType, SerializedTFRecordInfo] = {}
+    node_entity_info: Dict[NodeType, SerializedTFRecordInfo] = {}
+    edge_entity_info: Dict[EdgeType, SerializedTFRecordInfo] = {}
+    positive_label_entity_info: Dict[EdgeType, SerializedTFRecordInfo] = {}
+    negative_label_entity_info: Dict[EdgeType, SerializedTFRecordInfo] = {}
 
     preprocessed_metadata_pb = preprocessed_metadata_pb_wrapper.preprocessed_metadata_pb
 

--- a/python/gigl/orchestration/kubeflow/kfp_pipeline.py
+++ b/python/gigl/orchestration/kubeflow/kfp_pipeline.py
@@ -1,5 +1,5 @@
 import os
-from typing import Final, Optional
+from typing import Dict, Final, Optional
 
 import kfp
 import kfp.dsl.pipeline_channel
@@ -38,7 +38,7 @@ SPECED_COMPONENTS: Final[list[str]] = [
 _speced_component_root: Final[LocalUri] = LocalUri.join(
     _COMPONENTS_BASE_PATH, "components"
 )
-_speced_component_op_dict: Final[dict[GiGLComponents, kfp.components.YamlComponent]] = {
+_speced_component_op_dict: Final[Dict[GiGLComponents, kfp.components.YamlComponent]] = {
     GiGLComponents(component): kfp.components.load_component_from_file(
         LocalUri.join(_speced_component_root, component, "component.yaml").uri
     )

--- a/python/gigl/src/common/graph_builder/abstract_graph_builder.py
+++ b/python/gigl/src/common/graph_builder/abstract_graph_builder.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections import defaultdict
-from typing import Generic, Optional, TypeVar
+from typing import Dict, Generic, Optional, TypeVar
 
 import torch
 
@@ -36,12 +36,12 @@ class GraphBuilder(Generic[TGraph]):
         Unregisters / resets all registered nodes and edges.
         "Reinitialized the class to a clean state"
         """
-        self.subgraph_node_id_counter: dict[NodeType, int] = defaultdict(int)
-        self.global_node_to_subgraph_node_map: dict[Node, Node] = {}
-        self.ordered_edges: dict[EdgeType, list[Edge]] = defaultdict(list)
-        self.ordered_nodes: dict[NodeType, list[Node]] = defaultdict(list)
-        self.subgraph_node_features_dict: dict[Node, torch.Tensor] = {}
-        self.subgraph_edge_feature_dict: dict[Edge, Optional[torch.Tensor]] = {}
+        self.subgraph_node_id_counter: Dict[NodeType, int] = defaultdict(int)
+        self.global_node_to_subgraph_node_map: Dict[Node, Node] = {}
+        self.ordered_edges: Dict[EdgeType, list[Edge]] = defaultdict(list)
+        self.ordered_nodes: Dict[NodeType, list[Node]] = defaultdict(list)
+        self.subgraph_node_features_dict: Dict[Node, torch.Tensor] = {}
+        self.subgraph_edge_feature_dict: Dict[Edge, Optional[torch.Tensor]] = {}
 
         self.should_register_node_features: Optional[bool] = None
         self.should_register_edge_features: Optional[bool] = None

--- a/python/gigl/src/common/graph_builder/gbml_graph_protocol.py
+++ b/python/gigl/src/common/graph_builder/gbml_graph_protocol.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol, Set
+from typing import Dict, Protocol, Set
 
 import torch
 
@@ -36,18 +36,18 @@ class GbmlGraphDataProtocol(Protocol):
         these graphs data formats.
 
         Returns:
-            dict[Node, Node]
+            Dict[Node, Node]
         """
         ...
 
     @global_node_to_subgraph_node_mapping.setter
     def global_node_to_subgraph_node_mapping(
-        self, global_node_to_subgraph_node_mapping: dict[Node, Node]
+        self, global_node_to_subgraph_node_mapping: Dict[Node, Node]
     ) -> None:
         """See global_node_to_subgraph_node_mapping
 
         Args:
-            global_node_to_subgraph_node_mapping (dict[Node, Node])
+            global_node_to_subgraph_node_mapping (Dict[Node, Node])
         """
         ...
 

--- a/python/gigl/src/common/graph_builder/pyg_graph_data.py
+++ b/python/gigl/src/common/graph_builder/pyg_graph_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import torch
 from torch_geometric.data.hetero_data import HeteroData
@@ -121,7 +121,7 @@ class PygGraphData(HeteroData, GbmlGraphDataProtocol):
         if not hasattr(self, "x_dict"):
             return FrozenDict({})
 
-        global_node_to_features_map: dict[Node, torch.Tensor] = {}
+        global_node_to_features_map: Dict[Node, torch.Tensor] = {}
         for self_node_type, all_node_features_for_node_type in self.x_dict.items():
             for subgraph_node_id, node_features in enumerate(
                 all_node_features_for_node_type
@@ -139,7 +139,7 @@ class PygGraphData(HeteroData, GbmlGraphDataProtocol):
         return FrozenDict(global_node_to_features_map)
 
     def get_global_edge_features_dict(self) -> FrozenDict[Edge, torch.Tensor]:
-        global_edge_to_features_map: dict[Edge, torch.Tensor] = {}
+        global_edge_to_features_map: Dict[Edge, torch.Tensor] = {}
 
         is_graph_data_in_global_space: bool = (
             not self.subgraph_node_to_global_node_mapping

--- a/python/gigl/src/common/modeling_task_specs/graphsage_template_modeling_spec.py
+++ b/python/gigl/src/common/modeling_task_specs/graphsage_template_modeling_spec.py
@@ -1,5 +1,5 @@
 from contextlib import ExitStack
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 import torch.distributed
@@ -90,7 +90,7 @@ class GraphSageTemplateTrainerSpec(
         )
 
         # Prepare dataloader configurations
-        dataloader_batch_size_map: dict[DataloaderTypes, int] = {
+        dataloader_batch_size_map: Dict[DataloaderTypes, int] = {
             DataloaderTypes.train_main: self.main_sample_batch_size,
             DataloaderTypes.val_main: self.main_sample_batch_size,
             DataloaderTypes.test_main: self.main_sample_batch_size,
@@ -99,7 +99,7 @@ class GraphSageTemplateTrainerSpec(
             DataloaderTypes.test_random_negative: self.random_negative_batch_size,
         }
 
-        dataloader_num_workers_map: dict[DataloaderTypes, int] = {
+        dataloader_num_workers_map: Dict[DataloaderTypes, int] = {
             DataloaderTypes.train_main: int(kwargs.get("train_main_num_workers", 2)),
             DataloaderTypes.val_main: int(kwargs.get("val_main_num_workers", 1)),
             DataloaderTypes.test_main: int(kwargs.get("test_main_num_workers", 1)),
@@ -460,7 +460,7 @@ class GraphSageTemplateTrainerSpec(
         random_negative_data_loader: torch.utils.data.dataloader._BaseDataLoaderIter,
         device: torch.device,
         num_batches: int,
-    ) -> dict[str, Any]:
+    ) -> Dict[str, Any]:
         self.model.eval()
         total_mrr: float = 0.0
         total_loss: float = 0.0

--- a/python/gigl/src/common/modeling_task_specs/node_classification_modeling_task_spec.py
+++ b/python/gigl/src/common/modeling_task_specs/node_classification_modeling_task_spec.py
@@ -1,6 +1,5 @@
-from collections import OrderedDict
 from contextlib import ExitStack
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional, OrderedDict
 
 import tensorflow as tf
 import torch
@@ -57,13 +56,13 @@ class NodeClassificationModelingTaskSpec(
 
         main_sample_batch_size = int(kwargs.get("main_sample_batch_size", 16))
 
-        dataloader_batch_size_map: dict[DataloaderTypes, int] = {
+        dataloader_batch_size_map: Dict[DataloaderTypes, int] = {
             DataloaderTypes.train_main: main_sample_batch_size,
             DataloaderTypes.val_main: main_sample_batch_size,
             DataloaderTypes.test_main: main_sample_batch_size,
         }
         # TODO (mkolodner-sc): Investigate how we can automatically infer num_worker values
-        dataloader_num_workers_map: dict[DataloaderTypes, int] = {
+        dataloader_num_workers_map: Dict[DataloaderTypes, int] = {
             DataloaderTypes.train_main: int(kwargs.get("train_main_num_workers", 0)),
             DataloaderTypes.val_main: int(kwargs.get("val_main_num_workers", 0)),
             DataloaderTypes.test_main: int(kwargs.get("test_main_num_workers", 0)),

--- a/python/gigl/src/common/models/layers/loss.py
+++ b/python/gigl/src/common/models/layers/loss.py
@@ -1,6 +1,6 @@
 import itertools
 from enum import Enum
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 import torch
@@ -73,7 +73,7 @@ class MarginLoss(nn.Module):
 
     def forward(
         self,
-        loss_input: list[dict[CondensedEdgeType, BatchScores]],
+        loss_input: list[Dict[CondensedEdgeType, BatchScores]],
         device: torch.device = torch.device("cpu"),
     ) -> Tuple[torch.Tensor, int]:
         batch_loss = torch.tensor(0.0).to(device=device)
@@ -151,7 +151,7 @@ class SoftmaxLoss(nn.Module):
 
     def forward(
         self,
-        loss_input: list[dict[CondensedEdgeType, BatchScores]],
+        loss_input: list[Dict[CondensedEdgeType, BatchScores]],
         device: torch.device = torch.device("cpu"),
     ) -> Tuple[torch.Tensor, int]:
         batch_loss = torch.tensor(0.0).to(device=device)

--- a/python/gigl/src/common/models/layers/normalization.py
+++ b/python/gigl/src/common/models/layers/normalization.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Dict, Union
 
 import torch
 from torch.nn import functional as F
@@ -7,8 +7,8 @@ from gigl.src.common.types.graph_data import NodeType
 
 
 def l2_normalize_embeddings(
-    node_typed_embeddings: Union[torch.Tensor, dict[NodeType, torch.Tensor]]
-) -> Union[torch.Tensor, dict[NodeType, torch.Tensor]]:
+    node_typed_embeddings: Union[torch.Tensor, Dict[NodeType, torch.Tensor]]
+) -> Union[torch.Tensor, Dict[NodeType, torch.Tensor]]:
     if isinstance(node_typed_embeddings, dict):
         for node_type in node_typed_embeddings:
             node_typed_embeddings[node_type] = F.normalize(
@@ -18,6 +18,6 @@ def l2_normalize_embeddings(
         node_typed_embeddings = F.normalize(node_typed_embeddings, p=2, dim=-1)
     else:
         raise ValueError(
-            f"Expected type torch.Tensor or dict[NodeType, torch.Tensor], got type {type(node_typed_embeddings)}"
+            f"Expected type torch.Tensor or Dict[NodeType, torch.Tensor], got type {type(node_typed_embeddings)}"
         )
     return node_typed_embeddings

--- a/python/gigl/src/common/models/layers/task.py
+++ b/python/gigl/src/common/models/layers/task.py
@@ -1,6 +1,6 @@
 import copy
 from abc import ABC, abstractmethod
-from typing import Optional, Set, Tuple
+from typing import Dict, Optional, Set, Tuple
 
 import torch
 import torch.nn as nn
@@ -699,7 +699,7 @@ class DirectAU(NodeAnchorBasedLinkPredictionBaseTask):
 class NodeAnchorBasedLinkPredictionTasks:
     def __init__(self) -> None:
         self._task_to_fn_map = nn.ModuleDict()
-        self._task_to_weights_map: dict[str, float] = {}
+        self._task_to_weights_map: Dict[str, float] = {}
         self._result_types: Set[ModelResultType] = set()
 
     def _get_all_tasks(
@@ -726,9 +726,9 @@ class NodeAnchorBasedLinkPredictionTasks:
         gbml_config_pb_wrapper: GbmlConfigPbWrapper,
         should_eval: bool,
         device: torch.device,
-    ) -> Tuple[torch.Tensor, dict[str, float]]:
-        loss_to_val_map: dict[str, float] = {}
-        loss_to_batch_size_map: dict[str, int] = {}
+    ) -> Tuple[torch.Tensor, Dict[str, float]]:
+        loss_to_val_map: Dict[str, float] = {}
+        loss_to_batch_size_map: Dict[str, int] = {}
         for task, weight in self._get_all_tasks():
             loss_val, batch_size = task(
                 task_input=batch_results,
@@ -743,7 +743,7 @@ class NodeAnchorBasedLinkPredictionTasks:
             cur_loss = loss_to_val_map[loss_type]
             sample_wise_loss += cur_loss / loss_to_batch_size_map[loss_type]
         final_loss: torch.Tensor
-        final_loss_map: dict[str, float]
+        final_loss_map: Dict[str, float]
 
         final_loss = sample_wise_loss
         final_loss_map = {

--- a/python/gigl/src/common/models/pyg/heterogeneous.py
+++ b/python/gigl/src/common/models/pyg/heterogeneous.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 import torch_geometric.data
@@ -21,8 +21,8 @@ class HGT(nn.Module):
     This implementation is based on the example of:
     https://github.com/pyg-team/pytorch_geometric/blob/master/examples/hetero/hgt_dblp.py
     Args:
-        node_type_to_feat_dim_map (dict[NodeType, int]): Dictionary mapping node types to their input dimensions.
-        edge_type_to_feat_dim_map (dict[EdgeType, int]): Dictionary mapping node types to their feature dimensions.
+        node_type_to_feat_dim_map (Dict[NodeType, int]): Dictionary mapping node types to their input dimensions.
+        edge_type_to_feat_dim_map (Dict[EdgeType, int]): Dictionary mapping node types to their feature dimensions.
         hid_dim (int): Hidden dimension size.
         out_dim (int, optional): Output dimension size. Defaults to 128.
         num_layers (int, optional): Number of layers. Defaults to 2.
@@ -31,15 +31,15 @@ class HGT(nn.Module):
 
     def __init__(
         self,
-        node_type_to_feat_dim_map: dict[NodeType, int],
-        edge_type_to_feat_dim_map: dict[EdgeType, int],
+        node_type_to_feat_dim_map: Dict[NodeType, int],
+        edge_type_to_feat_dim_map: Dict[EdgeType, int],
         hid_dim: int,
         out_dim: int = 128,
         num_layers: int = 2,
         num_heads: int = 2,
         should_l2_normalize_embedding_layer_output: bool = False,
         feature_embedding_layers: Optional[
-            dict[NodeType, FeatureEmbeddingLayer]
+            Dict[NodeType, FeatureEmbeddingLayer]
         ] = None,
         **kwargs,
     ):
@@ -73,14 +73,14 @@ class HGT(nn.Module):
         data: torch_geometric.data.hetero_data.HeteroData,
         output_node_types: list[NodeType],
         device: torch.device,
-    ) -> dict[NodeType, torch.Tensor]:
+    ) -> Dict[NodeType, torch.Tensor]:
         """
         Runs the forward pass of the module
         Args:
             data (torch_geometric.data.hetero_data.HeteroData): Input HeteroData object.
             output_node_types (list[NodeType]): List of node types for which to return the output embeddings.
         Returns:
-            dict[NodeType, torch.Tensor]: Dictionary with node types as keys and output tensors as values.
+            Dict[NodeType, torch.Tensor]: Dictionary with node types as keys and output tensors as values.
         """
         node_type_to_features_dict = data.x_dict
 
@@ -117,7 +117,7 @@ class HGT(nn.Module):
                 node_type_to_features_dict, edge_index_dict
             )
 
-        node_typed_embeddings: dict[NodeType, torch.Tensor] = {}
+        node_typed_embeddings: Dict[NodeType, torch.Tensor] = {}
 
         for node_type in output_node_types:
             node_typed_embeddings[node_type] = (
@@ -137,8 +137,8 @@ class HGT(nn.Module):
 class SimpleHGN(nn.Module):
     def __init__(
         self,
-        node_type_to_feat_dim_map: dict[NodeType, int],
-        edge_type_to_feat_dim_map: dict[EdgeType, int],
+        node_type_to_feat_dim_map: Dict[NodeType, int],
+        edge_type_to_feat_dim_map: Dict[EdgeType, int],
         node_hid_dim: int,
         edge_hid_dim: int,
         edge_type_dim: int,
@@ -156,8 +156,8 @@ class SimpleHGN(nn.Module):
         SimpleHGN layer from the paper: https://arxiv.org/pdf/2112.14936
 
         Args:
-            node_type_to_feat_dim_map (dict[NodeType, int]): Dictionary mapping node types to their input dimensions.
-            edge_type_to_feat_dim_map (dict[EdgeType, int]): Dictionary mapping edge types to their feature dimensions.
+            node_type_to_feat_dim_map (Dict[NodeType, int]): Dictionary mapping node types to their input dimensions.
+            edge_type_to_feat_dim_map (Dict[EdgeType, int]): Dictionary mapping edge types to their feature dimensions.
             node_hid_dim (int): Hidden dimension size for node features.
             edge_hid_dim (int): Hidden dimension size for edge features.
             edge_type_dim (int): Hidden dimension size for edge types.
@@ -221,7 +221,7 @@ class SimpleHGN(nn.Module):
         data: torch_geometric.data.hetero_data.HeteroData,
         output_node_types: list[NodeType],
         device: torch.device,
-    ) -> dict[NodeType, torch.Tensor]:
+    ) -> Dict[NodeType, torch.Tensor]:
         # Align dimensions across all node-types and all edge-types, resp.
         x_dict = {
             node_type: self.node_type_lin_dict[node_type](x)

--- a/python/gigl/src/common/models/pyg/homogeneous.py
+++ b/python/gigl/src/common/models/pyg/homogeneous.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -34,7 +34,7 @@ class BasicHomogeneousGNN(nn.Module, GnnModel):
         in_dim: int,
         hid_dim: int,
         out_dim: int,
-        conv_kwargs: dict[str, Any] = {},
+        conv_kwargs: Dict[str, Any] = {},
         edge_dim: Optional[int] = None,
         num_layers: int = DEFAULT_NUM_GNN_HOPS,
         activation: Callable = F.relu,

--- a/python/gigl/src/common/models/pyg/link_prediction.py
+++ b/python/gigl/src/common/models/pyg/link_prediction.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import torch
 import torch.nn as nn
@@ -45,7 +45,7 @@ class LinkPredictionGNN(nn.Module):
         ],
         output_node_types: list[NodeType],
         device: torch.device,
-    ) -> dict[NodeType, torch.Tensor]:
+    ) -> Dict[NodeType, torch.Tensor]:
         if isinstance(data, torch_geometric.data.hetero_data.HeteroData):
             return self.__encoder(
                 data=data, output_node_types=output_node_types, device=device

--- a/python/gigl/src/common/models/pyg/nn/conv/hgt_conv.py
+++ b/python/gigl/src/common/models/pyg/nn/conv/hgt_conv.py
@@ -1,5 +1,5 @@
 import math
-from typing import Optional, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
@@ -32,7 +32,7 @@ class HGTConv(MessagePassing):
         hetero/hgt_dblp.py>`_.
 
     Args:
-        in_channels (int or dict[str, int]): Size of each input sample of every
+        in_channels (int or Dict[str, int]): Size of each input sample of every
             node type, or :obj:`-1` to derive the size from the first input(s)
             to the forward method.
         out_channels (int): Size of each output sample.
@@ -49,7 +49,7 @@ class HGTConv(MessagePassing):
 
     def __init__(
         self,
-        in_channels: Union[int, dict[str, int]],
+        in_channels: Union[int, Dict[str, int]],
         out_channels: int,
         metadata: Metadata,
         heads: int = 1,
@@ -105,11 +105,11 @@ class HGTConv(MessagePassing):
         ones(self.skip)
         ones(self.p_rel)
 
-    def _cat(self, x_dict: dict[str, Tensor]) -> Tuple[Tensor, dict[str, int]]:
+    def _cat(self, x_dict: Dict[str, Tensor]) -> Tuple[Tensor, Dict[str, int]]:
         """Concatenates a dictionary of features."""
         cumsum = 0
         outs: list[Tensor] = []
-        offset: dict[str, int] = {}
+        offset: Dict[str, int] = {}
         for key, x in x_dict.items():
             outs.append(x)
             offset[key] = cumsum
@@ -118,10 +118,10 @@ class HGTConv(MessagePassing):
 
     def _construct_src_node_feat(
         self,
-        k_dict: dict[str, Tensor],
-        v_dict: dict[str, Tensor],
-        edge_index_dict: dict[EdgeType, Adj],
-    ) -> Tuple[Tensor, Tensor, dict[EdgeType, int]]:
+        k_dict: Dict[str, Tensor],
+        v_dict: Dict[str, Tensor],
+        edge_index_dict: Dict[EdgeType, Adj],
+    ) -> Tuple[Tensor, Tensor, Dict[EdgeType, int]]:
         """Constructs the source node representations."""
         cumsum = 0
         num_edge_types = len(self.edge_types)
@@ -131,7 +131,7 @@ class HGTConv(MessagePassing):
         ks: list[Tensor] = []
         vs: list[Tensor] = []
         type_list: list[Tensor] = []
-        offset: dict[EdgeType, int] = {}
+        offset: Dict[EdgeType, int] = {}
         for edge_type in edge_index_dict.keys():
             src = edge_type[0]
             N = k_dict[src].size(0)
@@ -161,21 +161,21 @@ class HGTConv(MessagePassing):
 
     def forward(
         self,
-        x_dict: dict[NodeType, Tensor],
-        edge_index_dict: dict[EdgeType, Adj],  # Support both.
-    ) -> dict[NodeType, Optional[Tensor]]:
+        x_dict: Dict[NodeType, Tensor],
+        edge_index_dict: Dict[EdgeType, Adj],  # Support both.
+    ) -> Dict[NodeType, Optional[Tensor]]:
         r"""Runs the forward pass of the module.
 
         Args:
-            x_dict (dict[str, torch.Tensor]): A dictionary holding input node
+            x_dict (Dict[str, torch.Tensor]): A dictionary holding input node
                 features  for each individual node type.
-            edge_index_dict (dict[Tuple[str, str, str], torch.Tensor]): A
+            edge_index_dict (Dict[Tuple[str, str, str], torch.Tensor]): A
                 dictionary holding graph connectivity information for each
                 individual edge type, either as a :class:`torch.Tensor` of
                 shape :obj:`[2, num_edges]` or a
                 :class:`torch_sparse.SparseTensor`.
 
-        :rtype: :obj:`dict[str, Optional[torch.Tensor]]` - The output node
+        :rtype: :obj:`Dict[str, Optional[torch.Tensor]]` - The output node
             embeddings for each node type.
             In case a node type does not receive any message, its output will
             be set to :obj:`None`.

--- a/python/gigl/src/common/models/pyg/nn/models/feature_embedding.py
+++ b/python/gigl/src/common/models/pyg/nn/models/feature_embedding.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 import torch.nn as nn
@@ -20,13 +20,13 @@ class FeatureEmbeddingLayer(nn.Module):
 
     def __init__(
         self,
-        features_to_embed: dict[str, int],
+        features_to_embed: Dict[str, int],
         feature_schema: FeatureSchema,
         feature_dim: int,
         aggregation: str = "mean",
         oov_idx: Optional[int] = None,
         padding_idx: Optional[int] = None,
-        feature_padding_value_map: Optional[dict[str, str]] = None,
+        feature_padding_value_map: Optional[Dict[str, str]] = None,
     ):
         """
         Feature Embedding layer takes in all input features, pass specified features through nn.Embedding layer,

--- a/python/gigl/src/common/models/pyg/nn/models/feature_interaction.py
+++ b/python/gigl/src/common/models/pyg/nn/models/feature_interaction.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, Optional
 
 import torch
 import torch.nn as nn
@@ -19,9 +19,9 @@ class FeatureInteraction(nn.Module):
         self,
         in_dim: int,
         use_dcnv2_feats_interaction: bool = False,
-        dcnv2_kwargs: dict[str, Any] = {},
+        dcnv2_kwargs: Dict[str, Any] = {},
         use_mlp_feats_interaction: bool = False,
-        mlp_feats_kwargs: dict[str, Any] = {},
+        mlp_feats_kwargs: Dict[str, Any] = {},
         activation: Callable = F.relu,
         combination_mode: Optional[str] = None,
     ) -> None:

--- a/python/gigl/src/common/models/pyg/utils.py
+++ b/python/gigl/src/common/models/pyg/utils.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import Any, Iterable, Tuple
+from typing import Any, Dict, Iterable, Tuple
 
 import torch_geometric
 
@@ -10,8 +10,8 @@ MESSAGE_PASSING_BASE_CLS_ARGS = list(
 
 
 def filter_dict(
-    input_dict: dict[str, Any], keys_to_keep: Iterable[str] = []
-) -> Tuple[dict[str, Any], dict[str, Any]]:
+    input_dict: Dict[str, Any], keys_to_keep: Iterable[str] = []
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """
     Filters out certain items from an input directory based on keys to keep.
 

--- a/python/gigl/src/common/models/utils/torch.py
+++ b/python/gigl/src/common/models/utils/torch.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import torch
 
 from gigl.src.common.types.graph_data import NodeType
@@ -5,7 +7,7 @@ from gigl.src.common.types.graph_data import NodeType
 
 def to_hetero_feat(
     h: torch.Tensor, type_indices: torch.LongTensor, types: list[str]
-) -> dict[NodeType, torch.Tensor]:
+) -> Dict[NodeType, torch.Tensor]:
     """
     Convert homogeneous graph features into heterogeneous graph feature dict.
 
@@ -15,7 +17,7 @@ def to_hetero_feat(
         types (list): indicates the possible types
 
     Returns
-        dict[str, torch.Tensor]: dictionary mapping each type to a tensor of corresponding rows in the heterogeneous graph
+        Dict[str, torch.Tensor]: dictionary mapping each type to a tensor of corresponding rows in the heterogeneous graph
 
     """
 

--- a/python/gigl/src/common/translators/training_samples_protos_translator.py
+++ b/python/gigl/src/common/translators/training_samples_protos_translator.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import NamedTuple, Optional, Tuple
+from typing import Dict, NamedTuple, Optional, Tuple
 
 import torch
 
@@ -40,7 +40,7 @@ class NodeAnchorBasedLinkPredictionSample:
     root_node: Node  # root node for this sample
     subgraph: GbmlGraphDataProtocol  # subgraph with features used for message passing
     # mapping of edge type to positive and negative nodes and edge features
-    condensed_edge_type_to_supervision_edge_data: dict[
+    condensed_edge_type_to_supervision_edge_data: Dict[
         CondensedEdgeType, SampleSupervisionEdgeData
     ]
 
@@ -87,19 +87,19 @@ class TrainingSamplesProtosTranslator:
     ) -> list[NodeAnchorBasedLinkPredictionSample]:
         training_samples: list[NodeAnchorBasedLinkPredictionSample] = []
         for sample in samples:
-            condensed_supervision_edge_type_to_pos_nodes: dict[
+            condensed_supervision_edge_type_to_pos_nodes: Dict[
                 CondensedEdgeType, list[NodeId]
             ] = defaultdict(list)
-            condensed_supervision_edge_type_to_hard_neg_nodes: dict[
+            condensed_supervision_edge_type_to_hard_neg_nodes: Dict[
                 CondensedEdgeType, list[NodeId]
             ] = defaultdict(list)
-            condensed_supervision_edge_type_to_pos_edge_feats: dict[
+            condensed_supervision_edge_type_to_pos_edge_feats: Dict[
                 CondensedEdgeType, list[torch.FloatTensor]
             ] = defaultdict(list)
-            condensed_supervision_edge_type_to_hard_neg_edge_feats: dict[
+            condensed_supervision_edge_type_to_hard_neg_edge_feats: Dict[
                 CondensedEdgeType, list[torch.FloatTensor]
             ] = defaultdict(list)
-            condensed_edge_type_to_supervision_edge_data: dict[
+            condensed_edge_type_to_supervision_edge_data: Dict[
                 CondensedEdgeType,
                 NodeAnchorBasedLinkPredictionSample.SampleSupervisionEdgeData,
             ] = {}

--- a/python/gigl/src/common/types/model.py
+++ b/python/gigl/src/common/types/model.py
@@ -1,6 +1,5 @@
-from collections import OrderedDict
 from enum import Enum
-from typing import Optional, Protocol, runtime_checkable
+from typing import Optional, OrderedDict, Protocol, runtime_checkable
 
 import torch
 

--- a/python/gigl/src/common/types/model_eval_metrics.py
+++ b/python/gigl/src/common/types/model_eval_metrics.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
+from typing import Dict
 
 
 class EvalMetricType(Enum):
@@ -31,11 +32,11 @@ class EvalMetric:
 
 class EvalMetricsCollection:
     def __init__(self, metrics: list[EvalMetric] = []):
-        self._metrics: dict[str, EvalMetric] = dict()
+        self._metrics: Dict[str, EvalMetric] = dict()
         self.add_metrics(metrics=metrics)
 
     @property
-    def metrics(self) -> dict[str, EvalMetric]:
+    def metrics(self) -> Dict[str, EvalMetric]:
         return self._metrics
 
     def add_metric(self, model_metric: EvalMetric):

--- a/python/gigl/src/common/types/pb_wrappers/dataset_metadata.py
+++ b/python/gigl/src/common/types/pb_wrappers/dataset_metadata.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
-from typing import Type, cast
+from typing import Dict, Type, cast
 
 from gigl.common import Uri, UriFactory
 from gigl.src.common.types.pb_wrappers.types import DatasetMetadataPb, TrainingSamplePb
 from snapchat.research.gbml import dataset_metadata_pb2, training_samples_schema_pb2
 
-DATASET_TO_TRAINING_SAMPLE_TYPE: dict[
+DATASET_TO_TRAINING_SAMPLE_TYPE: Dict[
     Type[DatasetMetadataPb], Type[TrainingSamplePb]
 ] = {
     dataset_metadata_pb2.SupervisedNodeClassificationDataset: training_samples_schema_pb2.SupervisedNodeClassificationSample,

--- a/python/gigl/src/common/types/pb_wrappers/dataset_metadata_utils.py
+++ b/python/gigl/src/common/types/pb_wrappers/dataset_metadata_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import glob
 from dataclasses import dataclass
-from typing import Optional, Type, TypeVar, Union, cast
+from typing import Dict, Optional, Type, TypeVar, Union, cast
 
 import google.protobuf.message
 import torch
@@ -94,21 +94,21 @@ class Dataloaders:
 class SupervisedNodeClassificationDatasetDataloaders:
     def __init__(
         self,
-        batch_size_map: dict[DataloaderTypes, int],
-        num_workers_map: dict[DataloaderTypes, int],
+        batch_size_map: Dict[DataloaderTypes, int],
+        num_workers_map: Dict[DataloaderTypes, int],
     ):
-        self.dataloaders: dict[DataloaderTypes, torch.utils.data.DataLoader] = {}
+        self.dataloaders: Dict[DataloaderTypes, torch.utils.data.DataLoader] = {}
         self._batch_size_map = batch_size_map
         self._num_workers_map = num_workers_map
 
     def _get_data_loader_configs(
         self,
-        uris_prefix_map: dict[DataloaderTypes, str],
+        uris_prefix_map: Dict[DataloaderTypes, str],
         device: torch.device,
         should_loop: bool = True,
-    ) -> dict[DataloaderTypes, DataloaderConfig]:
+    ) -> Dict[DataloaderTypes, DataloaderConfig]:
         data_loader_types = list(uris_prefix_map.keys())
-        dataloader_configs: dict[DataloaderTypes, DataloaderConfig] = {}
+        dataloader_configs: Dict[DataloaderTypes, DataloaderConfig] = {}
         for data_loader_type in data_loader_types:
             dataloader_configs[data_loader_type] = DataloaderConfig(
                 uris=_get_tfrecord_uris(
@@ -125,10 +125,10 @@ class SupervisedNodeClassificationDatasetDataloaders:
     def _load_dataloaders_from_config(
         self,
         gbml_config_pb_wrapper: GbmlConfigPbWrapper,
-        configs: dict[DataloaderTypes, DataloaderConfig],
+        configs: Dict[DataloaderTypes, DataloaderConfig],
         graph_builder: GraphBuilder,
-    ) -> dict[DataloaderTypes, torch.utils.data.DataLoader]:
-        dataloaders: dict[DataloaderTypes, torch.utils.data.DataLoader] = {}
+    ) -> Dict[DataloaderTypes, torch.utils.data.DataLoader]:
+        dataloaders: Dict[DataloaderTypes, torch.utils.data.DataLoader] = {}
         for data_loader_type, config in configs.items():
             if data_loader_type in self.dataloaders:
                 dataloaders[data_loader_type] = self.dataloaders[data_loader_type]
@@ -147,17 +147,17 @@ class SupervisedNodeClassificationDatasetDataloaders:
         self,
         gbml_config_pb_wrapper: GbmlConfigPbWrapper,
         data_loader_types: list[DataloaderTypes],
-    ) -> dict[DataloaderTypes, str]:
+    ) -> Dict[DataloaderTypes, str]:
         dataset_pb: dataset_metadata_pb2.SupervisedNodeClassificationDataset = (
             gbml_config_pb_wrapper.dataset_metadata_pb_wrapper.dataset_metadata_pb.supervised_node_classification_dataset
         )
-        uri_map: dict[DataloaderTypes, str] = {
+        uri_map: Dict[DataloaderTypes, str] = {
             DataloaderTypes.train_main: dataset_pb.train_data_uri,
             DataloaderTypes.val_main: dataset_pb.val_data_uri,
             DataloaderTypes.test_main: dataset_pb.test_data_uri,
         }
 
-        target_uri_map: dict[DataloaderTypes, str] = {
+        target_uri_map: Dict[DataloaderTypes, str] = {
             data_loader_type: uri_map[data_loader_type]
             for data_loader_type in data_loader_types
         }
@@ -171,7 +171,7 @@ class SupervisedNodeClassificationDatasetDataloaders:
         device: torch.device,
         data_loader_types: list[DataloaderTypes],
         should_loop: bool = True,
-    ) -> dict[DataloaderTypes, torch.utils.data.DataLoader]:
+    ) -> Dict[DataloaderTypes, torch.utils.data.DataLoader]:
         graph_builder = GraphBuilderFactory.get_graph_builder(
             backend_name=graph_backend
         )
@@ -242,22 +242,22 @@ class SupervisedNodeClassificationDatasetDataloaders:
 class NodeAnchorBasedLinkPredictionDatasetDataloaders:
     def __init__(
         self,
-        batch_size_map: dict[DataloaderTypes, int],
-        num_workers_map: dict[DataloaderTypes, int],
+        batch_size_map: Dict[DataloaderTypes, int],
+        num_workers_map: Dict[DataloaderTypes, int],
     ):
-        self.dataloaders: dict[DataloaderTypes, torch.utils.data.DataLoader] = {}
+        self.dataloaders: Dict[DataloaderTypes, torch.utils.data.DataLoader] = {}
         self._batch_size_map = batch_size_map
         self._num_workers_map = num_workers_map
 
     def _get_data_loader_configs(
         self,
         gbml_config_pb_wrapper: GbmlConfigPbWrapper,
-        uris_prefix_map: dict[DataloaderTypes, Union[str, dict[str, str]]],
+        uris_prefix_map: Dict[DataloaderTypes, Union[str, Dict[str, str]]],
         device: torch.device,
         should_loop: bool = True,
-    ) -> dict[DataloaderTypes, DataloaderConfig]:
+    ) -> Dict[DataloaderTypes, DataloaderConfig]:
         data_loader_types = list(uris_prefix_map.keys())
-        dataloader_configs: dict[DataloaderTypes, DataloaderConfig] = {}
+        dataloader_configs: Dict[DataloaderTypes, DataloaderConfig] = {}
 
         seed_map = {
             DataloaderTypes.train_main: 42,
@@ -269,7 +269,7 @@ class NodeAnchorBasedLinkPredictionDatasetDataloaders:
         }
 
         for data_loader_type in data_loader_types:
-            uris: Union[list[Uri], dict[NodeType, list[Uri]]]
+            uris: Union[list[Uri], Dict[NodeType, list[Uri]]]
             if isinstance(uris_prefix_map[data_loader_type], str):
                 uris_prefix: str = uris_prefix_map[data_loader_type]  # type: ignore
                 uris = _get_tfrecord_uris(UriFactory.create_uri(uris_prefix))
@@ -278,7 +278,7 @@ class NodeAnchorBasedLinkPredictionDatasetDataloaders:
                     gbml_config_pb_wrapper.task_metadata_pb_wrapper
                 )
                 uris = {}
-                node_type_to_uris_prefix: dict[str, str] = uris_prefix_map[  # type: ignore
+                node_type_to_uris_prefix: Dict[str, str] = uris_prefix_map[  # type: ignore
                     data_loader_type
                 ]
                 for (
@@ -306,10 +306,10 @@ class NodeAnchorBasedLinkPredictionDatasetDataloaders:
     def _load_dataloaders_from_config(
         self,
         gbml_config_pb_wrapper: GbmlConfigPbWrapper,
-        configs: dict[DataloaderTypes, DataloaderConfig],
+        configs: Dict[DataloaderTypes, DataloaderConfig],
         graph_builder: GraphBuilder,
-    ) -> dict[DataloaderTypes, torch.utils.data.DataLoader]:
-        dataloaders: dict[DataloaderTypes, torch.utils.data.DataLoader] = {}
+    ) -> Dict[DataloaderTypes, torch.utils.data.DataLoader]:
+        dataloaders: Dict[DataloaderTypes, torch.utils.data.DataLoader] = {}
         for data_loader_type, config in configs.items():
             if data_loader_type in self.dataloaders:
                 dataloaders[data_loader_type] = self.dataloaders[data_loader_type]
@@ -339,11 +339,11 @@ class NodeAnchorBasedLinkPredictionDatasetDataloaders:
         self,
         gbml_config_pb_wrapper: GbmlConfigPbWrapper,
         data_loader_types: list[DataloaderTypes],
-    ) -> dict[DataloaderTypes, Union[str, dict[str, str]]]:
+    ) -> Dict[DataloaderTypes, Union[str, Dict[str, str]]]:
         dataset_pb: dataset_metadata_pb2.NodeAnchorBasedLinkPredictionDataset = (
             gbml_config_pb_wrapper.dataset_metadata_pb_wrapper.dataset_metadata_pb.node_anchor_based_link_prediction_dataset
         )
-        uri_map: dict[DataloaderTypes, Union[str, dict[str, str]]] = {
+        uri_map: Dict[DataloaderTypes, Union[str, Dict[str, str]]] = {
             DataloaderTypes.train_main: dataset_pb.train_main_data_uri,
             DataloaderTypes.val_main: dataset_pb.val_main_data_uri,
             DataloaderTypes.train_random_negative: dict(
@@ -358,7 +358,7 @@ class NodeAnchorBasedLinkPredictionDatasetDataloaders:
             ),
         }
 
-        target_uri_map: dict[DataloaderTypes, Union[str, dict[str, str]]] = {
+        target_uri_map: Dict[DataloaderTypes, Union[str, Dict[str, str]]] = {
             data_loader_type: uri_map[data_loader_type]
             for data_loader_type in data_loader_types
         }
@@ -372,7 +372,7 @@ class NodeAnchorBasedLinkPredictionDatasetDataloaders:
         device: torch.device,
         data_loader_types: list[DataloaderTypes],
         should_loop: bool = True,
-    ) -> dict[DataloaderTypes, torch.utils.data.DataLoader]:
+    ) -> Dict[DataloaderTypes, torch.utils.data.DataLoader]:
         graph_builder = GraphBuilderFactory.get_graph_builder(
             backend_name=graph_backend
         )

--- a/python/gigl/src/common/types/pb_wrappers/flattened_graph_metadata.py
+++ b/python/gigl/src/common/types/pb_wrappers/flattened_graph_metadata.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Type, cast
+from typing import Dict, Type, cast
 
 from gigl.common import Uri, UriFactory
 from gigl.src.common.types.pb_wrappers.types import (
@@ -13,7 +13,7 @@ from snapchat.research.gbml import (
     training_samples_schema_pb2,
 )
 
-FLATTENED_GRAPH_TO_TRAINING_SAMPLE_TYPE: dict[
+FLATTENED_GRAPH_TO_TRAINING_SAMPLE_TYPE: Dict[
     Type[FlattenedGraphMetadataOutputPb], Type[TrainingSamplePb]
 ] = {
     flattened_graph_metadata_pb2.SupervisedNodeClassificationOutput: training_samples_schema_pb2.SupervisedNodeClassificationSample,
@@ -22,7 +22,7 @@ FLATTENED_GRAPH_TO_TRAINING_SAMPLE_TYPE: dict[
 }
 
 
-FLATTENED_GRAPH_TO_DATASET_TYPE: dict[
+FLATTENED_GRAPH_TO_DATASET_TYPE: Dict[
     Type[FlattenedGraphMetadataOutputPb], Type[DatasetMetadataPb]
 ] = {
     flattened_graph_metadata_pb2.SupervisedNodeClassificationOutput: dataset_metadata_pb2.SupervisedNodeClassificationDataset,

--- a/python/gigl/src/common/types/pb_wrappers/gigl_resource_config.py
+++ b/python/gigl/src/common/types/pb_wrappers/gigl_resource_config.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import gigl.src.common.constants.resource_config as resource_config_constants
 from gigl.common import GcsUri, UriFactory
@@ -114,7 +114,7 @@ class GiglResourceConfigWrapper:
         self,
         component: Optional[GiGLComponents] = None,
         replacement_key: str = "COMPONENT",
-    ) -> dict[str, str]:
+    ) -> Dict[str, str]:
         """
         Returns a dictionary of resource labels that can be used to tag resources in GCP.
         Users may also provide a custom suffix to replace in the resource labels which defaults to "COMPONENT".
@@ -126,7 +126,7 @@ class GiglResourceConfigWrapper:
             replacement_key (str): The key to replace in the resource labels.
 
         Returns:
-            dict[str, str]: The resource labels with the component replaced by the shortened cost label.
+            Dict[str, str]: The resource labels with the component replaced by the shortened cost label.
         """
         labels = dict(self.shared_resource_config.resource_labels)
 

--- a/python/gigl/src/common/types/pb_wrappers/graph_data_types.py
+++ b/python/gigl/src/common/types/pb_wrappers/graph_data_types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Sequence, Set, Union, cast
+from typing import Dict, Optional, Sequence, Set, Union, cast
 
 from gigl.common.utils.func_tools import lru_cache
 from gigl.src.common.types.graph_data import CondensedEdgeType, CondensedNodeType
@@ -247,8 +247,8 @@ class GraphPbWrapper:
     @staticmethod
     def hydrate_subgraph_features(
         dry_graph_proto: GraphPbWrapper,
-        node_features_dict: Optional[dict[NodePbWrapper, Sequence[float]]] = None,
-        edge_features_dict: Optional[dict[EdgePbWrapper, Sequence[float]]] = None,
+        node_features_dict: Optional[Dict[NodePbWrapper, Sequence[float]]] = None,
+        edge_features_dict: Optional[Dict[EdgePbWrapper, Sequence[float]]] = None,
     ) -> GraphPbWrapper:
         """
         Hydrate subgraph function is currently used in graphflat,

--- a/python/gigl/src/common/types/pb_wrappers/graph_metadata.py
+++ b/python/gigl/src/common/types/pb_wrappers/graph_metadata.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Tuple
+from typing import Dict, Tuple
 
 from gigl.common.logger import Logger
 from gigl.common.utils.func_tools import lru_cache
@@ -19,7 +19,7 @@ logger = Logger()
 class GraphMetadataPbWrapper:
     graph_metadata_pb: graph_schema_pb2.GraphMetadata
 
-    __condensed_edge_type_to_condensed_node_types: dict[
+    __condensed_edge_type_to_condensed_node_types: Dict[
         CondensedEdgeType, Tuple[CondensedNodeType, CondensedNodeType]
     ] = field(init=False)
     __hash: int = field(init=False)
@@ -36,7 +36,7 @@ class GraphMetadataPbWrapper:
             )
 
         # Populate the __condensed_edge_type_to_condensed_node_types field.
-        node_type_to_condensed_node_types: dict[NodeType, CondensedNodeType] = dict()
+        node_type_to_condensed_node_types: Dict[NodeType, CondensedNodeType] = dict()
         for (
             condensed_node_type,
             node_type,
@@ -45,7 +45,7 @@ class GraphMetadataPbWrapper:
                 condensed_node_type
             )
 
-        condensed_edge_type_to_condensed_node_types: dict[
+        condensed_edge_type_to_condensed_node_types: Dict[
             CondensedEdgeType, Tuple[CondensedNodeType, CondensedNodeType]
         ] = dict()
         for condensed_edge_type in self.graph_metadata_pb.condensed_edge_type_map:
@@ -87,7 +87,7 @@ class GraphMetadataPbWrapper:
     @property
     def condensed_edge_type_to_condensed_node_types(
         self,
-    ) -> dict[CondensedEdgeType, Tuple[CondensedNodeType, CondensedNodeType]]:
+    ) -> Dict[CondensedEdgeType, Tuple[CondensedNodeType, CondensedNodeType]]:
         """
         Allows access to a mapping which simplifies looking up src/dst
         CondensedNodeTypes for each CondensedEdgeType.
@@ -142,7 +142,7 @@ class GraphMetadataPbWrapper:
 
     @property  # type: ignore
     @lru_cache(maxsize=1)
-    def condensed_node_type_to_node_type_map(self) -> dict[CondensedNodeType, NodeType]:
+    def condensed_node_type_to_node_type_map(self) -> Dict[CondensedNodeType, NodeType]:
         return {
             CondensedNodeType(condensed_node_type): NodeType(node_type)
             for condensed_node_type, node_type in self.graph_metadata_pb.condensed_node_type_map.items()
@@ -150,12 +150,12 @@ class GraphMetadataPbWrapper:
 
     @property  # type: ignore
     @lru_cache(maxsize=1)
-    def node_type_to_condensed_node_type_map(self) -> dict[NodeType, CondensedNodeType]:
+    def node_type_to_condensed_node_type_map(self) -> Dict[NodeType, CondensedNodeType]:
         return {v: k for k, v in self.condensed_node_type_to_node_type_map.items()}
 
     @property  # type: ignore
     @lru_cache(maxsize=1)
-    def condensed_edge_type_to_edge_type_map(self) -> dict[CondensedEdgeType, EdgeType]:
+    def condensed_edge_type_to_edge_type_map(self) -> Dict[CondensedEdgeType, EdgeType]:
         return {
             CondensedEdgeType(condensed_edge_type): EdgeType(
                 src_node_type=NodeType(edge_type.src_node_type),
@@ -167,7 +167,7 @@ class GraphMetadataPbWrapper:
 
     @property  # type: ignore
     @lru_cache(maxsize=1)
-    def edge_type_to_condensed_edge_type_map(self) -> dict[EdgeType, CondensedEdgeType]:
+    def edge_type_to_condensed_edge_type_map(self) -> Dict[EdgeType, CondensedEdgeType]:
         return {v: k for k, v in self.condensed_edge_type_to_edge_type_map.items()}
 
     @property  # type: ignore

--- a/python/gigl/src/common/types/pb_wrappers/preprocessed_metadata.py
+++ b/python/gigl/src/common/types/pb_wrappers/preprocessed_metadata.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from functools import partial
+from typing import Dict
 
 from tensorflow_metadata.proto.v0.schema_pb2 import Schema
 
@@ -28,38 +29,38 @@ logger = Logger()
 class PreprocessedMetadataPbWrapper:
     preprocessed_metadata_pb: preprocessed_metadata_pb2.PreprocessedMetadata
 
-    _condensed_node_type_to_feature_dim_map: dict[CondensedNodeType, int] = field(
+    _condensed_node_type_to_feature_dim_map: Dict[CondensedNodeType, int] = field(
         init=False
     )
-    _condensed_node_type_to_feature_schema_map: dict[
+    _condensed_node_type_to_feature_schema_map: Dict[
         CondensedNodeType, FeatureSchema
     ] = field(init=False)
 
-    _condensed_edge_type_to_feature_dim_map: dict[CondensedEdgeType, int] = field(
+    _condensed_edge_type_to_feature_dim_map: Dict[CondensedEdgeType, int] = field(
         init=False
     )
-    _condensed_edge_type_to_feature_schema_map: dict[
+    _condensed_edge_type_to_feature_schema_map: Dict[
         CondensedEdgeType, FeatureSchema
     ] = field(init=False)
 
-    _condensed_edge_type_to_pos_edge_feature_dim_map: dict[
+    _condensed_edge_type_to_pos_edge_feature_dim_map: Dict[
         CondensedEdgeType, int
     ] = field(init=False)
-    _condensed_edge_type_to_pos_edge_feature_schema_map: dict[
+    _condensed_edge_type_to_pos_edge_feature_schema_map: Dict[
         CondensedEdgeType, FeatureSchema
     ] = field(init=False)
 
-    _condensed_edge_type_to_hard_neg_edge_feature_dim_map: dict[
+    _condensed_edge_type_to_hard_neg_edge_feature_dim_map: Dict[
         CondensedEdgeType, int
     ] = field(init=False)
-    _condensed_edge_type_to_hard_neg_edge_feature_schema_map: dict[
+    _condensed_edge_type_to_hard_neg_edge_feature_schema_map: Dict[
         CondensedEdgeType, FeatureSchema
     ] = field(init=False)
 
     def __post_init__(self):
         # Populate the _condensed_node_type_to_feature_dim_map field
-        condensed_node_type_to_feature_dim_map: dict[CondensedNodeType, int] = {}
-        condensed_node_type_to_feature_schema_map: dict[
+        condensed_node_type_to_feature_dim_map: Dict[CondensedNodeType, int] = {}
+        condensed_node_type_to_feature_schema_map: Dict[
             CondensedNodeType, FeatureSchema
         ] = {}
         for condensed_node_type, node_metadata in dict(
@@ -92,8 +93,8 @@ class PreprocessedMetadataPbWrapper:
         )
 
         # Populate the _condensed_edge_type_to_feature_dim_map field
-        condensed_edge_type_to_feature_dim_map: dict[CondensedEdgeType, int] = {}
-        condensed_edge_type_to_feature_schema_map: dict[
+        condensed_edge_type_to_feature_dim_map: Dict[CondensedEdgeType, int] = {}
+        condensed_edge_type_to_feature_schema_map: Dict[
             CondensedEdgeType, FeatureSchema
         ] = {}
         for condensed_edge_type, edge_metadata in dict(
@@ -126,10 +127,10 @@ class PreprocessedMetadataPbWrapper:
         )
 
         # Populate the _condensed_edge_type_to_pos_edge_feature_dim_map field
-        condensed_edge_type_to_pos_edge_feature_dim_map: dict[
+        condensed_edge_type_to_pos_edge_feature_dim_map: Dict[
             CondensedEdgeType, int
         ] = {}
-        condensed_edge_type_to_pos_edge_feature_schema_map: dict[
+        condensed_edge_type_to_pos_edge_feature_schema_map: Dict[
             CondensedEdgeType, FeatureSchema
         ] = {}
         for condensed_edge_type, edge_metadata in dict(
@@ -162,10 +163,10 @@ class PreprocessedMetadataPbWrapper:
         )
 
         # Populate the _condensed_edge_type_to_hard_neg_edge_feature_dim_map field
-        condensed_edge_type_to_hard_neg_edge_feature_dim_map: dict[
+        condensed_edge_type_to_hard_neg_edge_feature_dim_map: Dict[
             CondensedEdgeType, int
         ] = {}
-        condensed_edge_type_to_hard_neg_edge_feature_schema_map: dict[
+        condensed_edge_type_to_hard_neg_edge_feature_schema_map: Dict[
             CondensedEdgeType, FeatureSchema
         ] = {}
         for condensed_edge_type, edge_metadata in dict(
@@ -344,13 +345,13 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_node_type_to_feature_dim_map(
         self,
-    ) -> dict[CondensedNodeType, int]:
+    ) -> Dict[CondensedNodeType, int]:
         """
         Allows access to a mapping which stores the feature dimension of each
         CondensedNodeTypes.
 
         Returns:
-            dict[CondensedNodeType, int]: A mapping which stores the feature dimension of each
+            Dict[CondensedNodeType, int]: A mapping which stores the feature dimension of each
             CondensedNodeTypes
         """
         return self._condensed_node_type_to_feature_dim_map
@@ -358,13 +359,13 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_node_type_to_feature_schema_map(
         self,
-    ) -> dict[CondensedNodeType, FeatureSchema]:
+    ) -> Dict[CondensedNodeType, FeatureSchema]:
         """
         Allows access to a mapping which stores the feature spec of each
         CondensedNodeTypes.
 
         Returns:
-            dict[CondensedNodeType, FeatureSchema]: A mapping which stores the feature spec of each
+            Dict[CondensedNodeType, FeatureSchema]: A mapping which stores the feature spec of each
             CondensedNodeTypes
         """
         return self._condensed_node_type_to_feature_schema_map
@@ -372,12 +373,12 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_node_type_to_feature_keys_map(
         self,
-    ) -> dict[CondensedNodeType, list[str]]:
+    ) -> Dict[CondensedNodeType, list[str]]:
         """
         Allows access to a mapping which stores the feature keys of each CondensedNodeTypes.
 
         Returns:
-            dict[CondensedNodeType, list[str]]: A mapping which stores the feature keys of each CondensedNodeTypes
+            Dict[CondensedNodeType, list[str]]: A mapping which stores the feature keys of each CondensedNodeTypes
         """
         return {
             condensed_node_type: list(
@@ -391,13 +392,13 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_edge_type_to_feature_dim_map(
         self,
-    ) -> dict[CondensedEdgeType, int]:
+    ) -> Dict[CondensedEdgeType, int]:
         """
         Allows access to a mapping which stores the message passing edge feature
         dimension of each CondensedEdgeTypes.
 
         Returns:
-            dict[CondensedEdgeType, int]: A mapping which stores the message passing edge feature
+            Dict[CondensedEdgeType, int]: A mapping which stores the message passing edge feature
             dimension of each CondensedEdgeTypes
         """
         return self._condensed_edge_type_to_feature_dim_map
@@ -405,13 +406,13 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_edge_type_to_feature_schema_map(
         self,
-    ) -> dict[CondensedEdgeType, FeatureSchema]:
+    ) -> Dict[CondensedEdgeType, FeatureSchema]:
         """
         Allows access to a mapping which stores the message passing edge feature
         spec, tf schema, and feature index of each CondensedEdgeTypes.
 
         Returns:
-            dict[CondensedEdgeType, FeatureSchema]: A mapping which stores the message passing edge feature
+            Dict[CondensedEdgeType, FeatureSchema]: A mapping which stores the message passing edge feature
             spec, tf schema, and feature index of each CondensedEdgeTypes
         """
         return self._condensed_edge_type_to_feature_schema_map
@@ -419,12 +420,12 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_edge_type_to_feature_keys_map(
         self,
-    ) -> dict[CondensedEdgeType, list[str]]:
+    ) -> Dict[CondensedEdgeType, list[str]]:
         """
         Allows access to a mapping which stores the feature keys of each CondensedEdgeTypes.
 
         Returns:
-            dict[CondensedEdgeType, list[str]]: A mapping which stores the feature keys of each CondensedEdgeTypes
+            Dict[CondensedEdgeType, list[str]]: A mapping which stores the feature keys of each CondensedEdgeTypes
         """
         return {
             condensed_edge_type: list(
@@ -438,13 +439,13 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_edge_type_to_pos_edge_feature_dim_map(
         self,
-    ) -> dict[CondensedEdgeType, int]:
+    ) -> Dict[CondensedEdgeType, int]:
         """
         Allows access to a mapping which stores the user-defined positive edge feature
         dimension of each CondensedEdgeTypes.
 
         Returns:
-            dict[CondensedEdgeType, int]: A mapping which stores the user-defined positive edge feature
+            Dict[CondensedEdgeType, int]: A mapping which stores the user-defined positive edge feature
             dimension of each CondensedEdgeTypes
         """
         return self._condensed_edge_type_to_pos_edge_feature_dim_map
@@ -452,13 +453,13 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_edge_type_to_pos_edge_feature_schema_map(
         self,
-    ) -> dict[CondensedEdgeType, FeatureSchema]:
+    ) -> Dict[CondensedEdgeType, FeatureSchema]:
         """
         Allows access to a mapping which stores the user-defined positive edge feature
         spec, tf schema, and feature index of each CondensedEdgeTypes.
 
         Returns:
-            dict[CondensedEdgeType, FeatureSchema]: A mapping which stores the user-defined positive edge feature
+            Dict[CondensedEdgeType, FeatureSchema]: A mapping which stores the user-defined positive edge feature
             spec, tf schema, and feature index of each CondensedEdgeTypes
         """
         return self._condensed_edge_type_to_pos_edge_feature_schema_map
@@ -466,12 +467,12 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_edge_type_to_pos_edge_feature_keys_map(
         self,
-    ) -> dict[CondensedEdgeType, list[str]]:
+    ) -> Dict[CondensedEdgeType, list[str]]:
         """
         Allows access to a mapping which stores the feature keys of each CondensedEdgeTypes.
 
         Returns:
-            dict[CondensedEdgeType, list[str]]: A mapping which stores the feature keys of each CondensedEdgeTypes
+            Dict[CondensedEdgeType, list[str]]: A mapping which stores the feature keys of each CondensedEdgeTypes
         """
         return {
             condensed_edge_type: list(
@@ -485,13 +486,13 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_edge_type_to_hard_neg_edge_feature_dim_map(
         self,
-    ) -> dict[CondensedEdgeType, int]:
+    ) -> Dict[CondensedEdgeType, int]:
         """
         Allows access to a mapping which stores the user-defined negative edge feature
         dimension of each CondensedEdgeTypes.
 
         Returns:
-            dict[CondensedEdgeType, int]: A mapping which stores the user-defined negative edge feature
+            Dict[CondensedEdgeType, int]: A mapping which stores the user-defined negative edge feature
             dimension of each CondensedEdgeTypes
         """
         return self._condensed_edge_type_to_hard_neg_edge_feature_dim_map
@@ -499,13 +500,13 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_edge_type_to_hard_neg_edge_feature_schema_map(
         self,
-    ) -> dict[CondensedEdgeType, FeatureSchema]:
+    ) -> Dict[CondensedEdgeType, FeatureSchema]:
         """
         Allows access to a mapping which stores the user-defined negative edge feature
         spec, tf schema, and feature index of each CondensedEdgeTypes.
 
         Returns:
-            dict[CondensedEdgeType, FeatureSchema]: A mapping which stores the user-defined negative edge feature
+            Dict[CondensedEdgeType, FeatureSchema]: A mapping which stores the user-defined negative edge feature
             spec, tf schema, and feature index of each CondensedEdgeTypes
         """
         return self._condensed_edge_type_to_hard_neg_edge_feature_schema_map
@@ -513,12 +514,12 @@ class PreprocessedMetadataPbWrapper:
     @property
     def condensed_edge_type_to_hard_neg_edge_feature_keys_map(
         self,
-    ) -> dict[CondensedEdgeType, list[str]]:
+    ) -> Dict[CondensedEdgeType, list[str]]:
         """
         Allows access to a mapping which stores the feature keys of each CondensedEdgeTypes.
 
         Returns:
-            dict[CondensedEdgeType, list[str]]: A mapping which stores the feature keys of each CondensedEdgeTypes
+            Dict[CondensedEdgeType, list[str]]: A mapping which stores the feature keys of each CondensedEdgeTypes
         """
         return {
             condensed_edge_type: list(

--- a/python/gigl/src/common/types/pb_wrappers/sampling_op.py
+++ b/python/gigl/src/common/types/pb_wrappers/sampling_op.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Set, Union, cast
+from typing import Dict, Optional, Set, Union, cast
 
 from gigl.src.common.types.exception import (
     SubgraphSamplingValidationError,
@@ -99,7 +99,7 @@ class UserDefinedPbWrapper:
         return self.user_defined_pb.path_to_udf
 
     @property
-    def params(self) -> dict[str, str]:
+    def params(self) -> Dict[str, str]:
         return dict(self.user_defined_pb.params)
 
 

--- a/python/gigl/src/common/types/pb_wrappers/subgraph_sampling_strategy.py
+++ b/python/gigl/src/common/types/pb_wrappers/subgraph_sampling_strategy.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Set, cast
+from typing import Dict, Set, cast
 
 from gigl.src.common.types.exception import (
     SubgraphSamplingValidationError,
@@ -27,7 +27,7 @@ class MessagePassingPathPbWrapper:
         """
         Builds dags using the provided message passing path sampling strategy for graph traversal
         """
-        op_name_to_sampling_op_pb_wrapper: dict[str, SamplingOpPbWrapper] = {}
+        op_name_to_sampling_op_pb_wrapper: Dict[str, SamplingOpPbWrapper] = {}
         root_sampling_op_names: Set[str] = set()
         # Firstly create the raw SamplingOpNodes indexed by the op name and identify root sampling op nodes
         for sampling_op_pb in self.message_passing_path_pb.sampling_ops:
@@ -93,7 +93,7 @@ class MessagePassingPathPbWrapper:
         return self.__root_sampling_op_names
 
     @property
-    def op_name_to_sampling_op_pb_wrapper(self) -> dict[str, SamplingOpPbWrapper]:
+    def op_name_to_sampling_op_pb_wrapper(self) -> Dict[str, SamplingOpPbWrapper]:
         return self.__op_name_to_sampling_op_pb_wrapper
 
 
@@ -102,7 +102,7 @@ class MessagePassingPathStrategyPbWrapper:
     message_passing_path_strategy_pb: MessagePassingPathStrategy
 
     def __post_init__(self):
-        root_node_type_to_message_passing_path_pb_wrapper: dict[
+        root_node_type_to_message_passing_path_pb_wrapper: Dict[
             NodeType, MessagePassingPathPbWrapper
         ] = {}
         for message_passing_path_pb in self.message_passing_path_strategy_pb.paths:
@@ -127,7 +127,7 @@ class MessagePassingPathStrategyPbWrapper:
     @property
     def root_node_type_to_message_passing_path_pb_wrapper(
         self,
-    ) -> dict[NodeType, MessagePassingPathPbWrapper]:
+    ) -> Dict[NodeType, MessagePassingPathPbWrapper]:
         return self.__root_node_type_to_message_passing_path_pb_wrapper
 
 
@@ -142,7 +142,7 @@ class GlobalRandomUniformStrategyPbWrapper:
     @property
     def root_node_type_to_message_passing_path_pb_wrapper(
         self,
-    ) -> dict[NodeType, MessagePassingPathPbWrapper]:
+    ) -> Dict[NodeType, MessagePassingPathPbWrapper]:
         return self.__root_node_type_to_message_passing_path_pb_wrapper
 
 
@@ -151,7 +151,7 @@ class SubgraphSamplingStrategyPbWrapper:
     subgraph_sampling_strategy_pb: SubgraphSamplingStrategy
 
     def __post_init__(self) -> None:
-        self.__root_node_type_to_message_passing_path_pb_wrapper: dict[
+        self.__root_node_type_to_message_passing_path_pb_wrapper: Dict[
             NodeType, MessagePassingPathPbWrapper
         ]
         sampling_strategy_field = cast(
@@ -285,7 +285,7 @@ class SubgraphSamplingStrategyPbWrapper:
     @property
     def root_node_type_to_message_passing_path_pb_wrapper(
         self,
-    ) -> dict[NodeType, MessagePassingPathPbWrapper]:
+    ) -> Dict[NodeType, MessagePassingPathPbWrapper]:
         """
         Returns a mapping of each root node type to their respective sampling op dag
         """

--- a/python/gigl/src/common/types/task_inputs.py
+++ b/python/gigl/src/common/types/task_inputs.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 
@@ -23,10 +23,10 @@ class InputBatch:
 @dataclass
 class BatchEmbeddings:
     query_embeddings: torch.FloatTensor
-    repeated_query_embeddings: dict[CondensedEdgeType, torch.FloatTensor]
-    pos_embeddings: dict[CondensedEdgeType, torch.FloatTensor]
-    hard_neg_embeddings: dict[CondensedEdgeType, torch.FloatTensor]
-    random_neg_embeddings: dict[CondensedNodeType, torch.FloatTensor]
+    repeated_query_embeddings: Dict[CondensedEdgeType, torch.FloatTensor]
+    pos_embeddings: Dict[CondensedEdgeType, torch.FloatTensor]
+    hard_neg_embeddings: Dict[CondensedEdgeType, torch.FloatTensor]
+    random_neg_embeddings: Dict[CondensedNodeType, torch.FloatTensor]
 
 
 # Returns scores for a single anchor node
@@ -53,5 +53,5 @@ class BatchCombinedScores:
 class NodeAnchorBasedLinkPredictionTaskInputs:
     input_batch: InputBatch
     batch_embeddings: Optional[BatchEmbeddings]
-    batch_scores: list[dict[CondensedEdgeType, BatchScores]]
-    batch_combined_scores: dict[CondensedEdgeType, BatchCombinedScores]
+    batch_scores: list[Dict[CondensedEdgeType, BatchScores]]
+    batch_combined_scores: Dict[CondensedEdgeType, BatchCombinedScores]

--- a/python/gigl/src/common/utils/bq.py
+++ b/python/gigl/src/common/utils/bq.py
@@ -1,7 +1,7 @@
 import datetime
 import itertools
 import re
-from typing import Iterable, Optional, Tuple, Union
+from typing import Dict, Iterable, Optional, Tuple, Union
 
 import google.api_core.retry
 import google.cloud.bigquery as bigquery
@@ -102,7 +102,7 @@ class BqUtils:
     def count_number_of_rows_in_bq_table(
         self,
         bq_table: str,
-        labels: dict[str, str] = {},
+        labels: Dict[str, str] = {},
     ) -> int:
         bq_table = bq_table.replace(":", ".")
         ROW_COUNTING_QUERY = f"""
@@ -123,7 +123,7 @@ class BqUtils:
     def run_query(
         self,
         query,
-        labels: dict[str, str],
+        labels: Dict[str, str],
         **job_config_args,
     ) -> RowIterator:
         logger.info(f"Running query: {query}")
@@ -339,7 +339,7 @@ class BqUtils:
         except Exception as e:
             logger.exception(f"Failed to delete table '{bq_table_path}' due to \n {e}")
 
-    def fetch_bq_table_schema(self, bq_table: str) -> dict[str, bigquery.SchemaField]:
+    def fetch_bq_table_schema(self, bq_table: str) -> Dict[str, bigquery.SchemaField]:
         """
         Create a dictionary representation for SchemaFields from BigQuery table.
         """

--- a/python/gigl/src/common/utils/file_loader.py
+++ b/python/gigl/src/common/utils/file_loader.py
@@ -2,7 +2,7 @@ import shutil
 import tempfile
 from collections.abc import Mapping
 from tempfile import _TemporaryFileWrapper as TemporaryFileWrapper  # type: ignore
-from typing import IO, AnyStr, Optional, Sequence, Tuple, Type, Union, cast
+from typing import IO, AnyStr, Dict, Optional, Sequence, Tuple, Type, Union, cast
 
 from gigl.common import GcsUri, HttpUri, LocalUri, Uri, UriFactory
 from gigl.common.logger import Logger
@@ -45,7 +45,7 @@ class FileLoader:
 
     def load_directories(
         self,
-        source_to_dest_directory_map: dict[Uri, Uri],
+        source_to_dest_directory_map: Dict[Uri, Uri],
     ):
         for dir_uri_src, dir_uri_dst in source_to_dest_directory_map.items():
             self.load_directory(dir_uri_src=dir_uri_src, dir_uri_dst=dir_uri_dst)
@@ -69,12 +69,12 @@ class FileLoader:
                 GcsUri.join(dir_uri_dst, local_fn.uri)
                 for local_fn in list_at_path(dir_uri_src, names_only=True)
             ]
-            local_file_path_to_gcs_path_map: dict[LocalUri, GcsUri] = {
+            local_file_path_to_gcs_path_map: Dict[LocalUri, GcsUri] = {
                 src: dst for src, dst in zip(local_paths, gcs_paths)
             }
             self.load_files(
                 source_to_dest_file_uri_map=cast(
-                    dict[Uri, Uri], local_file_path_to_gcs_path_map
+                    Dict[Uri, Uri], local_file_path_to_gcs_path_map
                 )
             )
         elif uri_map_schema == (LocalUri, LocalUri):
@@ -97,7 +97,7 @@ class FileLoader:
             }
             self.load_files(
                 source_to_dest_file_uri_map=cast(
-                    dict[Uri, Uri], source_to_dest_file_uri_map
+                    Dict[Uri, Uri], source_to_dest_file_uri_map
                 )
             )
         else:
@@ -113,13 +113,13 @@ class FileLoader:
         if uri_map_schema == (GcsUri, LocalUri):
             logger.info("Downloading from GCS to Local")
             self.__gcs_utils.download_files_from_gcs_paths_to_local_paths(
-                file_map=cast(dict[GcsUri, LocalUri], source_to_dest_file_uri_map)
+                file_map=cast(Dict[GcsUri, LocalUri], source_to_dest_file_uri_map)
             )
         elif uri_map_schema == (LocalUri, GcsUri):
             logger.info("Uploading from Local to GCS")
             self.__gcs_utils.upload_files_to_gcs(
                 local_file_path_to_gcs_path_map=cast(
-                    dict[LocalUri, GcsUri], source_to_dest_file_uri_map
+                    Dict[LocalUri, GcsUri], source_to_dest_file_uri_map
                 ),
                 parallel=True,
             )
@@ -130,7 +130,7 @@ class FileLoader:
                 logger.info("Will create symlinks")
                 create_file_symlinks(
                     local_source_to_link_path_map=cast(
-                        dict[LocalUri, LocalUri], local_source_to_link_path_map
+                        Dict[LocalUri, LocalUri], local_source_to_link_path_map
                     ),
                     should_overwrite=True,
                 )
@@ -138,7 +138,7 @@ class FileLoader:
                 logger.info("Will copy files")
                 copy_files(
                     local_source_to_local_dst_path_map=cast(
-                        dict[LocalUri, LocalUri], local_source_to_link_path_map
+                        Dict[LocalUri, LocalUri], local_source_to_link_path_map
                     ),
                     should_overwrite=True,
                 )
@@ -146,7 +146,7 @@ class FileLoader:
             logger.info("Downloading from HTTP to Local")
             HttpUtils.download_files_from_http(
                 http_to_local_path_map=cast(
-                    dict[HttpUri, LocalUri], source_to_dest_file_uri_map
+                    Dict[HttpUri, LocalUri], source_to_dest_file_uri_map
                 ),
             )
         else:

--- a/python/gigl/src/common/utils/model.py
+++ b/python/gigl/src/common/utils/model.py
@@ -1,5 +1,5 @@
 import tempfile
-from collections import OrderedDict
+from typing import OrderedDict
 
 import torch
 

--- a/python/gigl/src/common/utils/spark_job_manager.py
+++ b/python/gigl/src/common/utils/spark_job_manager.py
@@ -1,6 +1,6 @@
 import datetime
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 from google.cloud.dataproc_v1.types import (
     Cluster,
@@ -37,7 +37,7 @@ class DataprocClusterInitData:
     is_debug_mode: bool
     debug_cluster_owner_alias: Optional[str] = None
     init_script_uri: Optional[GcsUri] = None
-    labels: Optional[dict[str, str]] = None
+    labels: Optional[Dict[str, str]] = None
 
 
 class SparkJobManager:

--- a/python/gigl/src/config_populator/config_populator.py
+++ b/python/gigl/src/config_populator/config_populator.py
@@ -3,7 +3,7 @@ import sys
 import traceback
 from collections import Counter
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 import gigl.src.common.constants.bq as bq_constants
 import gigl.src.common.constants.gcs as gcs_constants
@@ -130,7 +130,7 @@ class ConfigPopulator:
                 )
             )
 
-            node_type_to_random_negative_tfrecord_uri_prefix: dict[str, str] = {}
+            node_type_to_random_negative_tfrecord_uri_prefix: Dict[str, str] = {}
             for node_type in random_negative_node_types:
                 node_type_to_random_negative_tfrecord_uri_prefix[
                     str(node_type)
@@ -229,9 +229,9 @@ class ConfigPopulator:
                 )
             )
 
-            train_node_type_to_random_negative_data_uri: dict[str, str] = {}
-            val_node_type_to_random_negative_data_uri: dict[str, str] = {}
-            test_node_type_to_random_negative_data_uri: dict[str, str] = {}
+            train_node_type_to_random_negative_data_uri: Dict[str, str] = {}
+            val_node_type_to_random_negative_data_uri: Dict[str, str] = {}
+            test_node_type_to_random_negative_data_uri: Dict[str, str] = {}
 
             for node_type in random_negative_node_types:
                 train_node_type_to_random_negative_data_uri[
@@ -328,7 +328,7 @@ class ConfigPopulator:
         """
         Populates the embeddings path and predictions path per inferencer node type in InferenceMetadata.
         """
-        node_type_to_inferencer_output_info_map: dict[
+        node_type_to_inferencer_output_info_map: Dict[
             str, inference_metadata_pb2.InferenceOutput
         ] = {}
         inferencer_node_types = self.task_metadata_pb_wrapper.get_task_root_node_types()

--- a/python/gigl/src/data_preprocessor/data_preprocessor.py
+++ b/python/gigl/src/data_preprocessor/data_preprocessor.py
@@ -4,7 +4,7 @@ import sys
 import threading
 from collections import defaultdict
 from itertools import chain, repeat
-from typing import Callable, Iterable, NamedTuple, Optional, Tuple, Union
+from typing import Callable, Dict, Iterable, NamedTuple, Optional, Tuple, Union
 
 import tensorflow as tf
 import tensorflow_data_validation as tfdv
@@ -74,8 +74,8 @@ logger = Logger()
 
 
 class PreprocessedMetadataReferences(NamedTuple):
-    node_data: dict[NodeDataReference, TransformedFeaturesInfo]
-    edge_data: dict[EdgeDataReference, TransformedFeaturesInfo]
+    node_data: Dict[NodeDataReference, TransformedFeaturesInfo]
+    edge_data: Dict[EdgeDataReference, TransformedFeaturesInfo]
 
 
 class DataPreprocessor:
@@ -310,10 +310,10 @@ class DataPreprocessor:
 
     def __preprocess_all_data_references(
         self,
-        node_ref_to_preprocessing_spec: dict[
+        node_ref_to_preprocessing_spec: Dict[
             NodeDataReference, NodeDataPreprocessingSpec
         ],
-        edge_ref_to_preprocessing_spec: dict[
+        edge_ref_to_preprocessing_spec: Dict[
             EdgeDataReference, EdgeDataPreprocessingSpec
         ],
     ) -> PreprocessedMetadataReferences:
@@ -342,8 +342,8 @@ class DataPreprocessor:
             f"{__build_data_reference_str(references=edge_ref_to_preprocessing_spec.keys())}"
         )
 
-        node_refs_and_results: dict[NodeDataReference, TransformedFeaturesInfo] = dict()
-        edge_refs_and_results: dict[EdgeDataReference, TransformedFeaturesInfo] = dict()
+        node_refs_and_results: Dict[NodeDataReference, TransformedFeaturesInfo] = dict()
+        edge_refs_and_results: Dict[EdgeDataReference, TransformedFeaturesInfo] = dict()
 
         # We kick off multiple Dataflow pipelines, each of which kicks off a setup.py sdist run.
         # sdist has race-condition issues for simultaneous runs: https://github.com/pypa/setuptools/issues/1222
@@ -358,7 +358,7 @@ class DataPreprocessor:
             max_workers=num_dataflow_jobs
         ) as executor:
             logger.info(f"Launching {num_dataflow_jobs} dataflow jobs in parallel.")
-            futures: dict[
+            futures: Dict[
                 concurrent.futures.Future[TransformedFeaturesInfo],
                 Tuple[Union[NodeDataReference, EdgeDataReference], FeatureTypes],
             ] = dict()
@@ -440,7 +440,7 @@ class DataPreprocessor:
     ) -> preprocessed_metadata_pb2.PreprocessedMetadata:
         preprocessed_metadata_pb = preprocessed_metadata_pb2.PreprocessedMetadata()
 
-        enumerator_node_type_metadata_map: dict[
+        enumerator_node_type_metadata_map: Dict[
             NodeType, EnumeratorNodeTypeMetadata
         ] = {
             node_type_metadata.enumerated_node_data_reference.node_type: node_type_metadata
@@ -492,8 +492,8 @@ class DataPreprocessor:
         # Populate all edge data.
         logger.info("Populating preprocessed metadata with edge data.")
 
-        enumerator_edge_type_metadata_map: dict[
-            EdgeType, dict[EdgeUsageType, EnumeratorEdgeTypeMetadata]
+        enumerator_edge_type_metadata_map: Dict[
+            EdgeType, Dict[EdgeUsageType, EnumeratorEdgeTypeMetadata]
         ] = defaultdict(dict)
         for edge_type_metadata in enumerator_edge_type_metadata:
             enumerator_edge_type_metadata_map[
@@ -502,8 +502,8 @@ class DataPreprocessor:
                 edge_type_metadata.enumerated_edge_data_reference.edge_usage_type
             ] = edge_type_metadata
 
-        preprocessed_metadata_references_map: dict[
-            EdgeType, dict[EdgeUsageType, TransformedFeaturesInfo]
+        preprocessed_metadata_references_map: Dict[
+            EdgeType, Dict[EdgeUsageType, TransformedFeaturesInfo]
         ] = defaultdict(dict)
         edge_info: Tuple[EdgeDataReference, TransformedFeaturesInfo]
         for edge_info in preprocessed_metadata_references.edge_data.items():
@@ -515,7 +515,7 @@ class DataPreprocessor:
             ] = edge_transformed_features_info
 
         edge_type: EdgeType
-        edge_transformed_features_info_map: dict[EdgeUsageType, TransformedFeaturesInfo]
+        edge_transformed_features_info_map: Dict[EdgeUsageType, TransformedFeaturesInfo]
         for (
             edge_type,
             edge_transformed_features_info_map,
@@ -641,17 +641,17 @@ class DataPreprocessor:
 
     def __patch_preprocessing_specs(
         self,
-        node_data_reference_to_preprocessing_spec: dict[
+        node_data_reference_to_preprocessing_spec: Dict[
             NodeDataReference, NodeDataPreprocessingSpec
         ],
-        edge_data_reference_to_preprocessing_spec: dict[
+        edge_data_reference_to_preprocessing_spec: Dict[
             EdgeDataReference, EdgeDataPreprocessingSpec
         ],
         enumerator_node_type_metadata: list[EnumeratorNodeTypeMetadata],
         enumerator_edge_type_metadata: list[EnumeratorEdgeTypeMetadata],
     ) -> Tuple[
-        dict[NodeDataReference, NodeDataPreprocessingSpec],
-        dict[EdgeDataReference, EdgeDataPreprocessingSpec],
+        Dict[NodeDataReference, NodeDataPreprocessingSpec],
+        Dict[EdgeDataReference, EdgeDataPreprocessingSpec],
     ]:
         """
         Patches the preprocessing specs for enumerated node and edge data references.
@@ -666,7 +666,7 @@ class DataPreprocessor:
         """
 
         # First, we patch the node data references.
-        enumerated_node_refs_to_preprocessing_specs: dict[
+        enumerated_node_refs_to_preprocessing_specs: Dict[
             NodeDataReference, NodeDataPreprocessingSpec
         ] = {}
 
@@ -710,7 +710,7 @@ class DataPreprocessor:
             ] = enumerated_node_data_preprocessing_spec
 
         # Now we do the same for edges.
-        enumerated_edge_refs_to_preprocessing_specs: dict[
+        enumerated_edge_refs_to_preprocessing_specs: Dict[
             EdgeDataReference, EdgeDataPreprocessingSpec
         ] = {}
         for enumerated_edge_metadata in enumerator_edge_type_metadata:
@@ -779,7 +779,7 @@ class DataPreprocessor:
 
         # Update the node and edge data references to include identifiers. In current configuration setup,
         # these identifiers are piped in from the DataPreprocessorConfig.
-        node_refs_to_specs: dict[NodeDataReference, NodeDataPreprocessingSpec] = {}
+        node_refs_to_specs: Dict[NodeDataReference, NodeDataPreprocessingSpec] = {}
         for (
             node_data_reference,
             node_data_preprocessing_spec,
@@ -796,7 +796,7 @@ class DataPreprocessor:
                 node_data_ref_with_identifier
             ] = node_data_preprocessing_spec
 
-        edge_refs_to_specs: dict[EdgeDataReference, EdgeDataPreprocessingSpec] = {}
+        edge_refs_to_specs: Dict[EdgeDataReference, EdgeDataPreprocessingSpec] = {}
         for (
             edge_data_reference,
             edge_data_preprocessing_spec,

--- a/python/gigl/src/data_preprocessor/lib/data_preprocessor_config.py
+++ b/python/gigl/src/data_preprocessor/lib/data_preprocessor_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional
 
 import tensorflow as tf
 
@@ -45,7 +45,7 @@ class DataPreprocessorConfig(ABC):
     @abstractmethod
     def get_nodes_preprocessing_spec(
         self,
-    ) -> dict[NodeDataReference, NodeDataPreprocessingSpec]:
+    ) -> Dict[NodeDataReference, NodeDataPreprocessingSpec]:
         """
         Defines transformation imperatives for different node types
         """
@@ -54,7 +54,7 @@ class DataPreprocessorConfig(ABC):
     @abstractmethod
     def get_edges_preprocessing_spec(
         self,
-    ) -> dict[EdgeDataReference, EdgeDataPreprocessingSpec]:
+    ) -> Dict[EdgeDataReference, EdgeDataPreprocessingSpec]:
         """
         Defines transformation imperatives for different edge types
         """
@@ -63,11 +63,11 @@ class DataPreprocessorConfig(ABC):
 
 def build_ingestion_feature_spec_fn(
     fixed_string_fields: Optional[list[str]] = None,
-    fixed_string_field_shapes: dict[str, list[int]] = {},
+    fixed_string_field_shapes: Dict[str, list[int]] = {},
     fixed_float_fields: Optional[list[str]] = None,
-    fixed_float_field_shapes: dict[str, list[int]] = {},
+    fixed_float_field_shapes: Dict[str, list[int]] = {},
     fixed_int_fields: Optional[list[str]] = None,
-    fixed_int_field_shapes: dict[str, list[int]] = {},
+    fixed_int_field_shapes: Dict[str, list[int]] = {},
     varlen_string_fields: Optional[list[str]] = None,
     varlen_float_fields: Optional[list[str]] = None,
     varlen_int_fields: Optional[list[str]] = None,

--- a/python/gigl/src/data_preprocessor/lib/enumerate/utils.py
+++ b/python/gigl/src/data_preprocessor/lib/enumerate/utils.py
@@ -2,7 +2,7 @@ import concurrent.futures
 import sys
 import traceback
 from dataclasses import dataclass
-from typing import Sequence, Tuple
+from typing import Dict, Sequence, Tuple
 
 import google.cloud.bigquery as bigquery
 
@@ -64,7 +64,7 @@ def get_enumerated_edge_features_bq_table_name(
     )
 
 
-def get_resource_labels() -> dict[str, str]:
+def get_resource_labels() -> Dict[str, str]:
     resource_config = get_resource_config()
     return resource_config.get_resource_labels(
         component=GiGLComponents.DataPreprocessor
@@ -269,7 +269,7 @@ class Enumerator:
     def __enumerate_all_edge_references(
         self,
         edge_data_references: Sequence[EdgeDataReference],
-        map_enumerator_node_type_metadata: dict[NodeType, EnumeratorNodeTypeMetadata],
+        map_enumerator_node_type_metadata: Dict[NodeType, EnumeratorNodeTypeMetadata],
     ) -> list[EnumeratorEdgeTypeMetadata]:
         results: list[EnumeratorEdgeTypeMetadata] = []
 
@@ -367,7 +367,7 @@ class Enumerator:
     def __enumerate_edge_reference(
         self,
         edge_data_ref: EdgeDataReference,
-        map_enumerator_node_type_metadata: dict[NodeType, EnumeratorNodeTypeMetadata],
+        map_enumerator_node_type_metadata: Dict[NodeType, EnumeratorNodeTypeMetadata],
     ) -> EnumeratorEdgeTypeMetadata:
         if not isinstance(edge_data_ref, BigqueryEdgeDataReference):
             raise NotImplementedError(
@@ -450,7 +450,7 @@ class Enumerator:
         ] = self.__enumerate_all_node_references(
             node_data_references=node_data_references
         )
-        map_enumerator_node_type_metadata: dict[
+        map_enumerator_node_type_metadata: Dict[
             NodeType, EnumeratorNodeTypeMetadata
         ] = {
             node_metadata.input_node_data_reference.node_type: node_metadata

--- a/python/gigl/src/data_preprocessor/lib/transform/utils.py
+++ b/python/gigl/src/data_preprocessor/lib/transform/utils.py
@@ -337,7 +337,7 @@ def get_load_data_and_transform_pipeline_component(
         )
 
         # The transformed_features returned by tft_beam.TransformDataset is a
-        # PCollection of Tuple[pa.RecordBatch, dict[str, pa.Array]]. The first
+        # PCollection of Tuple[pa.RecordBatch, Dict[str, pa.Array]]. The first
         # one are the transformed features. The second one are the passthrough
         # features, which doesn't apply here since we do not specify passthrough_keys
         # in tft_beam.Context. Hence we drop the second one in the tuple.

--- a/python/gigl/src/data_preprocessor/lib/types.py
+++ b/python/gigl/src/data_preprocessor/lib/types.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable, NamedTuple, Optional, Tuple
+from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple
 
 import apache_beam as beam
 import tensorflow as tf
@@ -11,12 +11,12 @@ from gigl.common import Uri
 
 # TODO (mkolodner-sc): Move these variables to a more general location, as they are used even outside of context of data preprocessor
 
-InstanceDict = dict[str, Any]
-TFTensorDict = dict[str, common_types.TensorType]
-FeatureSpecDict = dict[str, common_types.FeatureSpecType]
-FeatureIndexDict = dict[str, Tuple[int, int]]  # feature_name -> (start, end) index
-FeatureSchemaDict = dict[str, Feature]
-FeatureVocabDict = dict[str, list[str]]
+InstanceDict = Dict[str, Any]
+TFTensorDict = Dict[str, common_types.TensorType]
+FeatureSpecDict = Dict[str, common_types.FeatureSpecType]
+FeatureIndexDict = Dict[str, Tuple[int, int]]  # feature_name -> (start, end) index
+FeatureSchemaDict = Dict[str, Feature]
+FeatureVocabDict = Dict[str, list[str]]
 
 
 # Only these 3 dtypes are supported in TFTransform

--- a/python/gigl/src/inference/v1/gnn_inferencer.py
+++ b/python/gigl/src/inference/v1/gnn_inferencer.py
@@ -7,7 +7,7 @@ import sys
 import threading
 import traceback
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from apache_beam.runners.dataflow.dataflow_runner import DataflowPipelineResult
 from apache_beam.runners.runner import PipelineState
@@ -82,14 +82,14 @@ class InferencerV1:
 
     def write_from_gcs_to_bq(
         self,
-        schema: dict[str, list[dict[str, str]]],
+        schema: Dict[str, list[Dict[str, str]]],
         gcs_uri: GcsUri,
         bq_table_uri: str,
     ) -> None:
         """
         Writes embeddings or predictions from gcs folder to bq table with specified schema
         Args:
-            schema (Optional[dict[str, list[dict[str, str]]]): BQ Table schema for embeddings or predictions from inference output
+            schema (Optional[Dict[str, list[Dict[str, str]]]): BQ Table schema for embeddings or predictions from inference output
             gcs_uri (GcsUri): GCS Folder for embeddings or predictions from inference output
             bq_table_uri (str): Path to the table for embeddings or predictions output
         """
@@ -111,7 +111,7 @@ class InferencerV1:
         logger.info(f"Finished loading to BQ table {bq_table_uri}")
 
     def generate_inferencer_instance(self) -> BaseInferencer:
-        kwargs: dict[str, Any] = {}
+        kwargs: Dict[str, Any] = {}
 
         inferencer_class_path: str = (
             self.gbml_config_pb_wrapper.inferencer_config.inferencer_cls_path
@@ -260,7 +260,7 @@ class InferencerV1:
                 graph_builder=graph_builder,
             )
         )
-        node_type_to_inferencer_output_paths_map: dict[
+        node_type_to_inferencer_output_paths_map: Dict[
             NodeType, InferencerOutputPaths
         ] = dict()
         dataflow_setup_lock = threading.Lock()
@@ -270,7 +270,7 @@ class InferencerV1:
         num_workers = min(get_available_cpus(), MAX_INFERENCER_NUM_WORKERS)
         with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
             logger.info(f"Using up to {num_workers} threads.")
-            futures: dict[
+            futures: Dict[
                 concurrent.futures.Future[InferencerOutputPaths], NodeType
             ] = dict()
             for (

--- a/python/gigl/src/inference/v1/lib/base_inference_blueprint.py
+++ b/python/gigl/src/inference/v1/lib/base_inference_blueprint.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Callable, Generic, Iterable, Optional, TypeVar
+from typing import Callable, Dict, Generic, Iterable, Optional, TypeVar
 
 import apache_beam as beam
 from apache_beam import pvalue
@@ -145,10 +145,10 @@ class BaseInferenceBlueprint(
             return DEFAULT_PREDICTIONS_TABLE_SCHEMA
 
     @abstractmethod
-    def get_inference_data_tf_record_uri_prefixes(self) -> dict[NodeType, list[Uri]]:
+    def get_inference_data_tf_record_uri_prefixes(self) -> Dict[NodeType, list[Uri]]:
         """
         Returns:
-            dict[NodeType, list[Uri]]: Dictionary of node type to the list of uri prefixes where to find tf record files
+            Dict[NodeType, list[Uri]]: Dictionary of node type to the list of uri prefixes where to find tf record files
             that will be used for inference
         """
         raise NotImplementedError

--- a/python/gigl/src/inference/v1/lib/inference_output_schema.py
+++ b/python/gigl/src/inference/v1/lib/inference_output_schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import NamedTuple, Optional
+from typing import Dict, NamedTuple, Optional
 
 import google.cloud.bigquery as bigquery
 
@@ -16,7 +16,7 @@ class InferenceOutputBigqueryTableSchema(NamedTuple):
     identifier, which assists during de-enumeration.
     """
 
-    schema: Optional[dict[str, list[dict[str, str]]]] = None
+    schema: Optional[Dict[str, list[Dict[str, str]]]] = None
     node_field: Optional[str] = None
 
 
@@ -25,7 +25,7 @@ class InferenceOutputBigqueryTableSchemaBuilder:
         self.reset()
 
     def reset(self) -> None:
-        self._fields: dict[str, bigquery.SchemaField] = dict()
+        self._fields: Dict[str, bigquery.SchemaField] = dict()
         self._node_field: Optional[str] = None
 
     def add_field(
@@ -43,7 +43,7 @@ class InferenceOutputBigqueryTableSchemaBuilder:
         self._node_field = name
         return self
 
-    def _build_schema_property(self) -> dict[str, list[dict[str, str]]]:
+    def _build_schema_property(self) -> Dict[str, list[Dict[str, str]]]:
         schema_fields = [
             {"name": field.name, "type": field.field_type, "mode": field.mode}
             for field in self._fields.values()

--- a/python/gigl/src/inference/v1/lib/node_anchor_based_link_prediction_inferencer.py
+++ b/python/gigl/src/inference/v1/lib/node_anchor_based_link_prediction_inferencer.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import partial
-from typing import Callable
+from typing import Callable, Dict
 
 import apache_beam as beam
 
@@ -56,7 +56,7 @@ class NodeAnchorBasedLinkPredictionInferenceBlueprint(
         assert isinstance(inferencer, NodeAnchorBasedLinkPredictionBaseInferencer)
         super().__init__(inferencer=inferencer)
 
-    def get_inference_data_tf_record_uri_prefixes(self) -> dict[NodeType, list[Uri]]:
+    def get_inference_data_tf_record_uri_prefixes(self) -> Dict[NodeType, list[Uri]]:
         flattened_graph_metadata_pb_wrapper = (
             self.__gbml_config_pb_wrapper.flattened_graph_metadata_pb_wrapper
         )
@@ -64,7 +64,7 @@ class NodeAnchorBasedLinkPredictionInferenceBlueprint(
             flattened_graph_metadata_pb_wrapper.output_metadata,
             flattened_graph_metadata_pb2.NodeAnchorBasedLinkPredictionOutput,
         )
-        node_type_to_tf_record_uri_prefixes: dict[NodeType, list[Uri]] = defaultdict(
+        node_type_to_tf_record_uri_prefixes: Dict[NodeType, list[Uri]] = defaultdict(
             list
         )
         node_type_to_random_negative_tfrecord_uri_prefix = (

--- a/python/gigl/src/inference/v1/lib/node_classification_inferencer.py
+++ b/python/gigl/src/inference/v1/lib/node_classification_inferencer.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Callable
+from typing import Callable, Dict
 
 import apache_beam as beam
 
@@ -52,7 +52,7 @@ class NodeClassificationInferenceBlueprint(
         assert isinstance(inferencer, SupervisedNodeClassificationBaseInferencer)
         super().__init__(inferencer=inferencer)
 
-    def get_inference_data_tf_record_uri_prefixes(self) -> dict[NodeType, list[Uri]]:
+    def get_inference_data_tf_record_uri_prefixes(self) -> Dict[NodeType, list[Uri]]:
         flattened_graph_metadata_pb_wrapper = (
             self.__gbml_config_pb_wrapper.flattened_graph_metadata_pb_wrapper
         )

--- a/python/gigl/src/mocking/dataset_asset_mocking_suite.py
+++ b/python/gigl/src/mocking/dataset_asset_mocking_suite.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import numpy as np
 import torch
@@ -43,12 +43,12 @@ class DatasetAssetMockingSuite:
 
     @dataclass
     class ToyGraphData:
-        node_types: dict[str, NodeType]
-        edge_types: dict[str, EdgeType]
-        node_feats: dict[str, torch.Tensor]
-        edge_indices: dict[str, torch.Tensor]
-        node_labels: Optional[dict[str, torch.Tensor]] = None
-        edge_feats: Optional[dict[str, torch.Tensor]] = None
+        node_types: Dict[str, NodeType]
+        edge_types: Dict[str, EdgeType]
+        node_feats: Dict[str, torch.Tensor]
+        edge_indices: Dict[str, torch.Tensor]
+        node_labels: Optional[Dict[str, torch.Tensor]] = None
+        edge_feats: Optional[Dict[str, torch.Tensor]] = None
 
     @dataclass
     class UserDefinedLabels:
@@ -76,7 +76,7 @@ class DatasetAssetMockingSuite:
     @staticmethod
     def _get_pyg_dblp_dataset(
         store_at: str = "/tmp/DBLP",
-    ) -> Tuple[DBLPFromGCS, dict[str, NodeType], dict[str, EdgeType]]:
+    ) -> Tuple[DBLPFromGCS, Dict[str, NodeType], Dict[str, EdgeType]]:
         """DBLP graph is the graph in the first index in the returned dataset.
         https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.datasets.DBLP.html
         Detailed description of the dataset:
@@ -430,9 +430,9 @@ class DatasetAssetMockingSuite:
         task_metadata_type: TaskMetadataType = (
             TaskMetadataType.NODE_ANCHOR_BASED_LINK_PREDICTION_TASK
         )
-        edge_index: dict[EdgeType, torch.Tensor]
-        node_feats: dict[NodeType, torch.Tensor]
-        edge_feats: Optional[dict[EdgeType, torch.Tensor]] = None
+        edge_index: Dict[EdgeType, torch.Tensor]
+        node_feats: Dict[NodeType, torch.Tensor]
+        edge_feats: Optional[Dict[EdgeType, torch.Tensor]] = None
 
         # Extract edge types and node types from the HeteroData object
         edge_types = list(toy_data.edge_types)
@@ -559,12 +559,12 @@ class DatasetAssetMockingSuite:
 
     def compute_datasets_to_mock(
         self, selected_datasets: Optional[list[str]] = None
-    ) -> dict[str, MockedDatasetInfo]:
+    ) -> Dict[str, MockedDatasetInfo]:
         """
         Returns a dictionary of mocked datasets to be used in the mocking suite.
         If `selected_datasets` is provided, only those datasets will be returned.
         """
-        mocked_datasets: dict[str, MockedDatasetInfo] = dict()
+        mocked_datasets: Dict[str, MockedDatasetInfo] = dict()
         all_mocking_func_names: list[str] = [
             attr
             for attr in dir(self)

--- a/python/gigl/src/mocking/lib/mock_input_for_subgraph_sampler.py
+++ b/python/gigl/src/mocking/lib/mock_input_for_subgraph_sampler.py
@@ -1,6 +1,6 @@
 import tempfile
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 import tensorflow as tf
 import torch
@@ -108,7 +108,7 @@ def _generate_preprocessed_node_tfrecord_data(
     id2tfe_encoder = _InstanceDictToTFExample(feature_spec=feature_spec_dict)
 
     tfrecords = []
-    instance_dict_feats: dict[str, torch.Tensor]
+    instance_dict_feats: Dict[str, torch.Tensor]
     for node_id, node_feature_values in enumerate(node_features):
         instance_dict_feats = {data.node_id_column_name: torch.LongTensor([node_id])}
         instance_dict_feats.update(
@@ -260,7 +260,7 @@ def generate_preprocessed_tfrecord_data(
     node_labels_by_node_type = mocked_dataset_info.node_labels
     node_types = mocked_dataset_info.node_types
 
-    condensed_node_type_to_preprocessed_metadata: dict[
+    condensed_node_type_to_preprocessed_metadata: Dict[
         CondensedNodeType,
         preprocessed_metadata_pb2.PreprocessedMetadata.NodeMetadataOutput,
     ] = dict()
@@ -304,7 +304,7 @@ def generate_preprocessed_tfrecord_data(
     edge_features_by_edge_type = mocked_dataset_info.edge_feats
     edge_index_by_edge_type = mocked_dataset_info.edge_index
     edge_types = mocked_dataset_info.edge_types
-    condensed_edge_type_to_preprocessed_metadata: dict[
+    condensed_edge_type_to_preprocessed_metadata: Dict[
         CondensedEdgeType,
         preprocessed_metadata_pb2.PreprocessedMetadata.EdgeMetadataOutput,
     ] = dict()

--- a/python/gigl/src/mocking/lib/mocked_dataset_resources.py
+++ b/python/gigl/src/mocking/lib/mocked_dataset_resources.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 import torch
 
@@ -29,7 +29,7 @@ class MockedDatasetInfo:
         return list(self.edge_index.keys())
 
     @property
-    def num_nodes(self) -> dict[NodeType, int]:
+    def num_nodes(self) -> Dict[NodeType, int]:
         return {
             node_type: node_feat.shape[0]
             for node_type, node_feat in self.node_feats.items()
@@ -65,13 +65,13 @@ class MockedDatasetInfo:
         return num_edges
 
     @property
-    def num_node_features(self) -> dict[NodeType, int]:
+    def num_node_features(self) -> Dict[NodeType, int]:
         return {
             node_type: feats.shape[1] for node_type, feats in self.node_feats.items()
         }
 
     @property
-    def num_node_distinct_labels(self) -> dict[NodeType, int]:
+    def num_node_distinct_labels(self) -> Dict[NodeType, int]:
         if not self.node_labels:
             return {}
 
@@ -81,7 +81,7 @@ class MockedDatasetInfo:
         }
 
     @property
-    def num_edge_features(self) -> dict[EdgeType, int]:
+    def num_edge_features(self) -> Dict[EdgeType, int]:
         if self.edge_feats:
             return {
                 edge_type: feats.shape[1]
@@ -91,7 +91,7 @@ class MockedDatasetInfo:
             return {edge_type: 0 for edge_type in self.edge_types}
 
     @property
-    def num_user_def_edge_features(self) -> dict[EdgeType, dict[EdgeUsageType, int]]:
+    def num_user_def_edge_features(self) -> Dict[EdgeType, Dict[EdgeUsageType, int]]:
         num_user_def_edge_feats = {}
         if self.user_defined_edge_feats:
             for edge_type, udl_edge_feats in self.user_defined_edge_feats.items():
@@ -141,10 +141,10 @@ class MockedDatasetInfo:
 
     name: str
     task_metadata_type: TaskMetadataType
-    edge_index: dict[EdgeType, torch.Tensor]
-    node_feats: dict[NodeType, torch.Tensor]
-    edge_feats: Optional[dict[EdgeType, torch.Tensor]] = None
-    node_labels: Optional[dict[NodeType, torch.Tensor]] = None
+    edge_index: Dict[EdgeType, torch.Tensor]
+    node_feats: Dict[NodeType, torch.Tensor]
+    edge_feats: Optional[Dict[EdgeType, torch.Tensor]] = None
+    node_labels: Optional[Dict[NodeType, torch.Tensor]] = None
     sample_node_type: Optional[NodeType] = None
     # TODO (tzhao-sc): currently only supporting 1 supervision edge type, we would need
     #      to extend this to support multiple supervision edge types for HGS stage 2
@@ -154,9 +154,9 @@ class MockedDatasetInfo:
     node_id_column_name: str = "node_id"
     node_label_column_name: str = "node_label"
     user_defined_edge_index: Optional[
-        dict[EdgeType, dict[EdgeUsageType, torch.Tensor]]
+        Dict[EdgeType, Dict[EdgeUsageType, torch.Tensor]]
     ] = None
     user_defined_edge_feats: Optional[
-        dict[EdgeType, dict[EdgeUsageType, torch.Tensor]]
+        Dict[EdgeType, Dict[EdgeUsageType, torch.Tensor]]
     ] = None
     version: Optional[str] = None

--- a/python/gigl/src/mocking/lib/pyg_to_training_samples.py
+++ b/python/gigl/src/mocking/lib/pyg_to_training_samples.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch_geometric.transforms as T
@@ -156,7 +156,7 @@ def build_k_hop_subgraphs_from_pyg_heterodata(
     root_node_idxs: Optional[torch.Tensor] = None,
     num_hops: int = DEFAULT_NUM_HOPS_FOR_DATASETS,
     num_neighbors: int = DEFAULT_NUM_NODES_PER_HOP,
-) -> dict[NodeId, GraphPbWrapper]:
+) -> Dict[NodeId, GraphPbWrapper]:
     """
     Given inputs, return a map of each root node of type `root_node_type` and index in `root_node_idxs'
     to GraphPbWrappers which describe the `num_hops` surrounding subgraph.
@@ -178,7 +178,7 @@ def build_k_hop_subgraphs_from_pyg_heterodata(
         - 1,  # use all available CPUs except one, for this task.
     )
 
-    k_hop_subgraphs: dict[NodeId, GraphPbWrapper] = dict()
+    k_hop_subgraphs: Dict[NodeId, GraphPbWrapper] = dict()
 
     sample: HeteroData
     for root_node_idx, sample in zip(root_node_idxs.tolist(), loader):
@@ -207,7 +207,7 @@ def _get_random_negative_samples_for_pos_edges(
 
 
 def _build_rooted_node_neighborhood_samples_from_subgraphs(
-    subgraph_dict: dict[NodeId, GraphPbWrapper], condensed_node_type: CondensedNodeType
+    subgraph_dict: Dict[NodeId, GraphPbWrapper], condensed_node_type: CondensedNodeType
 ) -> list[training_samples_schema_pb2.RootedNodeNeighborhood]:
     samples: list[training_samples_schema_pb2.RootedNodeNeighborhood] = list()
 

--- a/python/gigl/src/mocking/lib/user_defined_edge_sampling.py
+++ b/python/gigl/src/mocking/lib/user_defined_edge_sampling.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List
+from typing import Dict, List
 
 from gigl.src.common.types.graph_data import EdgeUsageType, NodeId
 from gigl.src.mocking.lib.mocked_dataset_resources import MockedDatasetInfo
@@ -7,7 +7,7 @@ from gigl.src.mocking.lib.mocked_dataset_resources import MockedDatasetInfo
 
 def sample_hydrate_user_def_edge(
     mocked_dataset_info: MockedDatasetInfo, edge_usage_type: EdgeUsageType
-) -> dict[NodeId, List]:
+) -> Dict[NodeId, List]:
     """
     Samples all available pos/neg edges and hydrated these edges with their features.
     e.g. for positive edge the output will be {pos_edge_src: [pos_edge_dst, [f0, f1, ..., fn]]}

--- a/python/gigl/src/mocking/lib/versioning.py
+++ b/python/gigl/src/mocking/lib/versioning.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import NamedTuple
+from typing import Dict, NamedTuple
 
 from gigl.common import Uri, UriFactory
 from gigl.common.logger import Logger
@@ -22,7 +22,7 @@ class MockedDatasetArtifactMetadata(NamedTuple):
         }
 
     @staticmethod
-    def from_dict(dict_repr: dict[str, str]) -> MockedDatasetArtifactMetadata:
+    def from_dict(dict_repr: Dict[str, str]) -> MockedDatasetArtifactMetadata:
         return MockedDatasetArtifactMetadata(
             version=dict_repr["version"],
             frozen_gbml_config_uri=UriFactory.create_uri(
@@ -31,7 +31,7 @@ class MockedDatasetArtifactMetadata(NamedTuple):
         )
 
 
-def get_mocked_dataset_artifact_metadata() -> dict[str, MockedDatasetArtifactMetadata]:
+def get_mocked_dataset_artifact_metadata() -> Dict[str, MockedDatasetArtifactMetadata]:
     """
     Creates a dictionary of task names to mocked dataset artifact metadata.
 
@@ -40,7 +40,7 @@ def get_mocked_dataset_artifact_metadata() -> dict[str, MockedDatasetArtifactMet
     """
     artifact_metadata_uri = MOCKED_DATASET_ARTIFACT_METADATA_LOCAL_PATH
     f = open(artifact_metadata_uri.uri, "r")
-    metadata: dict[str, dict[str, str]] = {}
+    metadata: Dict[str, Dict[str, str]] = {}
     try:
         metadata = json.load(fp=f)
     except json.JSONDecodeError as e:
@@ -57,13 +57,13 @@ def get_mocked_dataset_artifact_metadata() -> dict[str, MockedDatasetArtifactMet
 
 
 def update_mocked_dataset_artifact_metadata(
-    task_name_to_artifact_metadata: dict[str, MockedDatasetArtifactMetadata]
+    task_name_to_artifact_metadata: Dict[str, MockedDatasetArtifactMetadata]
 ) -> None:
     """
     Update the mocked dataset artifact metadata with the given task names and metadata.
 
     Args:
-        task_name_to_versions (dict[str, MockedDatasetArtifactMetadata]): A dictionary containing task names and their corresponding metadata.
+        task_name_to_versions (Dict[str, MockedDatasetArtifactMetadata]): A dictionary containing task names and their corresponding metadata.
 
     Returns:
         None

--- a/python/gigl/src/mocking/mocking_assets/passthrough_preprocessor_config_for_mocked_assets.py
+++ b/python/gigl/src/mocking/mocking_assets/passthrough_preprocessor_config_for_mocked_assets.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 import gigl.src.mocking.lib.constants as test_tasks_constants
 from gigl.common.logger import Logger
@@ -49,8 +49,8 @@ class PassthroughPreprocessorConfigForMockedAssets(DataPreprocessorConfig):
 
     def get_nodes_preprocessing_spec(
         self,
-    ) -> dict[NodeDataReference, NodeDataPreprocessingSpec]:
-        node_data_ref_to_preprocessing_specs: dict[
+    ) -> Dict[NodeDataReference, NodeDataPreprocessingSpec]:
+        node_data_ref_to_preprocessing_specs: Dict[
             NodeDataReference, NodeDataPreprocessingSpec
         ] = dict()
 
@@ -110,8 +110,8 @@ class PassthroughPreprocessorConfigForMockedAssets(DataPreprocessorConfig):
 
     def get_edges_preprocessing_spec(
         self,
-    ) -> dict[EdgeDataReference, EdgeDataPreprocessingSpec]:
-        edge_data_ref_to_preprocessing_specs: dict[
+    ) -> Dict[EdgeDataReference, EdgeDataPreprocessingSpec]:
+        edge_data_ref_to_preprocessing_specs: Dict[
             EdgeDataReference, EdgeDataPreprocessingSpec
         ] = dict()
         for edge_type in self.__mocked_dataset.edge_types:

--- a/python/gigl/src/post_process/utils/component_runtime.py
+++ b/python/gigl/src/post_process/utils/component_runtime.py
@@ -1,10 +1,12 @@
+from typing import Dict
+
 # from gigl.common.services.kfp import KFPService
 from gigl.common.types.wrappers.kfp_api import KfpTaskDetails
 
 # TODO: This needs to update ot Vertex AI
 # def get_task_details_from_kfp_pipeline(
 #     kfp_service: KFPService, experiment_name: str, kfp_run_name: str
-# ) -> dict[str, KfpTaskDetails]:
+# ) -> Dict[str, KfpTaskDetails]:
 #     pipeline_run_detail: Optional[
 #         ApiRunDetailWrapper
 #     ] = kfp_service.get_latest_run_with_name(
@@ -15,8 +17,8 @@ from gigl.common.types.wrappers.kfp_api import KfpTaskDetails
 
 
 def assert_component_runtimes_match_expected_parameters(
-    task_details_map: dict[str, KfpTaskDetails],
-    component_name_runtime_hr: dict[str, int],
+    task_details_map: Dict[str, KfpTaskDetails],
+    component_name_runtime_hr: Dict[str, int],
 ) -> None:
     for component_name, expected_runtime_hr in component_name_runtime_hr.items():
         relevant_task = task_details_map.get(component_name)

--- a/python/gigl/src/post_process/utils/cosine_similarity.py
+++ b/python/gigl/src/post_process/utils/cosine_similarity.py
@@ -1,6 +1,6 @@
 import datetime as dt
 from datetime import datetime
-from typing import Tuple
+from typing import Dict, Tuple
 
 import pandas as pd
 
@@ -121,7 +121,7 @@ def calculate_cosine_similarity_stats(
 
 
 def assert_cosine_similarity_stats(
-    cosine_similarity_stats: pd.DataFrame, expected_cosine_similarity: dict[str, float]
+    cosine_similarity_stats: pd.DataFrame, expected_cosine_similarity: Dict[str, float]
 ) -> None:
     for stat, expected_val in expected_cosine_similarity.items():
         if cosine_similarity_stats[stat] < expected_val:

--- a/python/gigl/src/training/v1/lib/data_loaders/common.py
+++ b/python/gigl/src/training/v1/lib/data_loaders/common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Union
+from typing import Dict, Union
 
 from gigl.common import Uri
 from gigl.common.logger import Logger
@@ -26,7 +26,7 @@ class DataloaderTypes(Enum):
 
 @dataclass
 class DataloaderConfig:
-    uris: Union[list[Uri], dict[NodeType, list[Uri]]]
+    uris: Union[list[Uri], Dict[NodeType, list[Uri]]]
     batch_size: int = _DEFAULT_DATA_LOADER_BATCH_SIZE
     num_workers: int = _DEFAULT_DATA_LOADER_NUM_WORKERS
     should_loop: bool = False

--- a/python/gigl/src/training/v1/lib/data_loaders/node_anchor_based_link_prediction_data_loader.py
+++ b/python/gigl/src/training/v1/lib/data_loaders/node_anchor_based_link_prediction_data_loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass, field
 from functools import partial
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import torch
 import torch_geometric.data
@@ -38,10 +38,10 @@ from snapchat.research.gbml import training_samples_schema_pb2
 class NodeAnchorBasedLinkPredictionBatch:
     @dataclass
     class BatchSupervisionEdgeData:
-        root_node_to_target_node_id: dict[NodeId, torch.LongTensor] = field(
+        root_node_to_target_node_id: Dict[NodeId, torch.LongTensor] = field(
             default_factory=dict
         )  # maps root nodes to target node for positive or negative edges
-        label_edge_features: Optional[dict[NodeId, torch.FloatTensor]] = field(
+        label_edge_features: Optional[Dict[NodeId, torch.FloatTensor]] = field(
             default_factory=dict
         )  # maps root nodes to edge features for or negative positive edges
 
@@ -51,10 +51,10 @@ class NodeAnchorBasedLinkPredictionBatch:
     root_node_indices: (
         torch.LongTensor
     )  # lists root node indices within the batch for whom to compute loss
-    pos_supervision_edge_data: dict[CondensedEdgeType, BatchSupervisionEdgeData]
-    hard_neg_supervision_edge_data: dict[CondensedEdgeType, BatchSupervisionEdgeData]
-    condensed_node_type_to_subgraph_id_to_global_node_id: dict[
-        CondensedNodeType, dict[NodeId, NodeId]
+    pos_supervision_edge_data: Dict[CondensedEdgeType, BatchSupervisionEdgeData]
+    hard_neg_supervision_edge_data: Dict[CondensedEdgeType, BatchSupervisionEdgeData]
+    condensed_node_type_to_subgraph_id_to_global_node_id: Dict[
+        CondensedNodeType, Dict[NodeId, NodeId]
     ]  # for each condensed node type, maps subgraph node id to global node id
 
     @staticmethod
@@ -117,18 +117,18 @@ class NodeAnchorBasedLinkPredictionBatch:
         batch_graph_data = builder.build()
 
         _batch_root_nodes: list[NodeId] = list()
-        pos_supervision_edge_data: dict[
+        pos_supervision_edge_data: Dict[
             CondensedEdgeType,
             NodeAnchorBasedLinkPredictionBatch.BatchSupervisionEdgeData,
         ] = defaultdict(NodeAnchorBasedLinkPredictionBatch.BatchSupervisionEdgeData)
-        hard_neg_supervision_edge_data: dict[
+        hard_neg_supervision_edge_data: Dict[
             CondensedEdgeType,
             NodeAnchorBasedLinkPredictionBatch.BatchSupervisionEdgeData,
         ] = defaultdict(NodeAnchorBasedLinkPredictionBatch.BatchSupervisionEdgeData)
-        condensed_node_type_to_subgraph_id_to_global_node_id: dict[
-            CondensedNodeType, dict[NodeId, NodeId]
+        condensed_node_type_to_subgraph_id_to_global_node_id: Dict[
+            CondensedNodeType, Dict[NodeId, NodeId]
         ] = defaultdict(dict)
-        node_mapping: dict[
+        node_mapping: Dict[
             Node, Node
         ] = batch_graph_data.global_node_to_subgraph_node_mapping
         for node_with_global_id, node_with_subgraph_id in node_mapping.items():

--- a/python/gigl/src/training/v1/lib/data_loaders/rooted_node_neighborhood_data_loader.py
+++ b/python/gigl/src/training/v1/lib/data_loaders/rooted_node_neighborhood_data_loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import partial
-from typing import Set, Union
+from typing import Dict, Set, Union
 
 import torch
 import torch_geometric.data
@@ -36,12 +36,12 @@ class RootedNodeNeighborhoodBatch:
     graph: Union[
         torch_geometric.data.Data, torch_geometric.data.hetero_data.HeteroData
     ]  # batch-coalesced graph data used for message passing
-    condensed_node_type_to_root_node_indices_map: dict[
+    condensed_node_type_to_root_node_indices_map: Dict[
         CondensedNodeType, torch.LongTensor
     ]  # maps condensed node type to root node indices within the batch for whom to compute loss
     root_nodes: list[Node]
-    condensed_node_type_to_subgraph_id_to_global_node_id: dict[
-        CondensedNodeType, dict[NodeId, NodeId]
+    condensed_node_type_to_subgraph_id_to_global_node_id: Dict[
+        CondensedNodeType, Dict[NodeId, NodeId]
     ]  # for each condensed node type, maps subgraph node id to global node id
 
     @staticmethod
@@ -79,7 +79,7 @@ class RootedNodeNeighborhoodBatch:
         builder: GraphBuilder,
         graph_metadata_pb_wrapper: GraphMetadataPbWrapper,
         preprocessed_metadata_pb_wrapper: PreprocessedMetadataPbWrapper,
-        samples: list[dict[NodeType, RootedNodeNeighborhoodSample]],
+        samples: list[Dict[NodeType, RootedNodeNeighborhoodSample]],
     ) -> RootedNodeNeighborhoodBatch:
         """
         We coalesce the various sample subgraphs to build a single unified neighborhood, which we use for message
@@ -106,12 +106,12 @@ class RootedNodeNeighborhoodBatch:
                 builder.add_graph_data(graph_data=graph_data)
         batch_graph_data = builder.build()
 
-        node_mapping: dict[
+        node_mapping: Dict[
             Node, Node
         ] = batch_graph_data.global_node_to_subgraph_node_mapping
 
-        condensed_node_type_to_subgraph_id_to_global_node_id: dict[
-            CondensedNodeType, dict[NodeId, NodeId]
+        condensed_node_type_to_subgraph_id_to_global_node_id: Dict[
+            CondensedNodeType, Dict[NodeId, NodeId]
         ] = defaultdict(dict)
         for node_with_global_id, node_with_subgraph_id in node_mapping.items():
             condensed_node_type: CondensedNodeType = (
@@ -124,7 +124,7 @@ class RootedNodeNeighborhoodBatch:
             ] = node_with_global_id.id
 
         # We separate root node indices based on the node type of the root node
-        condensed_node_type_to_root_node_indices_map: dict[
+        condensed_node_type_to_root_node_indices_map: Dict[
             CondensedNodeType, torch.LongTensor
         ] = {}
         for node_type in unique_node_types:
@@ -193,8 +193,8 @@ class RootedNodeNeighborhoodBatch:
 
         node_mapping = batch_graph_data.global_node_to_subgraph_node_mapping
 
-        condensed_node_type_to_subgraph_id_to_global_node_id: dict[
-            CondensedNodeType, dict[NodeId, NodeId]
+        condensed_node_type_to_subgraph_id_to_global_node_id: Dict[
+            CondensedNodeType, Dict[NodeId, NodeId]
         ] = defaultdict(dict)
 
         for node_with_global_id, node_with_subgraph_id in node_mapping.items():
@@ -207,7 +207,7 @@ class RootedNodeNeighborhoodBatch:
                 node_with_subgraph_id.id
             ] = node_with_global_id.id
 
-        condensed_node_type_to_root_node_indices_map: dict[
+        condensed_node_type_to_root_node_indices_map: Dict[
             CondensedNodeType, torch.LongTensor
         ] = {
             graph_metadata_pb_wrapper.node_type_to_condensed_node_type_map[
@@ -253,7 +253,7 @@ class RootedNodeNeighborhoodBatch:
         has 20 batches, but the random-negative dataloader only has 10.  This pacing issue would cause us to
         not be able to fetch random negatives for the last 10 main-sample batches, undesirably.
         """
-        iterable_dataset_map: dict[
+        iterable_dataset_map: Dict[
             NodeType,
             torch.utils.data.IterableDataset[RootedNodeNeighborhoodSample],
         ] = {}

--- a/python/gigl/src/training/v1/lib/data_loaders/tf_records_iterable_dataset.py
+++ b/python/gigl/src/training/v1/lib/data_loaders/tf_records_iterable_dataset.py
@@ -1,4 +1,4 @@
-from typing import Callable, Generic, Iterable, Iterator, TypeVar
+from typing import Callable, Dict, Generic, Iterable, Iterator, TypeVar
 
 import numpy as np
 import tensorflow as tf
@@ -114,20 +114,20 @@ class LoopyIterableDataset(torch.utils.data.IterableDataset, Generic[T]):
 class CombinedIterableDatasets(torch.utils.data.IterableDataset, Generic[T]):
     def __init__(
         self,
-        iterable_dataset_map: dict[
+        iterable_dataset_map: Dict[
             NodeType,
             torch.utils.data.IterableDataset[T],
         ],
     ) -> None:
         self._iterable_dataset_map = iterable_dataset_map
 
-    def __iter__(self) -> Iterator[dict[NodeType, T]]:
+    def __iter__(self) -> Iterator[Dict[NodeType, T]]:
         iterators = [
             (node_type, iter(dataset))
             for node_type, dataset in self._iterable_dataset_map.items()
         ]
         while True:
-            combined_data: dict[NodeType, T] = {}
+            combined_data: Dict[NodeType, T] = {}
             for node_type, iterator in iterators:
                 samples = next(iterator)
                 combined_data[node_type] = samples

--- a/python/gigl/src/training/v1/lib/training_process.py
+++ b/python/gigl/src/training/v1/lib/training_process.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 import traceback
 from distutils.util import strtobool
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 import tensorflow as tf
 import torch
@@ -122,7 +122,7 @@ def setup_model_device(
 def generate_trainer_instance(
     gbml_config_pb_wrapper: GbmlConfigPbWrapper,
 ) -> BaseTrainer:
-    kwargs: dict[str, Any] = {}
+    kwargs: Dict[str, Any] = {}
 
     trainer_class_path: str = gbml_config_pb_wrapper.trainer_config.trainer_cls_path
     kwargs = dict(gbml_config_pb_wrapper.trainer_config.trainer_args)

--- a/python/gigl/src/validation_check/libs/template_config_checks.py
+++ b/python/gigl/src/validation_check/libs/template_config_checks.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from gigl.common import UriFactory
 from gigl.common.logger import Logger
@@ -60,7 +60,7 @@ def check_pipeline_has_valid_start_and_stop_flags(
                 )
 
 
-def check_if_runtime_args_all_str(args_name: str, runtime_args: dict[str, Any]) -> None:
+def check_if_runtime_args_all_str(args_name: str, runtime_args: Dict[str, Any]) -> None:
     """
     Check if all values of the given runtime arguements are string.
     """
@@ -241,7 +241,7 @@ def check_if_data_preprocessor_config_cls_valid(
     data_preprocessor_config_cls_path = (
         gbml_config_pb.dataset_config.data_preprocessor_config.data_preprocessor_config_cls_path
     )
-    runtime_args: dict[str, str] = dict(
+    runtime_args: Dict[str, str] = dict(
         gbml_config_pb.dataset_config.data_preprocessor_config.data_preprocessor_args
     )
     check_if_runtime_args_all_str(
@@ -278,7 +278,7 @@ def check_if_trainer_cls_valid(
         )
         return
     trainer_cls_path = gbml_config_pb.trainer_config.trainer_cls_path
-    runtime_args: dict[str, str] = dict(gbml_config_pb.trainer_config.trainer_args)
+    runtime_args: Dict[str, str] = dict(gbml_config_pb.trainer_config.trainer_args)
     check_if_runtime_args_all_str(args_name="trainerArgs", runtime_args=runtime_args)
     try:
         trainer_cls = os_utils.import_obj(trainer_cls_path)
@@ -301,7 +301,7 @@ def check_if_inferencer_cls_valid(
     """
     logger.info("Config validation check: if inferencerClsPath and its args are valid.")
     inferencer_cls_path = gbml_config_pb.inferencer_config.inferencer_cls_path
-    runtime_args: dict[str, str] = dict(
+    runtime_args: Dict[str, str] = dict(
         gbml_config_pb.inferencer_config.inferencer_args
     )
     check_if_runtime_args_all_str(args_name="inferencerArgs", runtime_args=runtime_args)
@@ -448,7 +448,7 @@ def check_if_post_processor_cls_valid(
         )
         return
 
-    runtime_args: dict[str, str] = dict(
+    runtime_args: Dict[str, str] = dict(
         gbml_config_pb.post_processor_config.post_processor_args
     )
     check_if_runtime_args_all_str(

--- a/python/gigl/utils/share_memory.py
+++ b/python/gigl/utils/share_memory.py
@@ -1,5 +1,5 @@
 from collections import abc
-from typing import Optional, TypeVar, Union
+from typing import Dict, Optional, TypeVar, Union
 
 import torch
 from graphlearn_torch.partition import PartitionBook, RangePartitionBook
@@ -12,8 +12,8 @@ def share_memory(
         Union[
             torch.Tensor,
             PartitionBook,
-            dict[_KeyType, torch.Tensor],
-            dict[_KeyType, PartitionBook],
+            Dict[_KeyType, torch.Tensor],
+            Dict[_KeyType, PartitionBook],
         ]
     ],
 ) -> None:
@@ -29,7 +29,7 @@ def share_memory(
     since the size of this tensor is very small, being equal in length to the number of machines.
 
     Args:
-        entity (Optional[Union[torch.Tensor, PartitionBook, dict[_KeyType, torch.Tensor], dict[_KeyType, PartitionBook]]]):
+        entity (Optional[Union[torch.Tensor, PartitionBook, Dict[_KeyType, torch.Tensor], Dict[_KeyType, PartitionBook]]]):
             Homogeneous or heterogeneous entity of tensors which is being moved to shared memory
     """
 

--- a/python/tests/integration/common/file_loader_test.py
+++ b/python/tests/integration/common/file_loader_test.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 import uuid
+from typing import Dict
 
 from parameterized import param, parameterized
 
@@ -94,7 +95,7 @@ class FileLoaderTest(unittest.TestCase):
         local_fs.create_empty_file_if_none_exists(local_path=local_file_path_src)
         self.assertTrue(local_fs.does_path_exist(local_file_path_src))
 
-        file_uri_map: dict[Uri, Uri] = {local_file_path_src: local_file_path_dst}
+        file_uri_map: Dict[Uri, Uri] = {local_file_path_src: local_file_path_dst}
         self.file_loader.load_files(source_to_dest_file_uri_map=file_uri_map)
         self.assertTrue(local_fs.does_path_exist(local_file_path_dst))
         self.assertTrue(os.path.islink(local_file_path_dst.uri))
@@ -120,7 +121,7 @@ class FileLoaderTest(unittest.TestCase):
         local_fs.create_empty_file_if_none_exists(local_path=local_file_path_src)
         self.assertTrue(local_fs.does_path_exist(local_file_path_src))
 
-        file_uri_map: dict[Uri, Uri] = {local_file_path_src: gcs_file_path_dst}
+        file_uri_map: Dict[Uri, Uri] = {local_file_path_src: gcs_file_path_dst}
         self.file_loader.load_files(source_to_dest_file_uri_map=file_uri_map)
         self.assertTrue(self.gcs_utils.does_gcs_file_exist(gcs_path=gcs_file_path_dst))
         self.gcs_utils.delete_gcs_file_if_exist(gcs_path=gcs_file_path_dst)
@@ -133,7 +134,7 @@ class FileLoaderTest(unittest.TestCase):
             self.test_asset_directory, "test_http_to_local.txt"
         )
         local_fs.remove_file_if_exist(local_path=local_file_path_dst)
-        file_uri_map: dict[Uri, Uri] = {http_file_path_src: local_file_path_dst}
+        file_uri_map: Dict[Uri, Uri] = {http_file_path_src: local_file_path_dst}
         self.file_loader.load_files(source_to_dest_file_uri_map=file_uri_map)
         self.assertTrue(local_fs.does_path_exist(local_file_path_dst))
 
@@ -163,7 +164,7 @@ class FileLoaderTest(unittest.TestCase):
         local_fs.remove_file_if_exist(local_path=local_file_path_src)
         self.assertTrue(self.gcs_utils.does_gcs_file_exist(gcs_file_path_src))
 
-        file_uri_map: dict[Uri, Uri] = {gcs_file_path_src: local_file_path_dst}
+        file_uri_map: Dict[Uri, Uri] = {gcs_file_path_src: local_file_path_dst}
         self.file_loader.load_files(source_to_dest_file_uri_map=file_uri_map)
         self.assertTrue(local_fs.does_path_exist(local_file_path_dst))
         self.gcs_utils.delete_gcs_file_if_exist(gcs_path=gcs_file_path_src)
@@ -208,7 +209,7 @@ class FileLoaderTest(unittest.TestCase):
             local_fs.create_empty_file_if_none_exists(local_path=file)
             self.assertTrue(local_fs.does_path_exist(file))
 
-        dir_uri_map: dict[Uri, Uri] = {local_src_dir: local_dst_dir}
+        dir_uri_map: Dict[Uri, Uri] = {local_src_dir: local_dst_dir}
         self.file_loader.load_directories(source_to_dest_directory_map=dir_uri_map)
 
         for file in local_file_paths_dst:
@@ -236,7 +237,7 @@ class FileLoaderTest(unittest.TestCase):
             local_fs.create_empty_file_if_none_exists(local_path=file)
             self.assertTrue(local_fs.does_path_exist(file))
 
-        dir_uri_map: dict[Uri, Uri] = {local_src_dir: gcs_dst_dir}
+        dir_uri_map: Dict[Uri, Uri] = {local_src_dir: gcs_dst_dir}
         self.file_loader.load_directories(source_to_dest_directory_map=dir_uri_map)
 
         for gcs_file in gcs_file_paths_dst:
@@ -274,7 +275,7 @@ class FileLoaderTest(unittest.TestCase):
             local_fs.create_empty_file_if_none_exists(local_file)
             self.assertTrue(local_fs.does_path_exist(local_file))
 
-        local_file_path_to_gcs_path_map: dict[LocalUri, GcsUri] = {
+        local_file_path_to_gcs_path_map: Dict[LocalUri, GcsUri] = {
             local_file_path_src: gcs_file_path_src
             for local_file_path_src, gcs_file_path_src in zip(
                 local_file_paths_src, gcs_file_paths_src
@@ -287,7 +288,7 @@ class FileLoaderTest(unittest.TestCase):
             self.assertTrue(self.gcs_utils.does_gcs_file_exist(gcs_file))
         local_fs.remove_folder_if_exist(local_path=local_src_dir)
 
-        dir_uri_map: dict[Uri, Uri] = {gcs_src_dir: local_dst_dir}
+        dir_uri_map: Dict[Uri, Uri] = {gcs_src_dir: local_dst_dir}
         self.file_loader.load_directories(source_to_dest_directory_map=dir_uri_map)
 
         for file in local_file_paths_dst:
@@ -305,7 +306,7 @@ class FileLoaderTest(unittest.TestCase):
         gcs_dst_dir: GcsUri = GcsUri.join(
             self.gcs_test_asset_directory, self.test_asset_directory, "dst"
         )
-        dir_uri_map: dict[Uri, Uri] = {gcs_src_dir: gcs_dst_dir}
+        dir_uri_map: Dict[Uri, Uri] = {gcs_src_dir: gcs_dst_dir}
 
         with self.assertRaises(TypeError):
             self.file_loader.load_directories(source_to_dest_directory_map=dir_uri_map)

--- a/python/tests/integration/pipeline/data_preprocessor/data_preprocessor_pipeline_test.py
+++ b/python/tests/integration/pipeline/data_preprocessor/data_preprocessor_pipeline_test.py
@@ -1,7 +1,7 @@
 import platform
 import tempfile
 import unittest
-from typing import Optional
+from typing import Dict, Optional
 
 import numpy as np
 import tensorflow as tf
@@ -82,7 +82,7 @@ class DataPreprocessorPipelineTest(unittest.TestCase):
         tfrecord_files: list[str],
         # This is set larger than cora num nodes & edges so as to read the whole dataset in 1 go.
         max_batch_size=16384,
-    ) -> dict[str, np.ndarray]:
+    ) -> Dict[str, np.ndarray]:
         schema = tfdv.load_schema_text(schema_path.uri)
         feature_spec = tft.tf_metadata.schema_utils.schema_as_feature_spec(
             schema
@@ -164,12 +164,12 @@ class DataPreprocessorPipelineTest(unittest.TestCase):
             + f"Source mock dataset info: {mocked_dataset_info}"
         )
 
-        condensed_node_type_to_node_type_map: dict[
+        condensed_node_type_to_node_type_map: Dict[
             CondensedNodeType, NodeType
         ] = (
             gbml_config_pb_wrapper.graph_metadata_pb_wrapper.condensed_node_type_to_node_type_map
         )
-        condensed_edge_type_to_edge_type_map: dict[
+        condensed_edge_type_to_edge_type_map: Dict[
             CondensedEdgeType, EdgeType
         ] = (
             gbml_config_pb_wrapper.graph_metadata_pb_wrapper.condensed_edge_type_to_edge_type_map
@@ -229,7 +229,7 @@ class DataPreprocessorPipelineTest(unittest.TestCase):
                 get_feature_field_name(n=n)
                 for n in range(mocked_dataset_info.num_node_features[node_type])
             ]
-            expected_node_feats_indexed_by_feat_name: dict[str, tf.Tensor] = {}
+            expected_node_feats_indexed_by_feat_name: Dict[str, tf.Tensor] = {}
             for column_tensor, node_feat_name in zip(
                 mocked_dataset_info.node_feats[node_type].T, expected_node_feature_names
             ):
@@ -280,7 +280,7 @@ class DataPreprocessorPipelineTest(unittest.TestCase):
                 f"{node_data_features_prefix.uri}*.tfrecord"
             )
             self.assertIsNotNone(node_tfrecords)
-            node_info: dict[
+            node_info: Dict[
                 str, np.ndarray
             ] = DataPreprocessorPipelineTest.__get_np_arrays_from_tfrecords(
                 schema_path=node_data_schema, tfrecord_files=node_tfrecords
@@ -324,7 +324,7 @@ class DataPreprocessorPipelineTest(unittest.TestCase):
         expected_num_edge_features: int,
         expected_num_edges: int,
         expected_edge_feature_names: list[str],
-        expected_edge_feats_indexed_by_feat_name: dict[str, tf.Tensor],
+        expected_edge_feats_indexed_by_feat_name: Dict[str, tf.Tensor],
     ):
         logger.info(
             f"Analyzing {preprocessed_metadata_pb2.PreprocessedMetadata.EdgeMetadataInfo.__name__}: "
@@ -360,7 +360,7 @@ class DataPreprocessorPipelineTest(unittest.TestCase):
         # Check node data is same.
         edge_tfrecords = tf.io.gfile.glob(f"{edge_data_prefix.uri}*.tfrecord")
         self.assertIsNotNone(edge_tfrecords)
-        edge_info: dict[
+        edge_info: Dict[
             str, np.ndarray
         ] = DataPreprocessorPipelineTest.__get_np_arrays_from_tfrecords(
             schema_path=edge_data_schema, tfrecord_files=edge_tfrecords
@@ -414,7 +414,7 @@ class DataPreprocessorPipelineTest(unittest.TestCase):
             f"assert_user_defined_edges_in_preprocessed_metadata_reflects_mocked_dataset_info for {edge_usage_type} edges"
         )
         user_defined_edge_index: Optional[
-            dict[EdgeType, dict[EdgeUsageType, torch.Tensor]]
+            Dict[EdgeType, Dict[EdgeUsageType, torch.Tensor]]
         ] = mocked_dataset_info.user_defined_edge_index
         src_node_id_key = edge_metadata_output_pb.src_node_id_key
         dst_node_id_key = edge_metadata_output_pb.dst_node_id_key
@@ -440,7 +440,7 @@ class DataPreprocessorPipelineTest(unittest.TestCase):
                 get_feature_field_name(n=n)
                 for n in range(expected_num_user_def_edge_features_for_label_type)
             ]
-            expected_positive_edge_feats_indexed_by_feat_name: dict[str, tf.Tensor] = {}
+            expected_positive_edge_feats_indexed_by_feat_name: Dict[str, tf.Tensor] = {}
             if expected_num_user_def_edge_features_for_label_type > 0:
                 assert mocked_dataset_info.user_defined_edge_feats is not None
                 for column_tensor, edge_feat_name in zip(
@@ -517,7 +517,7 @@ class DataPreprocessorPipelineTest(unittest.TestCase):
                 get_feature_field_name(n=n)
                 for n in range(mocked_dataset_info.num_edge_features[edge_type])
             ]
-            expected_main_edge_feats_indexed_by_feat_name: dict[str, tf.Tensor] = {}
+            expected_main_edge_feats_indexed_by_feat_name: Dict[str, tf.Tensor] = {}
             if (
                 mocked_dataset_info.edge_feats is not None
                 and len(mocked_dataset_info.edge_feats) > 0

--- a/python/tests/integration/pipeline/data_preprocessor/enumerator_test.py
+++ b/python/tests/integration/pipeline/data_preprocessor/enumerator_test.py
@@ -1,5 +1,5 @@
 import unittest
-from typing import Any, Tuple, Union
+from typing import Any, Dict, Tuple, Union
 
 import google.cloud.bigquery as bigquery
 import pandas as pd
@@ -45,7 +45,7 @@ _NEGATIVE_EDGES = [("Alice", "Alice"), ("Bob", "Bob"), ("Charlie", "Charlie")]
 _PERSON_NODE_IDENTIFIER_FIELD = "person"
 # Define node features rows for each node
 _PERSON_NODE_FEATURE_FLOAT_FIELDS = ["height", "age", "weight"]
-_PERSON_NODE_FEATURE_RECORDS: list[dict[str, Any]] = [
+_PERSON_NODE_FEATURE_RECORDS: list[Dict[str, Any]] = [
     {
         _PERSON_NODE_IDENTIFIER_FIELD: node,
         "height": float(i),
@@ -94,7 +94,7 @@ class EnumeratorTest(unittest.TestCase):
     def __upload_records_to_bq(
         self,
         data_reference: Union[BigqueryEdgeDataReference, BigqueryNodeDataReference],
-        records: list[dict[str, Any]],
+        records: list[Dict[str, Any]],
     ):
         self.__bq_utils.create_or_empty_bq_table(bq_path=data_reference.reference_uri)
         columns: list[str] = []
@@ -237,9 +237,9 @@ class EnumeratorTest(unittest.TestCase):
             self.assertIn(field, schema)
 
     def fetch_enumerated_node_map_and_assert_correctness(
-        self, map_enum_node_type_metadata: dict[NodeType, EnumeratorNodeTypeMetadata]
-    ) -> dict[int, str]:
-        int_to_orig_node_id_map: dict[int, str] = {}
+        self, map_enum_node_type_metadata: Dict[NodeType, EnumeratorNodeTypeMetadata]
+    ) -> Dict[int, str]:
+        int_to_orig_node_id_map: Dict[int, str] = {}
 
         person_enumerated_node_type_metadata = map_enum_node_type_metadata[
             _PERSON_NODE_TYPE
@@ -275,8 +275,8 @@ class EnumeratorTest(unittest.TestCase):
 
     def assert_enumerated_node_features_correctness(
         self,
-        int_to_orig_node_id_map: dict[int, str],
-        map_enum_node_type_metadata: dict[NodeType, EnumeratorNodeTypeMetadata],
+        int_to_orig_node_id_map: Dict[int, str],
+        map_enum_node_type_metadata: Dict[NodeType, EnumeratorNodeTypeMetadata],
     ):
         person_enumerated_node_type_metadata = map_enum_node_type_metadata[
             _PERSON_NODE_TYPE
@@ -334,8 +334,8 @@ class EnumeratorTest(unittest.TestCase):
 
     def assert_enumerated_edge_features_correctness(
         self,
-        int_to_orig_node_id_map: dict[int, str],
-        map_enum_edge_type_metadata: dict[
+        int_to_orig_node_id_map: Dict[int, str],
+        map_enum_edge_type_metadata: Dict[
             Tuple[EdgeType, EdgeUsageType], EnumeratorEdgeTypeMetadata
         ],
     ):
@@ -383,7 +383,7 @@ class EnumeratorTest(unittest.TestCase):
         def __assert_enumerated_table_rows_match_original_rows(
             table_name: str,
             expected_edge_feature_fields: list[str],
-            original_edge_feature_records: list[dict[str, Any]],
+            original_edge_feature_records: list[Dict[str, Any]],
         ):
             result = list(
                 self.__bq_utils.run_query(
@@ -480,11 +480,11 @@ class EnumeratorTest(unittest.TestCase):
                 edge_metadata.enumerated_edge_data_reference.reference_uri
             )
 
-        map_enum_node_type_metadata: dict[NodeType, EnumeratorNodeTypeMetadata] = {
+        map_enum_node_type_metadata: Dict[NodeType, EnumeratorNodeTypeMetadata] = {
             node_type_metadata.enumerated_node_data_reference.node_type: node_type_metadata
             for node_type_metadata in list_enumerator_node_type_metadata
         }
-        map_enum_edge_type_metadata: dict[
+        map_enum_edge_type_metadata: Dict[
             Tuple[EdgeType, EdgeUsageType], EnumeratorEdgeTypeMetadata
         ] = {
             (
@@ -493,7 +493,7 @@ class EnumeratorTest(unittest.TestCase):
             ): edge_type_metadata
             for edge_type_metadata in list_enumerator_edge_type_metadata
         }
-        int_to_orig_node_id_map: dict[
+        int_to_orig_node_id_map: Dict[
             int, str
         ] = self.fetch_enumerated_node_map_and_assert_correctness(
             map_enum_node_type_metadata=map_enum_node_type_metadata

--- a/python/tests/integration/pipeline/inferencer/inferencer_test.py
+++ b/python/tests/integration/pipeline/inferencer/inferencer_test.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+from typing import Dict
 
 import gigl.src.common.constants.gcs as gcs_constants
 from gigl.common import LocalUri
@@ -38,7 +39,7 @@ class InferencerTest(unittest.TestCase):
     def __clean_up_inferencer_test_assets(
         self,
         applied_task_identifier: AppliedTaskIdentifier,
-        node_type_to_inferencer_output_map: dict[str, InferenceOutput],
+        node_type_to_inferencer_output_map: Dict[str, InferenceOutput],
     ):
         self.__gcs_utils.delete_files_in_bucket_dir(
             gcs_path=gcs_constants.get_applied_task_temp_gcs_path(

--- a/python/tests/integration/pipeline/subgraph_sampler/subgraph_sampler_test.py
+++ b/python/tests/integration/pipeline/subgraph_sampler/subgraph_sampler_test.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 from collections import defaultdict
 from itertools import chain
-from typing import Iterable, Set, Tuple
+from typing import Dict, Iterable, Set, Tuple
 
 from gigl.common import LocalUri, Uri, UriFactory
 from gigl.common.logger import Logger
@@ -173,7 +173,7 @@ class SubgraphSamplerTest(unittest.TestCase):
         use_spark35: bool = False,
     ) -> Tuple[
         ExpectedGraphFromPreprocessor,
-        dict[NodeType, list[RootedNodeNeighborhood]],
+        Dict[NodeType, list[RootedNodeNeighborhood]],
         list[NodeAnchorBasedLinkPredictionSample],
     ]:
         """
@@ -278,7 +278,7 @@ class SubgraphSamplerTest(unittest.TestCase):
             "Missing node-anchor training samples from SGS output",
         )
 
-        root_node_type_to_num_training_samples: dict[NodeType, int] = defaultdict(
+        root_node_type_to_num_training_samples: Dict[NodeType, int] = defaultdict(
             lambda: 0
         )
         for training_sample in training_samples:
@@ -690,13 +690,13 @@ class SubgraphSamplerTest(unittest.TestCase):
         self,
         gbml_config_pb_wrapper: GbmlConfigPbWrapper,
         expected_graph_from_preprocessor: ExpectedGraphFromPreprocessor,
-    ) -> dict[NodePbWrapper, dict[NodeType, int]]:
+    ) -> Dict[NodePbWrapper, Dict[NodeType, int]]:
         """
         Builds a map counting the in-edge for each dst node from input graph, per src node type.
         Used to check the number of inbound edges for each node in the rooted subgraph samples
         """
-        input_graph_dst_node_to_src_node_type_to_in_edges_count_map: dict[
-            NodePbWrapper, dict[NodeType, int]
+        input_graph_dst_node_to_src_node_type_to_in_edges_count_map: Dict[
+            NodePbWrapper, Dict[NodeType, int]
         ] = defaultdict(lambda: defaultdict(lambda: 0))
         for (
             src_node,
@@ -729,16 +729,16 @@ class SubgraphSamplerTest(unittest.TestCase):
         self,
         subgraph_sampler_config_pb: gbml_config_pb2.GbmlConfig.DatasetConfig.SubgraphSamplerConfig,
         is_subgraph_sampling_strategy_provided: bool = False,
-    ) -> dict[
-        NodeType, dict[NodeType, list[subgraph_sampling_strategy_pb2.SamplingOp]]
+    ) -> Dict[
+        NodeType, Dict[NodeType, list[subgraph_sampling_strategy_pb2.SamplingOp]]
     ]:
         """
         Builds a map of samplingOps for each path in the subgraph sampling strategy. For each root node type, maps to the dst node type to the sampling ops.
         For each rooted node neighborhood sample, we can check that each dst node has the correct number of in-edges based on the sampling ops.
         """
         # map subgraph sampling strategy root node to dst node to sampling op
-        root_node_type_to_dst_node_type_to_sampling_ops_map: dict[
-            NodeType, dict[NodeType, list[subgraph_sampling_strategy_pb2.SamplingOp]]
+        root_node_type_to_dst_node_type_to_sampling_ops_map: Dict[
+            NodeType, Dict[NodeType, list[subgraph_sampling_strategy_pb2.SamplingOp]]
         ] = defaultdict(lambda: defaultdict(list))
         if is_subgraph_sampling_strategy_provided:
             for (
@@ -759,7 +759,7 @@ class SubgraphSamplerTest(unittest.TestCase):
         self,
         gbml_config_pb_wrapper: GbmlConfigPbWrapper,
         rooted_node_neighborhood_samples: list[RootedNodeNeighborhood],
-    ) -> dict[NodePbWrapper, list[EdgePbWrapper]]:
+    ) -> Dict[NodePbWrapper, list[EdgePbWrapper]]:
         """
         Builds a map of NodePbWrapper to inbound EdgePbWrappers for each sample.
         """
@@ -822,7 +822,7 @@ class SubgraphSamplerTest(unittest.TestCase):
         def __check_exact_number_of_in_edges_for_dst_node(
             dst_node_pb_wrapper: NodePbWrapper,
             sampling_ops: list[subgraph_sampling_strategy_pb2.SamplingOp],
-            condensed_edge_type_to_in_edges_count: dict[CondensedEdgeType, int],
+            condensed_edge_type_to_in_edges_count: Dict[CondensedEdgeType, int],
         ):
             for sampling_op in sampling_ops:
                 sampling_op_edge_type = EdgeType(
@@ -851,9 +851,9 @@ class SubgraphSamplerTest(unittest.TestCase):
         def __check_number_of_in_edges_for_dst_node(
             dst_node_pb_wrapper: NodePbWrapper,
             sampling_ops: list[subgraph_sampling_strategy_pb2.SamplingOp],
-            condensed_edge_type_to_in_edges_count: dict[CondensedEdgeType, int],
+            condensed_edge_type_to_in_edges_count: Dict[CondensedEdgeType, int],
         ):
-            condensed_edge_type_to_max_num_nodes_to_sample: dict[
+            condensed_edge_type_to_max_num_nodes_to_sample: Dict[
                 CondensedEdgeType, int
             ] = defaultdict(lambda: 0)
             for sampling_op in sampling_ops:
@@ -900,7 +900,7 @@ class SubgraphSamplerTest(unittest.TestCase):
         def __build_condensed_edge_type_to_in_edges_count_map(
             in_edges: list[EdgePbWrapper],
         ):
-            condensed_edge_type_to_in_edges_count: dict[
+            condensed_edge_type_to_in_edges_count: Dict[
                 CondensedEdgeType, int
             ] = defaultdict(lambda: 0)
             for edge_pb_wrapper in in_edges:

--- a/python/tests/integration/pipeline/subgraph_sampler/utils.py
+++ b/python/tests/integration/pipeline/subgraph_sampler/utils.py
@@ -3,7 +3,7 @@ import subprocess
 import tempfile
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import tensorflow as tf
 
@@ -51,8 +51,8 @@ logger = Logger()
 
 @dataclass
 class EdgeMetadataInfo:
-    feasible_adjacency_list_map: dict[NodePbWrapper, list[EdgePbWrapper]]
-    edge_type_to_edge_to_features_map: dict[EdgeType, dict[EdgePbWrapper, list[float]]]
+    feasible_adjacency_list_map: Dict[NodePbWrapper, list[EdgePbWrapper]]
+    edge_type_to_edge_to_features_map: Dict[EdgeType, Dict[EdgePbWrapper, list[float]]]
 
 
 @dataclass
@@ -67,7 +67,7 @@ class ExpectedGraphFromPreprocessor:
     - Edge metadata for negative user-defined label edges.
     """
 
-    node_type_to_node_to_features_map: dict[NodeType, dict[NodePbWrapper, list[float]]]
+    node_type_to_node_to_features_map: Dict[NodeType, Dict[NodePbWrapper, list[float]]]
     main_edge_info: EdgeMetadataInfo
     pos_edge_info: EdgeMetadataInfo
     neg_edge_info: EdgeMetadataInfo
@@ -76,7 +76,7 @@ class ExpectedGraphFromPreprocessor:
 def read_output_nablp_samples_from_subgraph_sampler(
     gbml_config_pb_wrapper: GbmlConfigPbWrapper,
 ) -> Tuple[
-    dict[NodeType, list[training_samples_schema_pb2.RootedNodeNeighborhood]],
+    Dict[NodeType, list[training_samples_schema_pb2.RootedNodeNeighborhood]],
     list[training_samples_schema_pb2.NodeAnchorBasedLinkPredictionSample],
 ]:
     """
@@ -89,7 +89,7 @@ def read_output_nablp_samples_from_subgraph_sampler(
         gbml_config_pb_wrapper.gbml_config_pb.shared_config.flattened_graph_metadata.node_anchor_based_link_prediction_output
     )
 
-    node_type_to_rooted_neighborhood_samples: dict[
+    node_type_to_rooted_neighborhood_samples: Dict[
         NodeType, list[training_samples_schema_pb2.RootedNodeNeighborhood]
     ] = defaultdict(list)
     for (
@@ -152,7 +152,7 @@ def read_output_node_based_task_samples_from_subgraph_sampler(
 
 def _build_node_features_map(
     gbml_config_pb_wrapper: GbmlConfigPbWrapper,
-) -> dict[NodeType, dict[NodePbWrapper, list[float]]]:
+) -> Dict[NodeType, Dict[NodePbWrapper, list[float]]]:
     """
     Builds a map from NodeType to a map from NodePbWrapper to a list of features for that node, for all NodeTypes encountered in preprocessed output.
     """
@@ -161,8 +161,8 @@ def _build_node_features_map(
         gbml_config_pb_wrapper.preprocessed_metadata_pb_wrapper.preprocessed_metadata_pb
     )
 
-    node_type_to_node_to_features_map: dict[
-        NodeType, dict[NodePbWrapper, list[float]]
+    node_type_to_node_to_features_map: Dict[
+        NodeType, Dict[NodePbWrapper, list[float]]
     ] = {}
     for (
         condensed_node_type,
@@ -197,7 +197,7 @@ def _build_node_features_map(
 def _build_edge_features_map(
     gbml_config_pb_wrapper: GbmlConfigPbWrapper,
     edge_usage_type: EdgeUsageType = EdgeUsageType.MAIN,
-) -> dict[EdgeType, dict[EdgePbWrapper, list[float]]]:
+) -> Dict[EdgeType, Dict[EdgePbWrapper, list[float]]]:
     """
     Builds a map from EdgeType to a map from EdgePbWrapper to a list of features for that edge, for all EdgeTypes encountered in preprocessed output.
     """
@@ -206,8 +206,8 @@ def _build_edge_features_map(
         gbml_config_pb_wrapper.preprocessed_metadata_pb_wrapper.preprocessed_metadata_pb
     )
 
-    edge_type_to_edge_to_features_map: dict[
-        EdgeType, dict[EdgePbWrapper, list[float]]
+    edge_type_to_edge_to_features_map: Dict[
+        EdgeType, Dict[EdgePbWrapper, list[float]]
     ] = {}
     for (
         condensed_edge_type,
@@ -248,7 +248,7 @@ def _build_edge_features_map(
 def _build_feasible_adjacency_list_map(
     gbml_config_pb_wrapper: GbmlConfigPbWrapper,
     edge_usage_type: EdgeUsageType = EdgeUsageType.MAIN,
-) -> dict[NodePbWrapper, list[EdgePbWrapper]]:
+) -> Dict[NodePbWrapper, list[EdgePbWrapper]]:
     """
     Builds a map from NodePbWrapper to a list of EdgePbWrappers, representing the adjacency list for each src node,
     for all nodes encountered in Data Preprocessor output.  This will be used to test feasibility of edges which
@@ -260,7 +260,7 @@ def _build_feasible_adjacency_list_map(
     )
     graph_metadata_pb_wrapper = gbml_config_pb_wrapper.graph_metadata_pb_wrapper
 
-    src_node_to_edge_map: dict[NodePbWrapper, list[EdgePbWrapper]] = defaultdict(list)
+    src_node_to_edge_map: Dict[NodePbWrapper, list[EdgePbWrapper]] = defaultdict(list)
 
     for (
         condensed_edge_type,
@@ -308,9 +308,9 @@ def _build_feasible_adjacency_list_map(
 
 
 def bidirectionalize_feasible_adjacency_list_map(
-    src_node_to_edge_map: dict[NodePbWrapper, list[EdgePbWrapper]],
+    src_node_to_edge_map: Dict[NodePbWrapper, list[EdgePbWrapper]],
     gbml_config_pb_wrapper: GbmlConfigPbWrapper,
-) -> dict[NodePbWrapper, list[EdgePbWrapper]]:
+) -> Dict[NodePbWrapper, list[EdgePbWrapper]]:
     """
     Given an adjacency list map from NodePbWrapper to a list of EdgePbWrappers, this function
     returns a bidirectional adjacency list map applied to main graph edges.
@@ -328,7 +328,7 @@ def bidirectionalize_feasible_adjacency_list_map(
         not gbml_config_pb_wrapper.graph_metadata_pb_wrapper.is_heterogeneous
     ), "Bidirectionalizing adjacency list map is only supported for homogeneous graphs."
 
-    bidirectional_adjacency_list_map: dict[
+    bidirectional_adjacency_list_map: Dict[
         NodePbWrapper, list[EdgePbWrapper]
     ] = defaultdict(list)
     for _, edge_pbws in src_node_to_edge_map.items():
@@ -347,9 +347,9 @@ def bidirectionalize_feasible_adjacency_list_map(
 
 
 def bidirectionalize_edge_type_to_edge_to_features_map(
-    edge_type_to_edge_to_features_map: dict[EdgeType, dict[EdgePbWrapper, list[float]]],
+    edge_type_to_edge_to_features_map: Dict[EdgeType, Dict[EdgePbWrapper, list[float]]],
     gbml_config_pb_wrapper: GbmlConfigPbWrapper,
-) -> dict[EdgeType, dict[EdgePbWrapper, list[float]]]:
+) -> Dict[EdgeType, Dict[EdgePbWrapper, list[float]]]:
     """
     Given a map from EdgeType to a map from EdgePbWrapper to a list of features for that edge, this function
     returns a bidirectional map.
@@ -367,11 +367,11 @@ def bidirectionalize_edge_type_to_edge_to_features_map(
         not gbml_config_pb_wrapper.graph_metadata_pb_wrapper.is_heterogeneous
     ), "Bidirectionalizing edge type to edge to features map is only supported for homogeneous graphs."
 
-    bidirectional_edge_type_to_edge_to_features_map: dict[
-        EdgeType, dict[EdgePbWrapper, list[float]]
+    bidirectional_edge_type_to_edge_to_features_map: Dict[
+        EdgeType, Dict[EdgePbWrapper, list[float]]
     ] = {}
     for edge_type, edge_to_features_map in edge_type_to_edge_to_features_map.items():
-        bidirectional_edge_to_features_map: dict[EdgePbWrapper, list[float]] = {}
+        bidirectional_edge_to_features_map: Dict[EdgePbWrapper, list[float]] = {}
         for edge_pbw, features in edge_to_features_map.items():
             bidirectional_edge_pbw = edge_pbw.flip_edge()
             bidirectional_edge_to_features_map[edge_pbw] = features

--- a/python/tests/test_assets/distributed/constants.py
+++ b/python/tests/test_assets/distributed/constants.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Final
+from typing import Dict, Final
 
 import torch
 
@@ -33,11 +33,11 @@ MOCKED_HETEROGENEOUS_EDGE_TYPES: Final[list[EdgeType]] = sorted(
     [USER_TO_USER_EDGE_TYPE, USER_TO_ITEM_EDGE_TYPE]
 )
 
-NODE_TYPE_TO_FEATURE_DIMENSION_MAP: Final[dict[NodeType, int]] = {
+NODE_TYPE_TO_FEATURE_DIMENSION_MAP: Final[Dict[NodeType, int]] = {
     USER_NODE_TYPE: 2,
     ITEM_NODE_TYPE: 1,
 }
-EDGE_TYPE_TO_FEATURE_DIMENSION_MAP: Final[dict[EdgeType, int]] = {
+EDGE_TYPE_TO_FEATURE_DIMENSION_MAP: Final[Dict[EdgeType, int]] = {
     USER_TO_USER_EDGE_TYPE: 2,
     USER_TO_ITEM_EDGE_TYPE: 1,
 }
@@ -150,25 +150,25 @@ class TestGraphData:
     """
 
     # Node id tensor for mocked data
-    node_ids: dict[NodeType, torch.Tensor]
+    node_ids: Dict[NodeType, torch.Tensor]
 
     # Edge index tensor for mocked data
-    edge_index: dict[EdgeType, torch.Tensor]
+    edge_index: Dict[EdgeType, torch.Tensor]
 
     # Node feature tensor for mocked data
-    node_features: dict[NodeType, torch.Tensor]
+    node_features: Dict[NodeType, torch.Tensor]
 
     # Edge feature tensor for mocked data
-    edge_features: dict[EdgeType, torch.Tensor]
+    edge_features: Dict[EdgeType, torch.Tensor]
 
     # Positive edge label tensor for mocked data
-    positive_labels: dict[EdgeType, torch.Tensor]
+    positive_labels: Dict[EdgeType, torch.Tensor]
 
     # Input negative edge label tensor to partitioner for mocked data
-    negative_labels: dict[EdgeType, torch.Tensor]
+    negative_labels: Dict[EdgeType, torch.Tensor]
 
 
-RANK_TO_MOCKED_GRAPH: Final[dict[int, TestGraphData]] = {
+RANK_TO_MOCKED_GRAPH: Final[Dict[int, TestGraphData]] = {
     0: TestGraphData(
         node_ids={
             USER_NODE_TYPE: MOCKED_USER_NODES_IDS_ON_RANK_ZERO,
@@ -221,7 +221,7 @@ RANK_TO_MOCKED_GRAPH: Final[dict[int, TestGraphData]] = {
     ),
 }
 
-RANK_TO_NODE_TYPE_TYPE_TO_NUM_NODES: Final[dict[int, dict[NodeType, int]]] = {
+RANK_TO_NODE_TYPE_TYPE_TO_NUM_NODES: Final[Dict[int, Dict[NodeType, int]]] = {
     rank: {
         USER_NODE_TYPE: test_graph_data.node_ids[USER_NODE_TYPE].size(0),
         ITEM_NODE_TYPE: test_graph_data.node_ids[ITEM_NODE_TYPE].size(0),

--- a/python/tests/test_assets/distributed/run_distributed_partitioner.py
+++ b/python/tests/test_assets/distributed/run_distributed_partitioner.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Type, Union
+from typing import Dict, Type, Union
 
 import torch
 from graphlearn_torch.distributed import init_rpc, init_worker_group
@@ -23,9 +23,9 @@ class InputDataStrategy(Enum):
 
 def run_distributed_partitioner(
     rank: int,
-    output_dict: dict[int, PartitionOutput],
+    output_dict: Dict[int, PartitionOutput],
     is_heterogeneous: bool,
-    rank_to_input_graph: dict[int, TestGraphData],
+    rank_to_input_graph: Dict[int, TestGraphData],
     should_assign_edges_by_src_node: bool,
     master_addr: str,
     master_port: int,
@@ -36,9 +36,9 @@ def run_distributed_partitioner(
     Runs the distributed partitioner on a specific rank.
     Args:
         rank (int): Current rank of process
-        output_dict: dict[int, PartitionOutput]: Dict initialized by mp.Manager().dict() in which outputs of partitioner will be written to. This is a mapping of rank to Partition output.
+        output_dict: Dict[int, PartitionOutput]: Dict initialized by mp.Manager().dict() in which outputs of partitioner will be written to. This is a mapping of rank to Partition output.
         is_heterogeneous (bool): Whether homogeneous or heterogeneous inputs should be used
-        rank_to_input_graph (dict[int, TestGraphData]): Mapping of rank to mocked input graph for testing partitioning
+        rank_to_input_graph (Dict[int, TestGraphData]): Mapping of rank to mocked input graph for testing partitioning
         should_assign_edges_by_src_node (bool): Whether to partion edges according to the partition book of the source node or destination node
         master_addr (str): Master address for initializing rpc for partitioning
         master_port (int): Master port for initializing rpc for partitioning
@@ -47,12 +47,12 @@ def run_distributed_partitioner(
     """
 
     input_graph = rank_to_input_graph[rank]
-    node_ids: Union[torch.Tensor, dict[NodeType, torch.Tensor]]
-    edge_index: Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
-    node_features: Union[torch.Tensor, dict[NodeType, torch.Tensor]]
-    edge_features: Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
-    positive_labels: Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
-    negative_labels: Union[torch.Tensor, dict[EdgeType, torch.Tensor]]
+    node_ids: Union[torch.Tensor, Dict[NodeType, torch.Tensor]]
+    edge_index: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
+    node_features: Union[torch.Tensor, Dict[NodeType, torch.Tensor]]
+    edge_features: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
+    positive_labels: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
+    negative_labels: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]
 
     if not is_heterogeneous:
         node_ids = input_graph.node_ids[USER_NODE_TYPE]

--- a/python/tests/test_assets/test_modeling_spec.py
+++ b/python/tests/test_assets/test_modeling_spec.py
@@ -1,5 +1,4 @@
-from collections import OrderedDict
-from typing import Optional
+from typing import Optional, OrderedDict
 
 import torch.utils.data
 

--- a/python/tests/unit/distributed/dataset_input_metadata_translator_test.py
+++ b/python/tests/unit/distributed/dataset_input_metadata_translator_test.py
@@ -1,6 +1,6 @@
 import unittest
 from collections import abc
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 from parameterized import param, parameterized
 
@@ -24,7 +24,7 @@ from gigl.src.mocking.mocking_assets.mocked_datasets_for_pipeline_tests import (
 
 class TranslatorTestCase(unittest.TestCase):
     def setUp(self):
-        self._name_to_mocked_dataset_map: dict[
+        self._name_to_mocked_dataset_map: Dict[
             str, MockedDatasetArtifactMetadata
         ] = get_mocked_dataset_artifact_metadata()
 
@@ -33,10 +33,10 @@ class TranslatorTestCase(unittest.TestCase):
         entity_info: Optional[
             Union[
                 SerializedTFRecordInfo,
-                dict[NodeType, SerializedTFRecordInfo],
-                dict[EdgeType, SerializedTFRecordInfo],
-                dict[NodeType, SerializedTFRecordInfo],
-                dict[EdgeType, SerializedTFRecordInfo],
+                Dict[NodeType, SerializedTFRecordInfo],
+                Dict[EdgeType, SerializedTFRecordInfo],
+                Dict[NodeType, SerializedTFRecordInfo],
+                Dict[EdgeType, SerializedTFRecordInfo],
             ]
         ],
         is_heterogeneous: bool,
@@ -48,10 +48,10 @@ class TranslatorTestCase(unittest.TestCase):
             entity_info: Optional[
                 Union[
                     SerializedTFRecordInfo,
-                    dict[NodeType, SerializedTFRecordInfo],
-                    dict[EdgeType, SerializedTFRecordInfo],
-                    dict[NodeType, SerializedTFRecordInfo],
-                    dict[EdgeType, SerializedTFRecordInfo],
+                    Dict[NodeType, SerializedTFRecordInfo],
+                    Dict[EdgeType, SerializedTFRecordInfo],
+                    Dict[NodeType, SerializedTFRecordInfo],
+                    Dict[EdgeType, SerializedTFRecordInfo],
                 ]
             ]: Entity information of which type correctness is being checked for. If heterogeneous, this is expected to be a dictionary.
             is_heterogeneous (bool): Whether the provided input data is heterogeneous or homogeneous

--- a/python/tests/unit/distributed/distributed_partitioner_test.py
+++ b/python/tests/unit/distributed/distributed_partitioner_test.py
@@ -2,7 +2,7 @@
 
 import unittest
 from collections import abc, defaultdict
-from typing import Iterable, MutableMapping, Optional, Tuple, Type, Union
+from typing import Dict, Iterable, MutableMapping, Optional, Tuple, Type, Union
 
 import graphlearn_torch as glt
 import torch
@@ -45,16 +45,16 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
         self,
         output_data: Union[
             torch.Tensor,
-            dict[NodeType, torch.Tensor],
-            dict[EdgeType, torch.Tensor],
+            Dict[NodeType, torch.Tensor],
+            Dict[EdgeType, torch.Tensor],
             PartitionBook,
-            dict[NodeType, PartitionBook],
-            dict[EdgeType, PartitionBook],
+            Dict[NodeType, PartitionBook],
+            Dict[EdgeType, PartitionBook],
             FeaturePartitionData,
-            dict[NodeType, FeaturePartitionData],
-            dict[EdgeType, FeaturePartitionData],
+            Dict[NodeType, FeaturePartitionData],
+            Dict[EdgeType, FeaturePartitionData],
             GraphPartitionData,
-            dict[EdgeType, GraphPartitionData],
+            Dict[EdgeType, GraphPartitionData],
         ],
         is_heterogeneous: bool,
         expected_entity_types: Union[list[EdgeType], list[NodeType]],
@@ -64,16 +64,16 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
         Args:
             output_data(Union[
                 torch.Tensor,
-                dict[NodeType, torch.Tensor],
-                dict[EdgeType, torch.Tensor],
+                Dict[NodeType, torch.Tensor],
+                Dict[EdgeType, torch.Tensor],
                 PartitionBook,
-                dict[NodeType, PartitionBook],
-                dict[EdgeType, PartitionBook],
+                Dict[NodeType, PartitionBook],
+                Dict[EdgeType, PartitionBook],
                 FeaturePartitionData,
-                dict[NodeType, FeaturePartitionData],
-                dict[EdgeType, FeaturePartitionData],
+                Dict[NodeType, FeaturePartitionData],
+                Dict[EdgeType, FeaturePartitionData],
                 GraphPartitionData,
-                dict[EdgeType, GraphPartitionData],
+                Dict[EdgeType, GraphPartitionData],
             ]): Items of which correctness is being checked for
             is_heterogeneous (bool): Whether the provided input data is heterogeneous or homogeneous
             expected_entity_types(Union[list[EdgeType], list[NodeType]]): Expected node or edge type which we are checking against for heterogeneous inputs
@@ -92,10 +92,10 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
         rank: int,
         is_heterogeneous: bool,
         should_assign_edges_by_src_node: bool,
-        output_node_partition_book: Union[PartitionBook, dict[NodeType, PartitionBook]],
-        output_edge_partition_book: Union[PartitionBook, dict[EdgeType, PartitionBook]],
+        output_node_partition_book: Union[PartitionBook, Dict[NodeType, PartitionBook]],
+        output_edge_partition_book: Union[PartitionBook, Dict[EdgeType, PartitionBook]],
         output_edge_index: Union[
-            GraphPartitionData, dict[EdgeType, GraphPartitionData]
+            GraphPartitionData, Dict[EdgeType, GraphPartitionData]
         ],
         expected_node_types: list[NodeType],
         expected_edge_types: list[EdgeType],
@@ -108,9 +108,9 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
             rank (int): Rank from current output
             is_heterogeneous (bool): Whether the output is expected to be homogeneous or heterogeneous
             should_assign_edges_by_src_node (bool): Whether to partion edges according to the partition book of the source node or destination node
-            output_node_partition_book (Union[PartitionBook, dict[NodeType, PartitionBook]]): Node Partition Book from partitioning, either a PartitionBook if homogeneous or a dict[NodeType, PartitionBook] if heterogeneous
-            output_edge_partition_book (Union[PartitionBook, dict[EdgeType, PartitionBook]]): Edge Partition Book from partitioning, either a PartitionBook if homogeneous or a dict[EdgeType, PartitionBook] if heterogeneous
-            output_edge_index: (Union[GraphPartitionData, dict[EdgeType, GraphPartitionData]]): Output edge indices and ids from partitioning, either a GraphPartitionData if homogeneous or a dict[EdgeType, GraphPartitionData] if heterogeneous
+            output_node_partition_book (Union[PartitionBook, Dict[NodeType, PartitionBook]]): Node Partition Book from partitioning, either a PartitionBook if homogeneous or a Dict[NodeType, PartitionBook] if heterogeneous
+            output_edge_partition_book (Union[PartitionBook, Dict[EdgeType, PartitionBook]]): Edge Partition Book from partitioning, either a PartitionBook if homogeneous or a Dict[EdgeType, PartitionBook] if heterogeneous
+            output_edge_index: (Union[GraphPartitionData, Dict[EdgeType, GraphPartitionData]]): Output edge indices and ids from partitioning, either a GraphPartitionData if homogeneous or a Dict[EdgeType, GraphPartitionData] if heterogeneous
             expected_node_types (list[NodeType]): Expected node types for heterogeneous input
             expected_edge_types (list[EdgeType]): Expected edge types for heterogeneous input
             expected_pb_dtype (torch.dtype): The expected datatype when indexing into a partition book. For range-base partitioning, this will be an torch.int64.
@@ -254,9 +254,9 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
         is_heterogeneous: bool,
         is_range_based_partition: bool,
         should_assign_edges_by_src_node: bool,
-        output_graph: Union[GraphPartitionData, dict[EdgeType, GraphPartitionData]],
+        output_graph: Union[GraphPartitionData, Dict[EdgeType, GraphPartitionData]],
         output_node_feat: Union[
-            FeaturePartitionData, dict[NodeType, FeaturePartitionData]
+            FeaturePartitionData, Dict[NodeType, FeaturePartitionData]
         ],
         expected_node_types: list[NodeType],
         expected_edge_types: list[EdgeType],
@@ -268,8 +268,8 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
             is_heterogeneous (bool): Whether the output is expected to be homogeneous or heterogeneous
             is_range_based_partition (bool): Whether range-based partitioning was used
             should_assign_edges_by_src_node (bool): Whether to partion edges according to the partition book of the source node or destination node
-            output_graph: (Union[GraphPartitionData, dict[EdgeType, GraphPartitionData]]): Output edge indices and ids from partitioning, either a GraphPartitionData if homogeneous or a dict[EdgeType, GraphPartitionData] if heterogeneous
-            output_node_feat (Union[FeaturePartitionData, dict[NodeType, FeaturePartitionData]]): Output node features from partitioning, either a FeaturePartitionData if homogeneous or a dict[NodeType, FeaturePartitionData] if heterogeneous
+            output_graph: (Union[GraphPartitionData, Dict[EdgeType, GraphPartitionData]]): Output edge indices and ids from partitioning, either a GraphPartitionData if homogeneous or a Dict[EdgeType, GraphPartitionData] if heterogeneous
+            output_node_feat (Union[FeaturePartitionData, Dict[NodeType, FeaturePartitionData]]): Output node features from partitioning, either a FeaturePartitionData if homogeneous or a Dict[NodeType, FeaturePartitionData] if heterogeneous
             expected_node_types (list[NodeType]): Expected node types for heterogeneous input
             expected_edge_types (list[EdgeType]): Expected edge types for heterogeneous input
         """
@@ -362,9 +362,9 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
         is_heterogeneous: bool,
         is_range_based_partition: bool,
         should_assign_edges_by_src_node: bool,
-        output_graph: Union[GraphPartitionData, dict[EdgeType, GraphPartitionData]],
+        output_graph: Union[GraphPartitionData, Dict[EdgeType, GraphPartitionData]],
         output_edge_feat: Union[
-            FeaturePartitionData, dict[EdgeType, FeaturePartitionData]
+            FeaturePartitionData, Dict[EdgeType, FeaturePartitionData]
         ],
         expected_edge_types: list[EdgeType],
     ) -> None:
@@ -375,8 +375,8 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
             is_heterogeneous (bool): Whether the output is expected to be homogeneous or heterogeneous
             is_range_based_partition (bool): Whether range-based partitioning was used
             should_assign_edges_by_src_node (bool): Whether to partion edges according to the partition book of the source node or destination node
-            output_graph: (Union[GraphPartitionData, dict[EdgeType, GraphPartitionData]]): Output edge indices and ids from partitioning, either a GraphPartitionData if homogeneous or a dict[EdgeType, GraphPartitionData] if heterogeneous
-            output_edge_feat (Union[FeaturePartitionData, dict[EdgeType, FeaturePartitionData]]): Output node features from partitioning, either a FeaturePartitionData if homogeneous or a dict[EdgeType, FeaturePartitionData] if heterogeneous
+            output_graph: (Union[GraphPartitionData, Dict[EdgeType, GraphPartitionData]]): Output edge indices and ids from partitioning, either a GraphPartitionData if homogeneous or a Dict[EdgeType, GraphPartitionData] if heterogeneous
+            output_edge_feat (Union[FeaturePartitionData, Dict[EdgeType, FeaturePartitionData]]): Output node features from partitioning, either a FeaturePartitionData if homogeneous or a Dict[EdgeType, FeaturePartitionData] if heterogeneous
             expected_edge_types (list[EdgeType]): Expected edge types for heterogeneous input
         """
         self._assert_data_type_correctness(
@@ -482,8 +482,8 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
         rank: int,
         is_heterogeneous: bool,
         should_assign_edges_by_src_node: bool,
-        output_node_partition_book: Union[PartitionBook, dict[NodeType, PartitionBook]],
-        output_labeled_edge_index: Union[torch.Tensor, dict[EdgeType, torch.Tensor]],
+        output_node_partition_book: Union[PartitionBook, Dict[NodeType, PartitionBook]],
+        output_labeled_edge_index: Union[torch.Tensor, Dict[EdgeType, torch.Tensor]],
         expected_edge_types: list[EdgeType],
         expected_pb_dtype: torch.dtype,
     ) -> None:
@@ -493,8 +493,8 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
             rank (int): Rank from current output
             is_heterogeneous (bool): Whether the output is expected to be homogeneous or heterogeneous
             should_assign_edges_by_src_node (bool): Whether to partion edges according to the partition book of the source node or destination node
-            output_node_partition_book: (Union[PartitionBook, dict[NodeType, PartitionBook]]): Node Partition Book from partitioning, either a PartitionBook if homogeneous or a dict[NodeType, PartitionBook] if heterogeneous
-            output_labeled_edge_index (Union[torch.Tensor, dict[EdgeType, torch.Tensor]]): Output labeled edges from partitioning, either a FeaturePartitionData if homogeneous or a dict[EdgeType, FeaturePartitionData] if heterogeneous
+            output_node_partition_book: (Union[PartitionBook, Dict[NodeType, PartitionBook]]): Node Partition Book from partitioning, either a PartitionBook if homogeneous or a Dict[NodeType, PartitionBook] if heterogeneous
+            output_labeled_edge_index (Union[torch.Tensor, Dict[EdgeType, torch.Tensor]]): Output labeled edges from partitioning, either a FeaturePartitionData if homogeneous or a Dict[EdgeType, FeaturePartitionData] if heterogeneous
             expected_edge_types (list[EdgeType]): Expected edge types for heterogeneous input
                 expected_pb_dtype (torch.dtype): The expected datatype when indexing into a partition book. For range-base partitioning, this will be an torch.int64.
             Otherwise, it will be a torch.uint8.
@@ -670,17 +670,17 @@ class DistRandomPartitionerTestCase(unittest.TestCase):
             join=True,
         )
 
-        unified_output_edge_index: dict[EdgeType, list[torch.Tensor]] = defaultdict(
+        unified_output_edge_index: Dict[EdgeType, list[torch.Tensor]] = defaultdict(
             list
         )
 
-        unified_output_node_feat: dict[NodeType, list[torch.Tensor]] = defaultdict(list)
+        unified_output_node_feat: Dict[NodeType, list[torch.Tensor]] = defaultdict(list)
 
-        unified_output_edge_feat: dict[EdgeType, list[torch.Tensor]] = defaultdict(list)
+        unified_output_edge_feat: Dict[EdgeType, list[torch.Tensor]] = defaultdict(list)
 
-        unified_output_pos_label: dict[EdgeType, list[torch.Tensor]] = defaultdict(list)
+        unified_output_pos_label: Dict[EdgeType, list[torch.Tensor]] = defaultdict(list)
 
-        unified_output_neg_label: dict[EdgeType, list[torch.Tensor]] = defaultdict(list)
+        unified_output_neg_label: Dict[EdgeType, list[torch.Tensor]] = defaultdict(list)
 
         is_range_based_partition = partitioner_class is DistRangePartitioner
 

--- a/python/tests/unit/distributed/partition_book_test.py
+++ b/python/tests/unit/distributed/partition_book_test.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Dict
 
 import torch
 from graphlearn_torch.partition import RangePartitionBook
@@ -44,7 +45,7 @@ class PartitionBookTest(unittest.TestCase):
         self,
         _,
         partition_book: torch.Tensor,
-        rank_to_expected_ids: dict[int, torch.Tensor],
+        rank_to_expected_ids: Dict[int, torch.Tensor],
     ):
         for rank, expected_ids in rank_to_expected_ids.items():
             with self.subTest(rank=rank):

--- a/python/tests/unit/gnn_library/pyg_training_test.py
+++ b/python/tests/unit/gnn_library/pyg_training_test.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from gigl.common.logger import Logger
 from gigl.src.applied_tasks.test_tasks.academic import (
     get_pyg_cora_dataset,
@@ -114,7 +116,7 @@ class PygTrainingTest(unittest.TestCase):
 
         # put model in train mode
         self.lp_model.train()
-        out: dict[NodeType, torch.Tensor] = self.lp_model(
+        out: Dict[NodeType, torch.Tensor] = self.lp_model(
             features, self.node_types, self.device
         )
         encoder_output: torch.Tensor = list(out.values())[0]

--- a/python/tests/unit/src/inference/lib/node_anchor_based_link_prediction_inferencer_test.py
+++ b/python/tests/unit/src/inference/lib/node_anchor_based_link_prediction_inferencer_test.py
@@ -1,7 +1,6 @@
 import tempfile
 import unittest
-from collections import OrderedDict
-from typing import Optional
+from typing import Optional, OrderedDict
 
 import torch
 import yaml

--- a/python/tests/unit/src/inference/lib/node_classification_inferencer_test.py
+++ b/python/tests/unit/src/inference/lib/node_classification_inferencer_test.py
@@ -1,7 +1,6 @@
 import tempfile
 import unittest
-from collections import OrderedDict
-from typing import Optional
+from typing import Optional, OrderedDict
 
 import torch
 import yaml

--- a/python/tests/unit/src/training/lib/data_loaders/combined_iterable_dataset_test.py
+++ b/python/tests/unit/src/training/lib/data_loaders/combined_iterable_dataset_test.py
@@ -1,6 +1,7 @@
 import tempfile
 import unittest
 from collections import defaultdict
+from typing import Dict
 
 import tensorflow as tf
 
@@ -29,7 +30,7 @@ class CombinedIterableDatasetTest(unittest.TestCase):
         self._files = self.__mock_tfrecord_files()
 
     def __mock_tfrecord_files(self):
-        tfrecord_files: dict[NodeType, list[LocalUri]] = defaultdict(list)
+        tfrecord_files: Dict[NodeType, list[LocalUri]] = defaultdict(list)
         for node_type_idx, condensed_node_type in enumerate(self._condensed_node_types):
             node_type = EXAMPLE_HETEROGENEOUS_GRAPH_METADATA_PB_WRAPPER.condensed_node_type_to_node_type_map[
                 condensed_node_type
@@ -69,7 +70,7 @@ class CombinedIterableDatasetTest(unittest.TestCase):
             )
             return samples
 
-        loopy_datasets_map: dict[NodeType, LoopyIterableDataset] = {}
+        loopy_datasets_map: Dict[NodeType, LoopyIterableDataset] = {}
         for condensed_node_type_str in self._files:
             tf_dataset = TfRecordsIterableDataset(
                 tf_record_uris=self._files[condensed_node_type_str],
@@ -99,7 +100,7 @@ class CombinedIterableDatasetTest(unittest.TestCase):
             )
             return samples
 
-        datasets_map: dict[NodeType, TfRecordsIterableDataset] = {}
+        datasets_map: Dict[NodeType, TfRecordsIterableDataset] = {}
         for condensed_node_type_str in self._files:
             tf_dataset = TfRecordsIterableDataset(
                 tf_record_uris=self._files[condensed_node_type_str],

--- a/python/tests/unit/utils/share_memory_test.py
+++ b/python/tests/unit/utils/share_memory_test.py
@@ -1,6 +1,6 @@
 import unittest
 from collections import abc
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 import torch
 from graphlearn_torch.partition import RangePartitionBook
@@ -40,7 +40,7 @@ class ShareMemoryTest(unittest.TestCase):
         self,
         _,
         entity: Optional[
-            Union[torch.Tensor, RangePartitionBook, dict[NodeType, torch.Tensor]]
+            Union[torch.Tensor, RangePartitionBook, Dict[NodeType, torch.Tensor]]
         ],
     ):
         share_memory(entity=entity)

--- a/scala_spark35/project/match_bom.py
+++ b/scala_spark35/project/match_bom.py
@@ -14,7 +14,7 @@
 # 3. Copy the output and paste it into the file project/GCPDepsBOM.scala
 # 4. Uncomment the line in build.sbt
 
-from typing import NewType, Tuple
+from typing import NewType, Dict, Tuple
 import subprocess
 
 BOM_VERSION = "26.2.0"
@@ -40,14 +40,14 @@ def run_command(cmd: str) -> str:
         exit(1)
     return result.stdout
 
-def get_deps_dict(deps: str) -> dict[Tuple[Group, Artifact], Version]:
-    deps_dict: dict[Tuple[Group, Artifact], Version] = {}
+def get_deps_dict(deps: str) -> Dict[Tuple[Group, Artifact], Version]:
+    deps_dict: Dict[Tuple[Group, Artifact], Version] = {}
     for line in deps.splitlines():
         group, artifact, version = line.split(':')
         deps_dict[(Group(group), Artifact(artifact))] = Version(version)
     return deps_dict
 
-def get_bom_deps(bom_version: Version) -> dict[Tuple[Group, Artifact], Version]:
+def get_bom_deps(bom_version: Version) -> Dict[Tuple[Group, Artifact], Version]:
     print(f"Getting dependencies for BOM version {bom_version}")
     url_bom_deps_versioned = f"{URL_BASE_BOM_DEPS}{bom_version}/index.html"
     cmd_get_bom_deps = f"curl '{url_bom_deps_versioned}' | {GREP_REGEX_GOOGLE_DEPS}"
@@ -55,7 +55,7 @@ def get_bom_deps(bom_version: Version) -> dict[Tuple[Group, Artifact], Version]:
     return get_deps_dict(result_stdout)
 
 
-def get_current_deps() -> dict[Tuple[Group, Artifact], Version]:
+def get_current_deps() -> Dict[Tuple[Group, Artifact], Version]:
     cmd_get_current_deps = f"sbt dependencyTree | {GREP_REGEX_GOOGLE_DEPS}"
     result_stdout = run_command(cmd_get_current_deps)
     return get_deps_dict(result_stdout)

--- a/scripts/bootstrap_resource_config.py
+++ b/scripts/bootstrap_resource_config.py
@@ -7,7 +7,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 from distutils.util import strtobool
-from typing import Optional
+from typing import Dict, Optional
 
 import yaml
 
@@ -43,7 +43,7 @@ class SupportedParams:
                 e,
             )
             raise
-        self.defaults: dict[str, Param] = {
+        self.defaults: Dict[str, Param] = {
             "project": Param(
                 default=project,
                 description="GCP Project name that you are planning on using",
@@ -220,7 +220,7 @@ if __name__ == "__main__":
         parser.add_argument(f"--{key}", type=str, help=help_text)
     args = parser.parse_args()
 
-    values: dict[str, str] = {}
+    values: Dict[str, str] = {}
     for key, param in supported_params.defaults.items():
         # Check if value is provided in command line arguments
         if getattr(args, key):

--- a/scripts/create_dev_instance.py
+++ b/scripts/create_dev_instance.py
@@ -4,7 +4,7 @@ import inspect
 import subprocess
 import tempfile
 from dataclasses import dataclass
-from typing import Optional
+from typing import Dict, Optional
 
 
 @dataclass
@@ -16,7 +16,7 @@ class Param:
 
 
 class SupportedParams:
-    defaults: dict[str, Param]
+    defaults: Dict[str, Param]
 
     def __init__(self):
         whoami = getpass.getuser()
@@ -30,7 +30,7 @@ class SupportedParams:
                 e,
             )
             raise
-        self.defaults: dict[str, Param] = {
+        self.defaults: Dict[str, Param] = {
             "project": Param(default=project, description="GCP project ID"),
             "zone": Param(default="us-central1-a", description="GCP zone"),
             "service_account": Param(default=None, description="Service account email"),
@@ -193,7 +193,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    values: dict[str, str] = {}
+    values: Dict[str, str] = {}
     for key, param in supported_params.defaults.items():
         # Check if value is provided in command line arguments
         if getattr(args, key):

--- a/testing/assert_yaml_configs_parse.py
+++ b/testing/assert_yaml_configs_parse.py
@@ -30,6 +30,7 @@ Examples:
 import argparse
 import os
 import re
+from typing import Dict
 
 from gigl.common import Uri, UriFactory
 from gigl.common.logger import Logger
@@ -59,7 +60,7 @@ def assert_configs_parse(directories: list[str], ignore_regex: list[str] = []) -
         - Errors for invalid YAML files.
     """
     proto_utils = ProtoUtils()
-    invalid_configs: dict[Uri, str] = {}
+    invalid_configs: Dict[Uri, str] = {}
     logger.info(f"Checking if configs in {directories} are valid.")
     logger.info(f"Ignoring regex: {ignore_regex}")
     ignore = [re.compile(regex) for regex in ignore_regex]


### PR DESCRIPTION
This reverts commit f4e3bc8b463039fd123c0945963835c71377efda.

Apparently dataflow / beam cares about the semantic differences here so we saw some failures that reverting this fixed