### PR TITLE
Reduce requirements for task metadata relative to graph metadata pb wrapper

### DIFF
--- a/python/gigl/src/validation_check/libs/template_config_checks.py
+++ b/python/gigl/src/validation_check/libs/template_config_checks.py
@@ -109,17 +109,21 @@ def check_if_task_metadata_valid(
         assert (
             len(task_metadata_pb.supervision_edge_types) > 0
         ), "Must provide at least one supervision edge type."
-        graph_metadata_pb_edge_types = [
-            GbmlProtosTranslator.edge_type_from_EdgeTypePb(edge_type_pb=edge_type_pb)
-            for edge_type_pb in graph_metadata_pb.edge_types
+        graph_metadata_node_types = [
+            GbmlProtosTranslator.node_type_from_NodeTypePb(
+                node_type_pb=graph_metadata_pb.node_types
+            )
         ]
         for edge_type_pb in task_metadata_pb.supervision_edge_types:
             edge_type = GbmlProtosTranslator.edge_type_from_EdgeTypePb(
                 edge_type_pb=edge_type_pb
             )
             assert (
-                edge_type in graph_metadata_pb_edge_types
-            ), f"Invalid supervision edge type: {edge_type}; not found in graphMetadata edge types {graph_metadata_pb_edge_types}."
+                edge_type.src_node_type in graph_metadata_node_types
+            ), f"Invalid supervision edge type: {edge_type}; which contains a source node type not found in graphMetadata node types: {graph_metadata_node_types}."
+            assert (
+                edge_type.dst_node_type in graph_metadata_node_types
+            ), f"Invalid supervision edge type: {edge_type}; which contains a destination node type not found in graphMetadata node types: {graph_metadata_node_types}."
     else:
         raise ValueError(
             f"Invalid 'taskMetadata'; must be one of {[TaskMetadataType.NODE_BASED_TASK, TaskMetadataType.NODE_ANCHOR_BASED_LINK_PREDICTION_TASK]}.",

--- a/python/gigl/src/validation_check/libs/template_config_checks.py
+++ b/python/gigl/src/validation_check/libs/template_config_checks.py
@@ -109,11 +109,7 @@ def check_if_task_metadata_valid(
         assert (
             len(task_metadata_pb.supervision_edge_types) > 0
         ), "Must provide at least one supervision edge type."
-        graph_metadata_node_types = [
-            GbmlProtosTranslator.node_type_from_NodeTypePb(
-                node_type_pb=graph_metadata_pb.node_types
-            )
-        ]
+        graph_metadata_node_types = graph_metadata_pb.node_types
         for edge_type_pb in task_metadata_pb.supervision_edge_types:
             edge_type = GbmlProtosTranslator.edge_type_from_EdgeTypePb(
                 edge_type_pb=edge_type_pb


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

Reduces the restrictions of our task metadata to only enforce that the source and destination node types of the supervision edge types are in the graph metadata, rather than the edge types as well. This can unblock use cases where we may have `A -> B`, `B -> B` as graph metadata edge types but `B -> A` as our supervision edge type.

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
