### PR TITLE
Add label_edge_type_to_message_passing_edge_type

### DIFF
--- a/python/gigl/types/graph.py
+++ b/python/gigl/types/graph.py
@@ -21,8 +21,8 @@ DEFAULT_HOMOGENEOUS_EDGE_TYPE = EdgeType(
     dst_node_type=DEFAULT_HOMOGENEOUS_NODE_TYPE,
 )
 
-_POSITIVE_LABEL_TAG = "gigl_positive"
-_NEGATIVE_LABEL_TAG = "gigl_negative"
+_POSITIVE_LABEL_TAG = "_gigl_positive"
+_NEGATIVE_LABEL_TAG = "_gigl_negative"
 
 # We really should support PyG EdgeType natively but since we type ignore it that's not ideal atm...
 # We can use this TypeVar to try and stem the bleeding (hopefully).
@@ -267,7 +267,7 @@ def message_passing_to_positive_label(
     """
     edge_type = (
         str(message_passing_edge_type[0]),
-        f"{message_passing_edge_type[1]}_{_POSITIVE_LABEL_TAG}",
+        f"{message_passing_edge_type[1]}{_POSITIVE_LABEL_TAG}",
         str(message_passing_edge_type[2]),
     )
     if isinstance(message_passing_edge_type, EdgeType):
@@ -291,7 +291,7 @@ def message_passing_to_negative_label(
     """
     edge_type = (
         str(message_passing_edge_type[0]),
-        f"{message_passing_edge_type[1]}_{_NEGATIVE_LABEL_TAG}",
+        f"{message_passing_edge_type[1]}{_NEGATIVE_LABEL_TAG}",
         str(message_passing_edge_type[2]),
     )
     if isinstance(message_passing_edge_type, EdgeType):
@@ -316,6 +316,23 @@ def is_label_edge_type(
     return _POSITIVE_LABEL_TAG in str(edge_type[1]) or _NEGATIVE_LABEL_TAG in str(
         edge_type[1]
     )
+
+
+def label_edge_type_to_message_passing_edge_type(
+    label_edge_type: _EdgeType,
+) -> _EdgeType:
+    """Convert a label edge type to a message passing edge type."""
+    if not is_label_edge_type(label_edge_type):
+        raise ValueError(f"Edge type {label_edge_type} is not a label edge type.")
+    relation = str(label_edge_type[1])
+    if relation.endswith(_POSITIVE_LABEL_TAG):
+        relation = relation[: -len(_POSITIVE_LABEL_TAG)]
+    elif relation.endswith(_NEGATIVE_LABEL_TAG):
+        relation = relation[: -len(_NEGATIVE_LABEL_TAG)]
+    if isinstance(label_edge_type, EdgeType):
+        return EdgeType(label_edge_type[0], Relation(relation), label_edge_type[2])
+    else:
+        return (label_edge_type[0], relation, label_edge_type[2])
 
 
 def select_label_edge_types(

--- a/python/gigl/types/graph.py
+++ b/python/gigl/types/graph.py
@@ -313,8 +313,9 @@ def is_label_edge_type(
     Returns:
         bool: True if the edge type is a label edge type, False otherwise.
     """
-    return _POSITIVE_LABEL_TAG in str(edge_type[1]) or _NEGATIVE_LABEL_TAG in str(
-        edge_type[1]
+    relation = str(edge_type[1])
+    return relation.endswith(_POSITIVE_LABEL_TAG) or relation.endswith(
+        _NEGATIVE_LABEL_TAG
     )
 
 
@@ -326,9 +327,12 @@ def label_edge_type_to_message_passing_edge_type(
         raise ValueError(f"Edge type {label_edge_type} is not a label edge type.")
     relation = str(label_edge_type[1])
     if relation.endswith(_POSITIVE_LABEL_TAG):
-        relation = relation[: -len(_POSITIVE_LABEL_TAG)]
+        relation = relation.removesuffix(_POSITIVE_LABEL_TAG)
     elif relation.endswith(_NEGATIVE_LABEL_TAG):
-        relation = relation[: -len(_NEGATIVE_LABEL_TAG)]
+        relation = relation.removesuffix(_NEGATIVE_LABEL_TAG)
+    else:
+        raise ValueError(f"Edge type {label_edge_type} is not a label edge type.")
+
     if isinstance(label_edge_type, EdgeType):
         return EdgeType(label_edge_type[0], Relation(relation), label_edge_type[2])
     else:

--- a/python/tests/unit/types_tests/graph_test.py
+++ b/python/tests/unit/types_tests/graph_test.py
@@ -10,6 +10,7 @@ from gigl.types.graph import (
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
     LoadedGraphTensors,
     is_label_edge_type,
+    label_edge_type_to_message_passing_edge_type,
     message_passing_to_negative_label,
     message_passing_to_positive_label,
     select_label_edge_types,
@@ -376,6 +377,69 @@ class GraphTypesTyest(unittest.TestCase):
             self.assertTrue(is_label_edge_type(edge_type=input_edge_type))
         else:
             self.assertFalse(is_label_edge_type(edge_type=input_edge_type))
+
+    @parameterized.expand(
+        [
+            param(
+                "non_label_edge_type_tuple",
+                input_edge_type=("foo", "regular_relation", "bar"),
+            ),
+            param(
+                "non_label_edge_type_edgetype",
+                input_edge_type=EdgeType(
+                    NodeType("foo"), Relation("regular_relation"), NodeType("bar")
+                ),
+            ),
+        ]
+    )
+    def test_label_edge_type_to_message_passing_edge_type_error_cases(
+        self, _, input_edge_type
+    ):
+        """Test that the function raises ValueError for non-label edge types."""
+        with self.assertRaises(ValueError, msg="is not a label edge type"):
+            label_edge_type_to_message_passing_edge_type(input_edge_type)
+
+    @parameterized.expand(
+        [
+            param(
+                "positive_label_tuple",
+                input_edge_type=("foo", "relation_gigl_positive", "bar"),
+                expected_output=("foo", "relation", "bar"),
+            ),
+            param(
+                "negative_label_tuple",
+                input_edge_type=("foo", "relation_gigl_negative", "bar"),
+                expected_output=("foo", "relation", "bar"),
+            ),
+            param(
+                "positive_label_edgetype",
+                input_edge_type=EdgeType(
+                    NodeType("foo"), Relation("relation_gigl_positive"), NodeType("bar")
+                ),
+                expected_output=EdgeType(
+                    NodeType("foo"), Relation("relation"), NodeType("bar")
+                ),
+            ),
+            param(
+                "negative_label_edgetype",
+                input_edge_type=EdgeType(
+                    NodeType("foo"), Relation("relation_gigl_negative"), NodeType("bar")
+                ),
+                expected_output=EdgeType(
+                    NodeType("foo"), Relation("relation"), NodeType("bar")
+                ),
+            ),
+        ]
+    )
+    def test_label_edge_type_to_message_passing_edge_type_valid_cases(
+        self, _, input_edge_type, expected_output
+    ):
+        """Test that the function correctly converts label edge types to message passing edge types."""
+        result = label_edge_type_to_message_passing_edge_type(input_edge_type)
+        self.assertEqual(result, expected_output)
+
+        # Ensure the result type matches the input type
+        self.assertEqual(type(result), type(expected_output))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Scope of work done**
Do this as a precursor to supporting multiple supervision edge types.
You can review this as a self-contained change (even if the end goal isn't obvious from here :P). Essentially this all goes to supporting https://github.com/Snapchat/GiGL/compare/kmonte/multipler-supervision-edges?expand=1#diff-f135690459bff031aa79fbf2b74e95ff2ed1f389b1f9c6d3fd7e8fe819a64e6bR20-R21 

<!-- Description of PR goes here -->
* Add label_edge_type_to_message_passing_edge_type 
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
