### PR TITLE
Set cuda devices for example loops

### DIFF
--- a/examples/link_prediction/heterogeneous_inference.py
+++ b/examples/link_prediction/heterogeneous_inference.py
@@ -128,9 +128,10 @@ def _inference_process(
     )  # The device is automatically inferred based off the local process rank and the available devices
     rank = machine_rank * local_world_size + local_rank
     world_size = machine_world_size * local_world_size
-    torch.cuda.set_device(
-        device
-    )  # Set the device for the current process. Without this, NCCL will fail when multiple GPUs are available.
+    if torch.cuda.is_available():
+        torch.cuda.set_device(
+            device
+        )  # Set the device for the current process. Without this, NCCL will fail when multiple GPUs are available.
     torch.distributed.init_process_group(
         backend="gloo" if device.type == "cpu" else "nccl",
         init_method=f"tcp://{master_ip_address}:{master_default_process_group_port}",

--- a/examples/link_prediction/heterogeneous_training.py
+++ b/examples/link_prediction/heterogeneous_training.py
@@ -356,7 +356,8 @@ def _training_process(
 
     # We use one training device for each local process
     device = get_available_device(local_process_rank=local_rank)
-
+    if torch.cuda.is_available():
+        torch.cuda.set_device(device)
     logger.info(f"---Rank {rank} training process set device {device}")
     loss_fn = RetrievalLoss(
         loss=torch.nn.CrossEntropyLoss(reduction="mean"),

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -122,7 +122,7 @@ def _inference_process(
     device = gigl.distributed.utils.get_available_device(
         local_process_rank=local_rank,
     )  # The device is automatically inferred based off the local process rank and the available devices
-    if device.type == "cuda":
+    if torch.cuda.is_available():
         # If using GPU, we set the device to the local process rank's GPU
         logger.info(
             f"Using GPU {device} with index {device.index} on local rank: {local_rank} for inference"

--- a/examples/link_prediction/homogeneous_training.py
+++ b/examples/link_prediction/homogeneous_training.py
@@ -315,7 +315,8 @@ def _training_process(
     logger.info(f"---Rank {rank} training process started")
 
     device = get_available_device(local_process_rank=local_rank)
-
+    if torch.cuda.is_available():
+        torch.cuda.set_device(device)
     logger.info(f"---Rank {rank}  training process set device {device}")
 
     logger.info(f"---Rank {rank} training process group initialized")


### PR DESCRIPTION
Without this, we could see issues with NCCL and devices failing.


As a follow up, we should consider renaming `get_available_device` to `setup_device` and have it set the cuda device if applicable, but let's do the less invasive change first. 