### PR TITLE
[KGE] Add some modeling code

### DIFF
--- a/python/gigl/experimental/knowledge_graph_embedding/lib/model/heterogeneous_graph_model.py
+++ b/python/gigl/experimental/knowledge_graph_embedding/lib/model/heterogeneous_graph_model.py
@@ -1,0 +1,427 @@
+from typing import Callable, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchrec
+from applied_tasks.knowledge_graph_embedding.common.torchrec.large_embedding_lookup import (
+    LargeEmbeddingLookup,
+)
+from applied_tasks.knowledge_graph_embedding.lib.config import ModelConfig
+from applied_tasks.knowledge_graph_embedding.lib.config.sampling import SamplingConfig
+from applied_tasks.knowledge_graph_embedding.lib.data.edge_batch import EdgeBatch
+from applied_tasks.knowledge_graph_embedding.lib.data.node_batch import NodeBatch
+from applied_tasks.knowledge_graph_embedding.lib.model.negative_sampling import (
+    against_batch_relationwise_contrastive_similarity,
+    in_batch_relationwise_contrastive_similarity,
+)
+from applied_tasks.knowledge_graph_embedding.lib.model.types import (
+    ModelPhase,
+    SimilarityType,
+)
+
+from gigl.common.logger import Logger
+
+logger = Logger()
+
+
+class HeterogeneousGraphSparseEmbeddingModel(nn.Module):
+    """
+    A backbone model to support sparse embedding of (possibly multi-relational) graphs.
+    Can also be used to implement matrix factorization and variants.
+
+    Args:
+        model_config (ModelConfig): Configuration object containing model parameters.
+    """
+
+    def __init__(self, model_config: ModelConfig):
+        """Initialize the model with the given embedding configurations."""
+        super().__init__()
+
+        self.num_edge_types = model_config.num_edge_types
+        self.node_emb_dim = model_config.node_embedding_dim
+        self.training_sampling_config = model_config.training_sampling
+        self.validation_sampling_config = model_config.validation_sampling
+        self.testing_sampling_config = model_config.testing_sampling
+        self.similarity_type = model_config.embedding_similarity_type
+        self._phase: ModelPhase = ModelPhase.TRAIN
+
+        # Validate the sampling configurations.
+        for sampling_config in (
+            self.training_sampling_config,
+            self.validation_sampling_config,
+            self.testing_sampling_config,
+        ):
+            assert sampling_config is not None, "Sampling config must be provided."
+            assert (
+                sampling_config.positive_edge_batch_size > 0
+            ), "Positive edge batch size must be greater than 0."
+            assert (
+                sampling_config.num_inbatch_negatives_per_edge
+                + sampling_config.num_random_negatives_per_edge
+                > 0
+            ), "At least one type of negative sampling must be specified."
+
+        # Define the embedding layers.
+        self.large_embeddings = LargeEmbeddingLookup(
+            embeddings_config=model_config.embeddings_config
+        )
+
+        # Define the operators applied to src and dst node types respectively
+        self.src_operator = model_config.src_operator.get_corresponding_module()(
+            num_edge_types=self.num_edge_types,
+            node_emb_dim=self.node_emb_dim,
+        )
+        self.dst_operator = model_config.dst_operator.get_corresponding_module()(
+            num_edge_types=self.num_edge_types,
+            node_emb_dim=self.node_emb_dim,
+        )
+
+        logger.info(f"Initialized model with: {self.__dict__}")
+
+    @property
+    def active_sampling_config(self) -> SamplingConfig:
+        if self.phase == ModelPhase.TRAIN:
+            return self.training_sampling_config
+        elif self.phase == ModelPhase.VAL:
+            return self.validation_sampling_config
+        elif self.phase == ModelPhase.TEST:
+            return self.testing_sampling_config
+        elif (
+            self.phase == ModelPhase.INFERENCE_SRC
+            or self.phase == ModelPhase.INFERENCE_DST
+        ):
+            raise ValueError(
+                "Active sampling config is not defined for inference phase. "
+            )
+        else:
+            raise ValueError(
+                f"Unknown model phase: {self.phase}. Cannot determine active sampling config."
+            )
+
+    def set_phase(self, phase: ModelPhase):
+        """
+        Set the phase of the model. This is used to determine which sampling
+        configuration to use during training, validation, or testing.
+
+        Note that this affects
+        (i) how data that is passed into the model is interpreted (e.g. #s of positives, negatives)
+        (ii) whether inbatch negatives are used to compute logits and labels
+
+        Args:
+            phase (ModelPhase): The current phase of the model (TRAIN, VALIDATION, TEST).
+        """
+        old_phase = self._phase
+        self._phase = phase
+        logger.info(f"Changed model phase from {old_phase} to {phase}")
+
+    @property
+    def phase(self) -> ModelPhase:
+        return self._phase
+
+    def fetch_src_and_dst_embeddings(
+        self, edge_batch: EdgeBatch
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        num_edges = edge_batch.batch_size
+        node_embeddings_kt: torchrec.KeyedTensor = self.large_embeddings(
+            edge_batch.src_dst_pairs
+        )
+        logger.debug(f"node embeddings kt: {node_embeddings_kt}")
+        node_embeddings = (
+            node_embeddings_kt.values()
+        )  # [2 * num_edges, num_node_types * node_dim]
+        logger.debug(
+            f"node embeddings kt values: {node_embeddings, node_embeddings.shape}"
+        )
+        node_embeddings = node_embeddings.reshape(
+            2 * num_edges, -1, self.node_emb_dim
+        )  # [2 * num_edges, num_node_types, node_dim]
+        logger.debug(
+            f"node embeddings values reshaped: {node_embeddings, node_embeddings.shape}"
+        )
+        node_embeddings = node_embeddings.sum(dim=1)  # [2 * num_edges, node_dim]
+        logger.debug(
+            f"node embeddings collapse middle axis: {node_embeddings, node_embeddings.shape}"
+        )
+        node_embeddings = node_embeddings.reshape(
+            num_edges, 2, self.node_emb_dim
+        )  # [num_edges, 2, node_dim]
+        logger.debug(
+            f"node embeddings reshape into correct tensor: {node_embeddings, node_embeddings.shape}"
+        )
+        src_embeddings = node_embeddings[:, 0, :]
+        dst_embeddings = node_embeddings[:, 1, :]
+        return src_embeddings, dst_embeddings
+
+    def apply_relation_operator(
+        self,
+        src_embeddings: torch.Tensor,
+        dst_embeddings: torch.Tensor,
+        condensed_edge_types: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """
+        Apply the src and dst relation operators to the source and destination embeddings.
+
+        Some reasonable configurations to reimplement common KG embedding algorithms:
+        - TransE: Translation on src embeddings, dst embeddings remain unchanged
+        - CompleX: Complex diagonal on src embeddings, dst embeddings remain unchanged
+        - DistMult: Diagonal on src embeddings, dst embeddings remain unchanged
+        - RESCAL: Linear on src embeddings, dst embeddings remain unchanged
+
+        This can also be used to implement things like raw Matrix Factorization
+        by using identity operators, or other custom operators.
+
+        Args:
+            src_embeddings: Source node embeddings.
+            dst_embeddings: Destination node embeddings.
+            condensed_edge_types: Edge types for the current batch.
+        Returns:
+            Tuple of transformed source and destination embeddings.
+
+        """
+        # Apply the src operator to the source embeddings
+        src_embeddings = self.src_operator(
+            embeddings=src_embeddings,
+            condensed_edge_types=condensed_edge_types,
+        )
+
+        # Apply the dst operator to the destination embeddings
+        dst_embeddings = self.dst_operator(
+            embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+        )
+
+        return src_embeddings, dst_embeddings
+
+    def score_edges(
+        self,
+        src_embeddings: torch.Tensor,
+        dst_embeddings: torch.Tensor,
+    ):
+        # Compute the scores using the specified scoring function
+        if self.similarity_type == SimilarityType.DOT:
+            scores = torch.sum(src_embeddings * dst_embeddings, dim=1)
+        elif self.similarity_type == SimilarityType.COSINE:
+            scores = F.cosine_similarity(src_embeddings, dst_embeddings, dim=1)
+        else:
+            raise ValueError(f"Unknown scoring function: {self.similarity_type}")
+
+        return scores
+
+    def infer_node_batch(
+        self,
+        node_batch: NodeBatch,
+    ) -> torch.Tensor:
+        """
+        Infer node embeddings for a given NodeBatch.
+
+        Args:
+            node_batch (NodeBatch): The batch of nodes to infer embeddings for.
+
+        Returns:
+            torch.Tensor: The inferred node embeddings.
+        """
+        # Fetch node embeddings from the embedding layer
+        num_nodes = node_batch.nodes.values().numel()
+        node_embeddings_kt: torchrec.KeyedTensor = self.large_embeddings(
+            node_batch.nodes
+        )
+        node_embeddings = node_embeddings_kt.values()
+
+        node_embeddings = node_embeddings.reshape(
+            num_nodes, -1, self.node_emb_dim
+        )  # [num_nodes, num_node_types, node_dim]
+        node_embeddings = node_embeddings.sum(dim=1)  # [num_nodes, node_dim]
+
+        operator = (
+            self.src_operator
+            if self.phase == ModelPhase.INFERENCE_SRC
+            else self.dst_operator
+        )
+
+        # Apply the operator to the node embeddings
+        node_embeddings = operator(
+            embeddings=node_embeddings,
+            condensed_edge_types=node_batch.condensed_edge_type.repeat(num_nodes),
+        )
+        return node_embeddings
+
+    def forward(
+        self, edge_batch: EdgeBatch
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        # Fetch node embeddings from the embedding layer
+        src_embeddings, dst_embeddings = self.fetch_src_and_dst_embeddings(edge_batch)
+        condensed_edge_types = edge_batch.condensed_edge_types
+        labels = edge_batch.labels
+
+        # Apply relation operator to transform embeddings based on edge types
+        src_embeddings, dst_embeddings = self.apply_relation_operator(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+        )
+
+        pos_src_embeddings, batch_neg_src_embeddings = (
+            src_embeddings[: self.active_sampling_config.positive_edge_batch_size],
+            src_embeddings[self.active_sampling_config.positive_edge_batch_size :],
+        )
+        pos_dst_embeddings, batch_neg_dst_embeddings = (
+            dst_embeddings[: self.active_sampling_config.positive_edge_batch_size],
+            dst_embeddings[self.active_sampling_config.positive_edge_batch_size :],
+        )
+        pos_condensed_edge_types, batch_neg_condensed_edge_types = (
+            condensed_edge_types[
+                : self.active_sampling_config.positive_edge_batch_size
+            ],
+            condensed_edge_types[
+                self.active_sampling_config.positive_edge_batch_size :
+            ],
+        )
+        pos_labels, batch_neg_labels = (
+            labels[: self.active_sampling_config.positive_edge_batch_size],
+            labels[self.active_sampling_config.positive_edge_batch_size :],
+        )
+
+        pos_logits: torch.Tensor
+        pos_labels: torch.Tensor
+        neg_logits = list()
+        neg_labels = list()
+
+        if self.active_sampling_config.num_inbatch_negatives_per_edge:
+            # Do inbatch negative sampling and compute logits and labels
+            (
+                in_batch_logits,
+                in_batch_labels,
+            ) = in_batch_relationwise_contrastive_similarity(
+                src_embeddings=pos_src_embeddings,
+                dst_embeddings=pos_dst_embeddings,
+                condensed_edge_types=pos_condensed_edge_types,
+                scoring_function=self.similarity_type,
+                corrupt_side=self.active_sampling_config.negative_corruption_side,
+                num_negatives=self.active_sampling_config.num_inbatch_negatives_per_edge,
+            )
+            pos_logits = in_batch_logits[:, 0].unsqueeze(1)
+            pos_labels = in_batch_labels[:, 0].unsqueeze(1)
+            neg_logits.append(in_batch_logits[:, 1:])
+            neg_labels.append(in_batch_labels[:, 1:])
+
+        if self.active_sampling_config.num_random_negatives_per_edge:
+            (
+                against_batch_logits,
+                against_batch_labels,
+            ) = against_batch_relationwise_contrastive_similarity(
+                src_embeddings=pos_src_embeddings,
+                dst_embeddings=pos_dst_embeddings,
+                condensed_edge_types=pos_condensed_edge_types,
+                batch_src_embeddings=batch_neg_src_embeddings,
+                batch_dst_embeddings=batch_neg_dst_embeddings,
+                batch_condensed_edge_types=batch_neg_condensed_edge_types,
+                scoring_function=self.similarity_type,
+                corrupt_side=self.active_sampling_config.negative_corruption_side,
+                num_negatives=self.active_sampling_config.num_random_negatives_per_edge,
+            )
+            pos_logits = against_batch_logits[:, 0].unsqueeze(1)
+            pos_labels = against_batch_labels[:, 0].unsqueeze(1)
+            neg_logits.append(against_batch_logits[:, 1:])
+            neg_labels.append(against_batch_labels[:, 1:])
+
+        # Concatenate positive and negative samples
+        neg_logits = torch.cat(neg_logits, dim=1)
+        neg_labels = torch.cat(neg_labels, dim=1)
+        logits = torch.cat([pos_logits, neg_logits], dim=1)
+        labels = torch.cat([pos_labels, neg_labels], dim=1)
+
+        return logits, labels, pos_condensed_edge_types
+
+
+class HeterogeneousGraphSparseEmbeddingModelAndLoss(nn.Module):
+    """
+    A simple heterogeneous information network model with loss. This module
+    wraps the `HeterogeneousGraphSparseEmbeddingModel` model for use with
+    torchrec TrainPipeline abstraction, which requires specific input/output
+    expectations regarding loss and outputs.  This is required by TorchRec's
+    convention.  For more details, see:
+
+    - https://github.com/pytorch/torchrec/blob/3ec6f537bf230556b58f5a527ed32e23cc50849d/examples/golden_training/train_dlrm.py#L111
+    - https://github.com/pytorch/torchrec/blob/3ec6f537bf230556b58f5a527ed32e23cc50849d/torchrec/models/dlrm.py#L850
+    """
+
+    def __init__(
+        self,
+        encoder_model: HeterogeneousGraphSparseEmbeddingModel,
+        loss_fn: Callable[
+            [torch.Tensor, torch.Tensor], torch.Tensor
+        ] = F.binary_cross_entropy_with_logits,
+    ):
+        """
+        Initialize the model with the given encoder model and loss function.
+
+        Args:
+            encoder_model (HeterogeneousGraphSparseEmbeddingModel): The underlying model for encoding.
+            loss_fn (Callable[[torch.Tensor, torch.Tensor], torch.Tensor]): The loss function to compute the loss.
+                Defaults to binary cross-entropy with logits.
+        """
+
+        super().__init__()
+        self.encoder_model = encoder_model
+        self.loss_fn = loss_fn
+
+    def set_phase(self, phase: ModelPhase):
+        """
+        Set the phase of the encoder model. This is used to determine which sampling
+        configuration to use during training, validation, or testing.
+
+        Note that this affects
+        (i) how data that is passed into the model is interpreted (e.g. #s of positives, negatives)
+        (ii) whether inbatch negatives are used to compute logits and labels
+
+        Args:
+            phase (ModelPhase): The current phase of the model (TRAIN, VAL, TEST, INFERENCE).
+        """
+
+        self.encoder_model.set_phase(phase=phase)
+
+    @property
+    def phase(self) -> ModelPhase:
+        return self.encoder_model.phase
+
+    def forward(self, batch: Union[EdgeBatch, NodeBatch]) -> Tuple[torch.Tensor, Tuple]:
+        """
+        If the batch is an EdgeBatch, compute the loss and return it along with
+        the logits and labels.
+
+        If the batch is a NodeBatch, infer node embeddings instead.
+
+        Args:
+            batch (Union[EdgeBatch, NodeBatch]): The input batch, which can be either an EdgeBatch or a NodeBatch.
+
+        Returns:
+            Tuple[torch.Tensor, Tuple]: A tuple containing the loss and a tuple of (loss, logits, labels) for EdgeBatch,
+                                        or (dummy_loss, node_embeddings) for NodeBatch.
+        """
+        if (
+            self.phase == ModelPhase.INFERENCE_SRC
+            or self.phase == ModelPhase.INFERENCE_DST
+        ):
+            # In inference phase, we only handle NodeBatch.
+            batch: NodeBatch
+            node_embeddings = self.encoder_model.infer_node_batch(node_batch=batch)
+            dummy_loss = torch.tensor(0.0)
+            node_ids = batch.nodes.values()
+            return dummy_loss, (
+                node_ids.detach(),
+                node_embeddings.detach(),
+            )
+        else:
+            # We expect an EdgeBatch in training, validation, or testing phases.
+            batch: EdgeBatch
+            logits: torch.Tensor
+            labels: torch.Tensor
+            logits, labels, condensed_edge_types = self.encoder_model(edge_batch=batch)
+            loss = self.loss_fn(logits, labels)
+            return loss, (
+                loss.detach(),
+                logits.detach(),
+                labels.detach(),
+                condensed_edge_types.detach(),
+            )

--- a/python/gigl/experimental/knowledge_graph_embedding/lib/model/loss_utils.py
+++ b/python/gigl/experimental/knowledge_graph_embedding/lib/model/loss_utils.py
@@ -1,0 +1,164 @@
+from typing import List, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+
+# TODO(nshah-sc): Some of these functions don't require labels, and we should refactor them to not require them.
+# The current implementation is parameterized as such to support some existing code.
+
+
+def bpr_loss(
+    scores: torch.Tensor,
+    labels: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Computes Bayesian Personalized Ranking (BPR) loss.
+
+    For each positive score s⁺ and its negatives s⁻₁, ..., s⁻_K, we compute:
+
+    $$
+    \mathcal{L}_\\text{BPR} = - \\frac{1}{BK} \sum_{i=1}^B \sum_{j=1}^K \log \sigma(s_i^+ - s_{ij}^-)
+    $$
+
+    Args:
+        scores: Score tensor of shape [B, 1 + K], where B is the batch size and K is the number of negatives.
+            1st column contains positive scores, and the rest are negative scores.
+        labels: Label tensor of shape [B, 1 + K], where 1 indicates positive and 0 indicates negative.
+            1st column contains positive labels, and the rest are negative labels.
+
+    Returns:
+        Scalar BPR loss
+    """
+    pos = scores[:, 0].unsqueeze(1)  # (B, 1)
+    neg = scores[:, 1:]  # (B, K)
+
+    diff = pos - neg  # (B, K)
+    loss = -F.logsigmoid(diff).mean()  # scalar
+
+    return loss
+
+
+def infonce_loss(
+    scores: torch.Tensor,
+    labels: torch.Tensor,
+    temperature: float = 1.0,
+) -> torch.Tensor:
+    """
+    Computes InfoNCE contrastive loss.
+
+    We treat each group of (1 positive + K negatives) as a (1 + K)-way classification:
+
+    $$
+    \mathcal{L}_\\text{InfoNCE} = - \\frac{1}{B} \sum_{i=1}^B \log \frac{\exp(s_i^+ / \\tau)}{\sum_{j=0}^{K} \exp(s_{ij} / \\tau)}
+    $$
+
+    Args:
+        scores: Score tensor of shape [B, 1 + K], where B is the batch size and K is the number of negatives.
+            1st column contains positive scores, and the rest are negative scores.
+        labels: Label tensor of shape [B, 1 + K], where 1 indicates positive and 0 indicates negative.
+            1st column contains positive labels, and the rest are negative labels.
+        num_negatives: K, number of negatives per positive
+
+    Returns:
+        Scalar InfoNCE loss
+    """
+    scores = scores / temperature  # (B, 1 + K)
+    loss = F.cross_entropy(
+        scores, torch.zeros(scores.size(0), dtype=torch.long, device=scores.device)
+    )
+    return loss
+
+
+def average_pos_neg_scores(
+    scores: torch.Tensor, labels: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Computes the average positive and negative scores from scores and labels.
+
+    Args:
+        scores: Score tensor.
+        labels: Label tensor of corresponding shape.  1s indicate positive, 0s indicate negative.
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor]: (avg_pos_score, avg_neg_score).  These are scalars,
+        and the tensors are detached from the computation graph since we don't want to backprop.
+    """
+
+    one_mask = labels == 1
+    avg_pos_score = scores[one_mask].mean().detach()
+    avg_neg_score = scores[~one_mask].mean().detach()
+    return avg_pos_score, avg_neg_score
+
+
+def hit_rate_at_k(
+    scores: torch.Tensor,
+    labels: torch.Tensor,
+    ks: Union[int, List[int]],
+) -> torch.Tensor:
+    """
+    Computes HitRate@K using pure tensor operations.
+
+    HitRate@K is defined as:
+        \[
+        \text{HitRate@K} = \frac{1}{N} \sum_{i=1}^N \mathbb{1}\{ \text{positive in top-K} \}
+        \]
+
+    Args:
+        scores: Score tensor of shape [B, 1 + K], where B is the batch size and K is the number of negatives.
+            1st column contains positive scores, and the rest are negative scores.
+        labels: Label tensor of shape [B, 1 + K], where 1 indicates positive and 0 indicates negative.
+            1st column contains positive labels, and the rest are negative labels.
+        ks: An integer or list of integers indicating K values.
+
+    Returns:
+        A tensor (if one K) or dict of tensors (if multiple Ks), each giving HitRate@K.
+    """
+    if isinstance(ks, int):
+        ks = [ks]
+    ks = torch.tensor(sorted(set(ks)), device=scores.device)
+
+    # Get top max_k indices (shape B x max_k)
+    max_k = ks.max().item()
+    topk_indices = torch.topk(scores, k=max_k, dim=1).indices  # shape: (B, max_k)
+
+    # Gather corresponding labels for top-k entries
+    topk_labels = torch.gather(labels, dim=1, index=topk_indices)  # shape: (B, max_k)
+
+    # For each k, compute hit (positive appeared in top-k)
+    hits_at_k = (topk_labels.cumsum(dim=1) > 0).float()  # (B, max_k)
+    hit_rates = hits_at_k[:, ks - 1].mean(dim=0)  # (len(ks),)
+    return hit_rates
+
+
+def mean_reciprocal_rank(
+    scores: torch.Tensor,
+    labels: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Computes Mean Reciprocal Rank (MRR) using pure tensor operations.
+
+    MRR is defined as:
+        \[
+        \text{MRR} = \frac{1}{N} \sum_{i=1}^N \frac{1}{\text{rank}_i}
+        \]
+        where rank_i is the 1-based index of the positive in the sorted list.
+
+    Args:
+        scores: Score tensor of shape [B, 1 + K], where B is the batch size and K is the number of negatives.
+            1st column contains positive scores, and the rest are negative scores.
+        labels: Label tensor of shape [B, 1 + K], where 1 indicates positive and 0 indicates negative.
+            1st column contains positive labels, and the rest are negative labels.
+
+    Returns:
+        Scalar tensor with MRR.
+    """
+
+    # Sort scores descending, get sort indices
+    sorted_indices = torch.argsort(scores, dim=1, descending=True)
+
+    # Use sort indices to reorder labels
+    sorted_labels = torch.gather(labels, dim=1, index=sorted_indices)
+
+    # Find the index of the positive label (label == 1) in sorted list
+    reciprocal_ranks = 1.0 / (torch.argmax(sorted_labels, dim=1).float() + 1.0)  # (B,)
+    return reciprocal_ranks.mean()

--- a/python/gigl/experimental/knowledge_graph_embedding/lib/model/negative_sampling.py
+++ b/python/gigl/experimental/knowledge_graph_embedding/lib/model/negative_sampling.py
@@ -1,0 +1,248 @@
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from applied_tasks.knowledge_graph_embedding.lib.model.types import (
+    NegativeSamplingCorruptionType,
+    SimilarityType,
+)
+
+
+def in_batch_relationwise_contrastive_similarity(
+    src_embeddings: torch.Tensor,  # [B, D]
+    dst_embeddings: torch.Tensor,  # [B, D]
+    condensed_edge_types: torch.Tensor,  # [B]
+    temperature: float = 1.0,
+    scoring_function: SimilarityType = SimilarityType.COSINE,
+    corrupt_side: NegativeSamplingCorruptionType = NegativeSamplingCorruptionType.DST,
+    num_negatives: Optional[int] = None,  # Number of negatives to sample per instance
+) -> torch.Tensor:
+    """
+    Computes relation-aware in-batch contrastive loss with optional sampled negatives.
+
+    Args:
+        src_embeddings: [B, D] Source node embeddings.
+        dst_embeddings: [B, D] Destination node embeddings.
+        condensed_edge_types: [B] Relation type IDs.
+        temperature: Scaling factor for similarity.
+        corrupt_side: "src", "dst", or "both".
+        num_negatives: Number of in-batch negatives to sample per example (if None, use all).
+
+    Returns:
+        logits: [B, 1 + K] Logits for positive and negative pairs.
+        labels: [B, 1 + K] Labels for positive and negative pairs. The first column is 1
+                (positive), rest are 0 (negatives).
+    """
+    B, D = src_embeddings.shape
+
+    # Compute similarity matrix between src and dst embeddings
+    if scoring_function == SimilarityType.DOT:
+        sim_matrix = src_embeddings @ dst_embeddings.T
+    elif scoring_function == SimilarityType.COSINE:
+        src_norm = F.normalize(src_embeddings, dim=1)
+        dst_norm = F.normalize(dst_embeddings, dim=1)
+        sim_matrix = src_norm @ dst_norm.T
+    elif scoring_function == SimilarityType.EUCLIDEAN:
+        # Negative squared L2 distance (to make it similar to scoring_function)
+        src_sq = src_embeddings.pow(2).sum(dim=1, keepdim=True)  # [B, 1]
+        dst_sq = dst_embeddings.pow(2).sum(dim=1, keepdim=True)  # [B, 1]
+        sim_matrix = -(
+            src_sq - 2 * src_embeddings @ dst_embeddings.T + dst_sq.T
+        )  # [B, B]
+    else:
+        raise ValueError(f"Unsupported scoring_function: {scoring_function}")
+
+    sim_matrix = sim_matrix / temperature  # [B, B]
+
+    # Create mask indicating valid relations (same relation type)
+    rel_mask = condensed_edge_types[:, None] == condensed_edge_types[None, :]  # [B, B]
+
+    # Identity matrix for diagonal masking (positive pair)
+    identity = torch.diag(torch.ones_like(condensed_edge_types, dtype=torch.bool))
+
+    # Process based on corruption side: "src", "dst", or "both"
+    if corrupt_side == NegativeSamplingCorruptionType.SRC:
+        # In "src" corruption, we modify the source side, keeping the destination side fixed
+        sim_matrix = sim_matrix.T  # [B, B] -> Now rows are dst, columns are src
+
+    elif corrupt_side == NegativeSamplingCorruptionType.DST:
+        # In "dst" corruption, we modify the destination side, keeping the source side fixed
+        # No change to sim_matrix, this is the default behavior
+        pass
+
+    elif corrupt_side == NegativeSamplingCorruptionType.BOTH:
+        # In "both" corruption, we randomly decide for each row whether to corrupt the src or dst
+        # Randomly decide to corrupt "src" or "dst" for each example (50% chance each)
+        is_src_corruption = torch.rand_like(
+            condensed_edge_types, dtype=torch.float32
+        ).bool()  # [B] Mask for src corruption
+
+        # Corrupt the source (flip relation mask and similarity matrix for those cases)
+        sim_matrix_src = sim_matrix.T  # [B, B] -> Now rows are dst, columns are src
+
+        # Corrupt the destination (standard sim_matrix dst corruption)
+        sim_matrix_dst = sim_matrix
+
+        # Combine the two corruptions
+        sim_matrix = torch.where(
+            is_src_corruption.unsqueeze(1), sim_matrix_src, sim_matrix_dst
+        )
+    else:
+        raise ValueError(
+            f"Corruption type must be in {NegativeSamplingCorruptionType.SRC, NegativeSamplingCorruptionType.DST, NegativeSamplingCorruptionType.BOTH}; got {corrupt_side}."
+        )
+
+    # Mask invalid negatives (i.e., non-matching relations and diagonal)
+    neg_mask = rel_mask & ~identity  # Mask for valid negative pairs
+
+    # Get positive logits (diagonal of the similarity matrix)
+    pos_logits = sim_matrix.diagonal().unsqueeze(1)  # [B, 1]
+
+    # Mask the similarity matrix to only keep valid negatives
+    logits_masked = sim_matrix.masked_fill(~neg_mask, float("-inf"))  # [B, B]
+
+    if num_negatives is None:
+        # If no negative sampling, use all valid negatives
+        logits = torch.cat([pos_logits, logits_masked], dim=1)
+        labels = torch.zeros_like(logits, dtype=torch.float)
+        labels = labels.scatter(
+            1, torch.zeros_like(condensed_edge_types, dtype=torch.long).view(-1, 1), 1
+        )  # Set positive labels to 1 (first column)
+        return logits, labels
+
+    # ---- Fully tensorized negative sampling ----
+
+    # Generate random scores for sampling negative pairs
+    rand = torch.rand_like(logits_masked)  # [B, B]
+    rand.masked_fill_(
+        ~neg_mask, float("inf")
+    )  # Set invalid positions to +inf so they won't be selected in topk
+
+    # Sample negatives using topk: smallest random scores are selected
+    K = num_negatives
+    sampled_idx = rand.topk(K, dim=1, largest=False, sorted=False).indices  # [B, K]
+
+    # Gather negative logits based on the sampled indices
+    neg_logits = logits_masked.gather(1, sampled_idx)  # [B, K] gather negative logits
+
+    # Concatenate positive logits with negative logits
+    logits = torch.cat([pos_logits, neg_logits], dim=1)  # [B, 1 + K]
+
+    labels = torch.zeros_like(logits, dtype=torch.float)
+    labels = labels.scatter(
+        1, torch.zeros_like(condensed_edge_types, dtype=torch.long).view(-1, 1), 1
+    )  # Set positive labels to 1 (first column)
+
+    return logits, labels
+
+
+def against_batch_relationwise_contrastive_similarity(
+    src_embeddings: torch.Tensor,  # [B, D]
+    dst_embeddings: torch.Tensor,  # [B, D]
+    condensed_edge_types: torch.Tensor,  # [B]
+    batch_src_embeddings: torch.Tensor,  # [N, D]
+    batch_dst_embeddings: torch.Tensor,  # [N, D]
+    batch_condensed_edge_types: torch.Tensor,  # [N]
+    temperature: float = 1.0,
+    scoring_function: SimilarityType = SimilarityType.COSINE,
+    corrupt_side: NegativeSamplingCorruptionType = NegativeSamplingCorruptionType.DST,
+    num_negatives: Optional[int] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Computes relation-aware contrastive logits using an external batch of negatives.
+
+    Args:
+        src_embeddings: [B, D] Source node embeddings for the positive batch.
+        dst_embeddings: [B, D] Destination node embeddings for the positive batch.
+        condensed_edge_types: [B] Relation type IDs for the positive batch.
+        batch_src_embeddings: [N, D] Source node embeddings for the negative batch.
+        batch_dst_embeddings: [N, D] Destination node embeddings for the negative batch.
+        batch_condensed_edge_types: [N] Relation type IDs for the negative batch.
+        temperature: Scaling factor for similarity.
+        scoring_function: Similarity scoring function to use ('dot', 'cosine', 'euclidean').
+        corrupt_side: "src", "dst", or "both".
+        num_negatives: Number of negatives to sample per instance. None means all negatives are used.
+
+    Returns:
+        logits: [B, 1 + K] similarity logits (positive + K negatives)
+        labels: [B, 1 + K] one-hot labels (first col is positive)
+    """
+
+    B, D = src_embeddings.shape
+    N = batch_src_embeddings.shape[0]
+
+    # Precompute similarity matrix between [B] queries and [N] candidates
+    if scoring_function == SimilarityType.DOT:
+        sim_fn = lambda x, y: x @ y.T
+    elif scoring_function == SimilarityType.COSINE:
+        sim_fn = lambda x, y: F.normalize(x, dim=1) @ F.normalize(y, dim=1).T
+    elif scoring_function == SimilarityType.EUCLIDEAN:
+
+        def sim_fn(x, y):
+            x_sq = x.pow(2).sum(dim=1, keepdim=True)  # [B, 1]
+            y_sq = y.pow(2).sum(dim=1, keepdim=True)  # [N, 1]
+            return -(x_sq - 2 * x @ y.T + y_sq.T)  # negative squared L2
+
+    else:
+        raise ValueError(
+            f"Similarity type must be in {SimilarityType.COSINE, SimilarityType.DOT, SimilarityType.EUCLIDEAN}. Got {scoring_function}"
+        )
+
+    # Build masks for valid negatives per relation type
+    # [B, N]: True where edge types match
+    rel_mask = condensed_edge_types[:, None] == batch_condensed_edge_types[None, :]
+
+    # Positive similarity
+    pos_logits = (
+        sim_fn(src_embeddings, dst_embeddings).diagonal().unsqueeze(1)
+    )  # [B, 1]
+
+    # Negative similarity matrix (B x N), depends on corruption side
+    if corrupt_side == NegativeSamplingCorruptionType.SRC:
+        neg_sim_matrix = sim_fn(batch_src_embeddings, dst_embeddings)  # [N, B]
+        neg_sim_matrix = neg_sim_matrix.T  # [B, N]
+    elif corrupt_side == NegativeSamplingCorruptionType.DST:
+        neg_sim_matrix = sim_fn(src_embeddings, batch_dst_embeddings)  # [B, N]
+    elif corrupt_side == NegativeSamplingCorruptionType.BOTH:
+        is_src_corruption = torch.rand_like(
+            condensed_edge_types, dtype=torch.float32
+        ).bool()  # [B] Mask for src corruption
+        neg_sim_src = sim_fn(batch_src_embeddings, dst_embeddings).T  # [B, N]
+        neg_sim_dst = sim_fn(src_embeddings, batch_dst_embeddings)  # [B, N]
+        neg_sim_matrix = torch.where(
+            is_src_corruption.unsqueeze(1), neg_sim_src, neg_sim_dst
+        )
+    else:
+        raise ValueError(f"Invalid corrupt_side: {corrupt_side}")
+
+    neg_sim_matrix = neg_sim_matrix / temperature  # [B, N]
+
+    # Mask invalid negatives (i.e., non-matching relations)
+    logits_masked = neg_sim_matrix.masked_fill(~rel_mask, float("-inf"))  # [B, N]
+
+    if num_negatives is None:
+        # If no negative sampling, use all valid negatives
+        logits = torch.cat([pos_logits, logits_masked], dim=1)
+        labels = torch.zeros_like(logits, dtype=torch.float)
+        labels = labels.scatter(
+            1, torch.zeros_like(condensed_edge_types, dtype=torch.long).view(-1, 1), 1
+        )  # Set positive labels to 1 (first column)
+        return logits, labels
+
+    # Sample K negatives per row from matching relation types
+    rand = torch.rand_like(logits_masked)  # [B, N]
+    rand.masked_fill_(~rel_mask, float("inf"))  # Prevent selecting mismatched negatives
+    sampled_idx = rand.topk(num_negatives, dim=1, largest=False).indices  # [B, K]
+
+    # Gather negative similarities
+    neg_logits = logits_masked.gather(1, sampled_idx)  # [B, K] gather negative logits
+
+    # Concatenate positive logits with negative logits
+    logits = torch.cat([pos_logits, neg_logits], dim=1)  # [B, 1 + K]
+
+    labels = torch.zeros_like(logits, dtype=torch.float)
+    labels = labels.scatter(
+        1, torch.zeros_like(condensed_edge_types, dtype=torch.long).view(-1, 1), 1
+    )  # Set positive labels to 1 (first column)
+
+    return logits, labels

--- a/python/gigl/experimental/knowledge_graph_embedding/tests/test_against_batch_contrastive_similarity_relationwise.py
+++ b/python/gigl/experimental/knowledge_graph_embedding/tests/test_against_batch_contrastive_similarity_relationwise.py
@@ -1,0 +1,227 @@
+import unittest
+
+import torch
+from applied_tasks.knowledge_graph_embedding.lib.model.negative_sampling import (
+    against_batch_relationwise_contrastive_similarity,
+)
+from applied_tasks.knowledge_graph_embedding.lib.model.types import (
+    NegativeSamplingCorruptionType,
+    SimilarityType,
+)
+
+
+class TestAgainstBatchRelationwiseContrastiveSimilarity(unittest.TestCase):
+    def test_correctness_dot_dst_one_negative(self):
+        # Test dot product similarity with destination-side corruption and one negative sample.
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        dst_embeddings = torch.tensor([[2.0, 0.0], [0.0, 3.0]])
+        condensed_edge_types = torch.tensor([0, 0])
+        batch_src_embeddings = torch.tensor([[1.5, 0.1], [0.2, 2.5]])
+        batch_dst_embeddings = torch.tensor([[2.1, 0.2], [0.3, 3.1]])
+        batch_condensed_edge_types = torch.tensor([0, 1])
+        temperature = 1.0
+        num_negatives = 1
+        corrupt_side = NegativeSamplingCorruptionType.DST
+        scoring_function = SimilarityType.DOT
+
+        logits, labels = against_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            batch_src_embeddings=batch_src_embeddings,
+            batch_dst_embeddings=batch_dst_embeddings,
+            batch_condensed_edge_types=batch_condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            corrupt_side=corrupt_side,
+            num_negatives=num_negatives,
+        )
+
+        # Positive logits (src @ dst.T).diagonal(): [2., 3.]
+        # Negative logits (src @ batch_dst.T) where relations match (type 0): [[1.0 * 2.1 + 0.0 * 0.2], [0.0 * 2.1 + 1.0 * 0.2]] => [[2.1], [0.2]]
+        expected_logits = torch.tensor([[2.0, 2.1], [3.0, 0.2]])
+        expected_labels = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
+
+        self.assertTrue(torch.allclose(logits, expected_logits))
+        self.assertTrue(torch.allclose(labels, expected_labels))
+
+    def test_correctness_cosine_src_two_negatives(self):
+        # Test cosine similarity with source-side corruption and two negative samples.
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        dst_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        condensed_edge_types = torch.tensor([0, 0])
+        batch_src_embeddings = torch.tensor([[0.0, 1.0], [1.0, 0.0], [0.5, 0.5]])
+        batch_dst_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]])
+        batch_condensed_edge_types = torch.tensor([0, 0, 1])
+        temperature = 1.0
+        num_negatives = 2
+        corrupt_side = NegativeSamplingCorruptionType.SRC
+        scoring_function = SimilarityType.COSINE
+
+        torch.manual_seed(42)  # For deterministic negative sampling
+
+        logits, labels = against_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            batch_src_embeddings=batch_src_embeddings,
+            batch_dst_embeddings=batch_dst_embeddings,
+            batch_condensed_edge_types=batch_condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            corrupt_side=corrupt_side,
+            num_negatives=num_negatives,
+        )
+
+        # Normalized embeddings for positive: [[1., 0.], [0., 1.]]
+        # Positive logits: [1., 1.]
+        # Normalized batch_src_embeddings: [[0., 1.], [1., 0.], [0.707, 0.707]]
+        # Negative similarities (normalized batch_src @ normalized dst.T) for matching relation (type 0):
+        # Row 0: [[0.*1 + 1.*0], [0.*0 + 1.*1]] => [0., 1.]
+        # Row 1: [[1.*1 + 0.*0], [1.*0 + 0.*1]] => [1., 0.]
+        # After masking non-matching (none here), and sampling 2: depends on seed, should pick the two.
+        # Let's manually calculate the cosine similarities:
+        # cos([1, 0], [0, 1]) = 0; cos([1, 0], [1, 0]) = 1
+        # cos([0, 1], [0, 1]) = 1; cos([0, 1], [1, 0]) = 0
+        expected_positive_logits = torch.tensor([[1.0], [1.0]])
+        # Due to seeding, the top 2 should be the two type 0 examples.
+        # The order might vary, but the values should be present.
+        expected_neg_logits_row0 = torch.tensor([0.0, 1.0])
+        expected_neg_logits_row1 = torch.tensor([1.0, 0.0])
+        expected_labels = torch.tensor([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+
+        self.assertTrue(
+            torch.allclose(logits[:, 0].unsqueeze(1), expected_positive_logits)
+        )
+        # Check if the negative logits contain the expected values (order might differ due to sampling)
+        for i in range(2):
+            self.assertEqual(logits[0, 1:].numel(), 2)
+            self.assertEqual(logits[1, 1:].numel(), 2)
+            for val in expected_neg_logits_row0:
+                self.assertTrue(torch.any(torch.isclose(logits[0, 1:], val)))
+            for val in expected_neg_logits_row1:
+                self.assertTrue(torch.any(torch.isclose(logits[1, 1:], val)))
+        self.assertTrue(torch.allclose(labels, expected_labels))
+
+    def test_correctness_euclidean_both_none_negatives(self):
+        # Test Euclidean similarity with both-side corruption and no explicit negative sampling.
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        dst_embeddings = torch.tensor([[0.0, 1.0], [1.0, 0.0]])
+        condensed_edge_types = torch.tensor([0, 0])
+        batch_src_embeddings = torch.tensor([[1.0, 1.0], [-1.0, 0.0]])
+        batch_dst_embeddings = torch.tensor([[0.0, 0.0], [0.0, -1.0]])
+        batch_condensed_edge_types = torch.tensor([0, 1])
+        temperature = 1.0
+        num_negatives = None
+        corrupt_side = NegativeSamplingCorruptionType.BOTH
+        scoring_function = SimilarityType.EUCLIDEAN
+
+        torch.manual_seed(10)  # For deterministic 'both' corruption
+
+        logits, labels = against_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            batch_src_embeddings=batch_src_embeddings,
+            batch_dst_embeddings=batch_dst_embeddings,
+            batch_condensed_edge_types=batch_condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            corrupt_side=corrupt_side,
+            num_negatives=num_negatives,
+        )
+
+        # Positive squared Euclidean distance:
+        # ||[1, 0] - [0, 1]||^2 = 1^2 + (-1)^2 = 2 => similarity = -2
+        # ||[0, 1] - [1, 0]||^2 = (-1)^2 + 1^2 = 2 => similarity = -2
+        expected_positive_logits = torch.tensor([[-2.0], [-2.0]])
+        pos_logits = logits[:, 0].unsqueeze(1)
+        self.assertTrue(torch.allclose(pos_logits, expected_positive_logits))
+        self.assertEqual(logits.shape, (2, 3))
+
+        expected_labels = torch.tensor([[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]])
+        self.assertTrue(torch.allclose(labels, expected_labels))
+
+    def test_correctness_dot_dst_zero_negatives(self):
+        # Test dot product with destination-side corruption and zero negative samples.
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        dst_embeddings = torch.tensor([[2.0, 0.0], [0.0, 3.0]])
+        condensed_edge_types = torch.tensor([0, 0])
+        batch_src_embeddings = torch.tensor([[1.5, 0.1], [0.2, 2.5]])
+        batch_dst_embeddings = torch.tensor([[2.1, 0.2], [0.3, 3.1]])
+        batch_condensed_edge_types = torch.tensor([0, 1])
+        temperature = 1.0
+        num_negatives = 0
+        corrupt_side = NegativeSamplingCorruptionType.DST
+        scoring_function = SimilarityType.DOT
+
+        logits, labels = against_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            batch_src_embeddings=batch_src_embeddings,
+            batch_dst_embeddings=batch_dst_embeddings,
+            batch_condensed_edge_types=batch_condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            num_negatives=num_negatives,
+        )
+
+        # Only positive logits
+        expected_logits = torch.tensor([[2.0], [3.0]])
+        expected_labels = torch.tensor([[1.0], [1.0]])
+
+        self.assertTrue(torch.allclose(logits, expected_logits))
+        self.assertTrue(torch.allclose(labels, expected_labels))
+        self.assertEqual(logits.shape, (2, 1))
+        self.assertEqual(labels.shape, (2, 1))
+
+    def test_correctness_dot_src_none_negatives(self):
+        # Test dot product with source-side corruption and "full" negative sampling (all in-batch negatives used).
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        dst_embeddings = torch.tensor([[2.0, 0.0], [0.0, 3.0]])
+        condensed_edge_types = torch.tensor([0, 0])
+        batch_src_embeddings = torch.tensor([[1.5, 0.1], [0.0, 1.0], [1.0, 0.0]])
+        batch_dst_embeddings = torch.tensor([[2.0, 0.0], [0.0, 3.0], [1.0, 1.0]])
+        batch_condensed_edge_types = torch.tensor([0, 0, 1])
+        temperature = 1.0
+        num_negatives = None
+        corrupt_side = NegativeSamplingCorruptionType.SRC
+        scoring_function = SimilarityType.DOT
+
+        logits, labels = against_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            batch_src_embeddings=batch_src_embeddings,
+            batch_dst_embeddings=batch_dst_embeddings,
+            batch_condensed_edge_types=batch_condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            corrupt_side=corrupt_side,
+            num_negatives=num_negatives,
+        )
+
+        # Positive logits (src @ dst.T).diagonal(): [2., 3.]
+        expected_positive_logits = torch.tensor([[2.0], [3.0]])
+
+        # Negative logits (batch_src @ dst.T) where relations match (type 0):
+        # Row 0: [1.5*2 + 0.1*0, 0*2 + 1*0] => [3.0, 0.0]
+        # Row 1: [1.5*0 + 0.1*3, 0*0 + 1*3] => [0.3, 3.0]
+        expected_neg_logits_masked = torch.tensor(
+            [[3.0, 0.0, float("-inf")], [0.3, 3.0, float("-inf")]]
+        )
+
+        expected_logits = torch.cat(
+            [expected_positive_logits, expected_neg_logits_masked], dim=1
+        )
+        expected_labels = torch.tensor([[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]])
+
+        self.assertTrue(torch.allclose(logits, expected_logits))
+        self.assertTrue(torch.equal(labels, expected_labels))
+        self.assertEqual(logits.shape, (2, 4))
+        self.assertEqual(labels.shape, (2, 4))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/gigl/experimental/knowledge_graph_embedding/tests/test_in_batch_relationwise_contrastive_similarity.py
+++ b/python/gigl/experimental/knowledge_graph_embedding/tests/test_in_batch_relationwise_contrastive_similarity.py
@@ -1,0 +1,181 @@
+import unittest
+
+import torch
+from applied_tasks.knowledge_graph_embedding.lib.model.negative_sampling import (
+    in_batch_relationwise_contrastive_similarity,
+)
+from applied_tasks.knowledge_graph_embedding.lib.model.types import (
+    NegativeSamplingCorruptionType,
+    SimilarityType,
+)
+
+
+class TestInBatchRelationwiseContrastiveSimilarity(unittest.TestCase):
+    def test_correctness_dot_dst_one_negative(self):
+        # Test dot product similarity with destination-side corruption and one negative sample.
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        dst_embeddings = torch.tensor([[2.0, 0.0], [0.0, 3.0]])
+        condensed_edge_types = torch.tensor([0, 0])
+        temperature = 1.0
+        num_negatives = 1
+        corrupt_side = NegativeSamplingCorruptionType.DST
+        scoring_function = SimilarityType.DOT
+
+        logits, labels = in_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            corrupt_side=corrupt_side,
+            num_negatives=num_negatives,
+        )
+
+        # Expected similarity matrix (src @ dst.T): [[2., 0.], [0., 3.]]
+        # Positive logits (diagonal): [2., 3.]
+        # Negative logits (other elements in the row, same relation): For the first row, the other is 0. For the second, it's 0.
+        expected_logits = torch.tensor([[2.0, 0.0], [3.0, 0.0]])
+        expected_labels = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
+
+        self.assertTrue(torch.allclose(logits, expected_logits))
+        self.assertTrue(torch.allclose(labels, expected_labels))
+
+    def test_correctness_cosine_src_one_negative(self):
+        # Test cosine similarity with source-side corruption and one negative sample.
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        dst_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        condensed_edge_types = torch.tensor([0, 0])
+        temperature = 1.0
+        num_negatives = 1
+        corrupt_side = NegativeSamplingCorruptionType.SRC
+        scoring_function = SimilarityType.COSINE
+
+        logits, labels = in_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            corrupt_side=corrupt_side,
+            num_negatives=num_negatives,
+        )
+
+        # Normalized embeddings are the same
+        # Similarity matrix (normalized dst @ normalized src.T): [[1., 0.], [0., 1.]]
+        # Positive logits: [1., 1.]
+        # Negative logits: [0., 0.]
+        expected_logits = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
+        expected_labels = torch.tensor([[1.0, 0.0], [1.0, 0.0]])
+
+        self.assertTrue(torch.allclose(logits, expected_logits))
+        self.assertTrue(torch.allclose(labels, expected_labels))
+
+    def test_correctness_euclidean_both_two_negatives(self):
+        # Test Euclidean similarity with both-side corruption and two negative samples.
+        # Note: Due to the 'both' corruption's randomness, we focus on the positive logit and label.
+        torch.manual_seed(0)  # For deterministic behavior of 'both' corruption
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]])
+        dst_embeddings = torch.tensor([[0.0, 1.0], [1.0, 0.0], [0.0, 0.0]])
+        condensed_edge_types = torch.tensor([0, 0, 1])
+        temperature = 1.0
+        num_negatives = 2
+        corrupt_side = NegativeSamplingCorruptionType.BOTH
+        scoring_function = SimilarityType.EUCLIDEAN
+
+        logits, labels = in_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            corrupt_side=corrupt_side,
+            num_negatives=num_negatives,
+        )
+
+        # Squared Euclidean distance: ||a - b||^2 = ||a||^2 + ||b||^2 - 2 * a @ b
+        # Similarity is the negative of this.
+
+        # Positive similarities:
+        # For 0: -((1^2 + 0^2) + (0^2 + 1^2) - 2 * (1*0 + 0*1)) = -2
+        # For 1: -((0^2 + 1^2) + (1^2 + 0^2) - 2 * (0*1 + 1*0)) = -2
+        # For 2: -((1^2 + 1^2) + (0^2 + 0^2) - 2 * (1*0 + 1*0)) = -2
+        expected_positive_logits = torch.tensor([-2.0, -2.0, -2.0]).unsqueeze(1)
+        expected_positive_labels = torch.ones(3, 1)
+
+        self.assertTrue(
+            torch.allclose(logits[:, 0].unsqueeze(1), expected_positive_logits)
+        )
+        self.assertTrue(
+            torch.allclose(labels[:, 0].unsqueeze(1), expected_positive_labels)
+        )
+        self.assertEqual(logits.shape, (3, 3))
+        self.assertEqual(labels.shape, (3, 3))
+        self.assertTrue(torch.all(labels[:, 0] == 1.0))
+        self.assertTrue(torch.all(labels[:, 1:] == 0.0))
+
+    def test_correctness_dot_dst_none_negatives(self):
+        # Test dot product with destination-side corruption and "full" negative sampling (all in-batch negatives used).
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        dst_embeddings = torch.tensor([[2.0, 0.0], [0.0, 3.0]])
+        condensed_edge_types = torch.tensor([0, 0])
+        temperature = 1.0
+        num_negatives = None
+        corrupt_side = NegativeSamplingCorruptionType.DST
+        scoring_function = SimilarityType.DOT
+
+        logits, labels = in_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            corrupt_side=corrupt_side,
+            num_negatives=num_negatives,
+        )
+
+        # Similarity matrix: [[2., 0.], [0., 3.]]
+        # Positive logits: [2., 3.]
+        # Negative logits (same relation): [[-inf, 0.], [0., -inf]]
+        # The negative logits are set to -inf for the non-positive examples.
+        expected_logits = torch.tensor(
+            [[2.0, -float("inf"), 0.0], [3.0, 0.0, -float("inf")]]
+        )
+        expected_labels = torch.tensor(
+            [[1, 0, 0], [1, 0, 0]]
+        )  # Indices of the positive example in the logits
+
+        self.assertTrue(torch.allclose(logits, expected_logits))
+        self.assertTrue(torch.equal(labels, expected_labels))
+        self.assertEqual(logits.shape, (2, 3))
+        self.assertEqual(labels.shape, (2, 3))
+
+    def test_correctness_num_negatives_zero(self):
+        # Test the case where num_negatives is 0, expecting only positive logits and labels as 1.
+        src_embeddings = torch.tensor([[1.0, 0.0], [0.0, 1.0]])
+        dst_embeddings = torch.tensor([[2.0, 0.0], [0.0, 3.0]])
+        condensed_edge_types = torch.tensor([0, 0])
+        temperature = 1.0
+        num_negatives = 0
+        scoring_function = SimilarityType.DOT
+
+        logits, labels = in_batch_relationwise_contrastive_similarity(
+            src_embeddings=src_embeddings,
+            dst_embeddings=dst_embeddings,
+            condensed_edge_types=condensed_edge_types,
+            temperature=temperature,
+            scoring_function=scoring_function,
+            num_negatives=num_negatives,
+        )
+
+        # Only positive logits
+        expected_logits = torch.tensor([[2.0], [3.0]])
+        expected_labels = torch.tensor([[1.0], [1.0]])
+
+        self.assertTrue(torch.allclose(logits, expected_logits))
+        self.assertTrue(torch.allclose(labels, expected_labels))
+        self.assertEqual(logits.shape, (2, 1))
+        self.assertEqual(labels.shape, (2, 1))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adding some files which support:

- the core heterogeneous graph embedding model which enables various combinations of in-batch vs. random sampling, src/dst operators, negative sampling corruptions, scoring functions etc.
- some negative sampling utilities
- tests for these utilities
- all code is written to be [torch.fx-traceable](https://docs.pytorch.org/docs/stable/fx.html)  -- this requires following certain patterns that avoid [well-known pitfalls](https://docs.pytorch.org/docs/stable/fx.html#limitations-of-symbolic-tracing), including dynamic control flow, and using non-torch functions and following miscellanea carefully.  

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
