### PR TITLE
Fix small issue with train/testing examples

### DIFF
--- a/examples/link_prediction/heterogeneous_training.py
+++ b/examples/link_prediction/heterogeneous_training.py
@@ -521,7 +521,7 @@ def _training_process(
             # We do this so we can use the model without DDP later, e.g. for inference.
             save_state_dict(model=model.unwrap_from_ddp(), save_to_path_uri=model_uri)
 
-    else:  # should_skip training is True, meaning we should only run testing
+    else:  # should_skip_training is True, meaning we should only run testing
         state_dict = load_state_dict_from_uri(load_from_uri=model_uri, device=device)
         model = init_example_gigl_heterogeneous_model(
             node_type_to_feature_dim=node_type_to_feature_dim,

--- a/examples/link_prediction/homogeneous_training.py
+++ b/examples/link_prediction/homogeneous_training.py
@@ -480,7 +480,7 @@ def _training_process(
             # We unwrap the model from DDP to save it
             # We do this so we can use the model without DDP later, e.g. for inference.
             save_state_dict(model=model.unwrap_from_ddp(), save_to_path_uri=model_uri)
-    else:  # should_skip training is True, meaning we should only run testing
+    else:  # should_skip_training is True, meaning we should only run testing
         state_dict = load_state_dict_from_uri(load_from_uri=model_uri, device=device)
         model = init_example_gigl_homogeneous_model(
             node_feature_dim=node_feature_dim,


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
This PR addresses two issues:
- If `should_skip_training` is True, we try to log a `train_start_time` after testing, but it has not been initialized, which causes error.
- If `should_skip_training` is True, we still try to re-save the model to the model uri, which should only be done after training.

We fix this by moving the train_start_time and model saving code to the code which runs if `should_skip_training=False`, and we introduce a time for logging how long the testing takes.

There is also a small consistency change here where we have the code block:
```
    if torch.cuda.is_available():
        torch.cuda.empty_cache()  # Releases all unoccupied cached memory currently held by the caching allocator on the CUDA-enabled GPU
        torch.cuda.synchronize()  # Ensures all CUDA operations have finished
    torch.distributed.barrier()  # Waits for all processes to reach the current point
```
which is currently done before calling `.shutdown()` in train and done after calling `.shutdown()` in test. It's good to be consistent between the two here, and this block should be called before `.shutdown()` in both cases so that we are only shutting down the dataloaders once it is safe to do so (all processes have reached the shutdown stage) and all cached memory is cleaned up before references are lost in `.shutdown()` call.

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
