### PR TITLE
shutdown example inference loaders

### DIFF
--- a/examples/link_prediction/heterogeneous_inference.py
+++ b/examples/link_prediction/heterogeneous_inference.py
@@ -266,13 +266,14 @@ def _inference_process(
         f"--- Rank {rank} finished writing embeddings to GCS for node type {inference_node_type}, which took {time.time()-write_embedding_start_time:.2f} seconds"
     )
 
-    # We first call barrier to ensure that all machines and processes have finished inference. Only once this is ensured is it safe to delete the data loader on the current
-    # machine + process -- otherwise we may fail on processes which are still doing on-the-fly subgraph sampling. We then call `gc.collect()` to cleanup the memory
-    # used by the data_loader on the current machine.
+    # We first call barrier to ensure that all machines and processes have finished inference.
+    # Only once all machines have finished inference is it safe to shutdown the data loader.
+    # Otherwise, processes which are still sampling *will* fail as the loaders they are trying to communicatate with will be shutdown.
+    # We then call `gc.collect()` to cleanup the memory used by the data_loader on the current machine.
 
     barrier()
 
-    del data_loader
+    data_loader.shutdown()
     gc.collect()
 
     logger.info(

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -259,7 +259,7 @@ def _inference_process(
 
     barrier()
 
-    del data_loader
+    data_loader.shutdown()
     gc.collect()
 
     logger.info(

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -253,9 +253,10 @@ def _inference_process(
         f"--- Rank {rank} finished writing embeddings to GCS, which took {time.time()-write_embedding_start_time:.2f} seconds"
     )
 
-    # We first call barrier to ensure that all machines and processes have finished inference. Only once this is ensured is it safe to delete the data loader on the current
-    # machine + process -- otherwise we may fail on processes which are still doing on-the-fly subgraph sampling. We then call `gc.collect()` to cleanup the memory
-    # used by the data_loader on the current machine.
+    # We first call barrier to ensure that all machines and processes have finished inference.
+    # Only once all machines have finished inference is it safe to shutdown the data loader.
+    # Otherwise, processes which are still sampling *will* fail as the loaders they are trying to communicatate with will be shutdown.
+    # We then call `gc.collect()` to cleanup the memory used by the data_loader on the current machine.
 
     barrier()
 


### PR DESCRIPTION
Doing this is the preferred way as calling del on the loaders does not always clean up all memory, leading to `part or all of the requested memory range is already mapped` errors.