### PR TITLE
Allow users to specify custom master nodes for networking utils

### DIFF
--- a/python/tests/unit/distributed/utils/networking_test.py
+++ b/python/tests/unit/distributed/utils/networking_test.py
@@ -1,5 +1,6 @@
 import subprocess
 import unittest
+from unittest.mock import patch
 
 import torch
 import torch.distributed as dist
@@ -7,10 +8,10 @@ import torch.multiprocessing as mp
 from parameterized import param, parameterized
 
 from gigl.distributed.utils import (
-    get_free_port,
     get_free_ports_from_master_node,
     get_internal_ip_from_master_node,
 )
+from tests.test_assets.distributed.utils import get_process_group_init_method
 
 
 def _test_fetching_free_ports_in_dist_context(
@@ -27,6 +28,61 @@ def _test_fetching_free_ports_in_dist_context(
         free_ports: list[int] = get_free_ports_from_master_node(num_ports=num_ports)
         assert len(free_ports) == num_ports
 
+        # Check that all ranks see the same ports broadcasted from master (rank 0)
+        gathered_ports_across_ranks = [
+            torch.zeros(num_ports, dtype=torch.int32) for _ in range(world_size)
+        ]
+        dist.all_gather_object(gathered_ports_across_ranks, free_ports)
+        assert (
+            len(gathered_ports_across_ranks) == world_size
+        ), f"Expected {world_size} ports, but got {len(gathered_ports_across_ranks)}"
+        ports_gathered_at_rank_0 = gathered_ports_across_ranks[0]
+        assert (
+            len(ports_gathered_at_rank_0) == num_ports
+        ), "returned number of ports to match requested number of ports"
+        assert all(
+            port >= 0 for port in ports_gathered_at_rank_0
+        ), "All ports should be non-negative integers"
+        assert all(
+            ports_gathered_at_rank_k == ports_gathered_at_rank_0
+            for ports_gathered_at_rank_k in gathered_ports_across_ranks
+        ), "All ranks should receive the same ports from master (rank 0)"
+    finally:
+        dist.destroy_process_group()
+
+
+def _test_fetching_free_ports_from_master_node_with_master_node_rank(
+    rank: int,
+    world_size: int,
+    init_process_group_init_method: str,
+    num_ports: int,
+    master_node_rank: int,
+    ports: list[int],
+):
+    # Initialize distributed process group
+    dist.init_process_group(
+        backend="gloo",
+        init_method=init_process_group_init_method,
+        world_size=world_size,
+        rank=rank,
+    )
+    try:
+        if rank == master_node_rank:
+            with patch(
+                "gigl.distributed.utils.networking.get_free_ports", return_value=ports
+            ):
+                free_ports: list[int] = get_free_ports_from_master_node(
+                    num_ports=num_ports, master_node_rank=master_node_rank
+                )
+        else:
+            with patch(
+                "gigl.distributed.utils.networking.get_free_ports",
+                side_effect=Exception("Should not be called on non-master node"),
+            ):
+                free_ports = get_free_ports_from_master_node(
+                    num_ports=num_ports, master_node_rank=master_node_rank
+                )
+        assert len(free_ports) == num_ports
         # Check that all ranks see the same ports broadcasted from master (rank 0)
         gathered_ports_across_ranks = [
             torch.zeros(num_ports, dtype=torch.int32) for _ in range(world_size)
@@ -72,6 +128,43 @@ def _test_get_internal_ip_from_master_node_in_dist_context(
         dist.destroy_process_group()
 
 
+def _test_get_internal_ip_from_master_node_in_dist_context_with_master_node_rank(
+    rank: int,
+    world_size: int,
+    init_process_group_init_method: str,
+    expected_ip: str,
+    master_node_rank: int,
+):
+    # Initialize distributed process group
+    dist.init_process_group(
+        backend="gloo",
+        init_method=init_process_group_init_method,
+        world_size=world_size,
+        rank=rank,
+    )
+    print(
+        f"Rank {rank} initialized process group with init method: {init_process_group_init_method}"
+    )
+    try:
+        if rank == master_node_rank:
+            master_ip = get_internal_ip_from_master_node(
+                master_node_rank=master_node_rank
+            )
+        else:
+            with patch(
+                "gigl.distributed.utils.networking.socket.gethostbyname",
+                side_effect=Exception("Should not be called on non-master node"),
+            ):
+                master_ip = get_internal_ip_from_master_node(
+                    master_node_rank=master_node_rank
+                )
+        assert (
+            master_ip == expected_ip
+        ), f"Expected master IP to be {expected_ip}, but got {master_ip}"
+    finally:
+        dist.destroy_process_group()
+
+
 class TestDistributedNetworkingUtils(unittest.TestCase):
     def tearDown(self):
         if dist.is_initialized():
@@ -102,11 +195,44 @@ class TestDistributedNetworkingUtils(unittest.TestCase):
     def test_get_free_ports_from_master_node_two_ranks(
         self, _name, num_ports, world_size
     ):
-        port = get_free_port()
-        init_process_group_init_method = f"tcp://127.0.0.1:{port}"
+        init_process_group_init_method = get_process_group_init_method()
         mp.spawn(
             fn=_test_fetching_free_ports_in_dist_context,
             args=(world_size, init_process_group_init_method, num_ports),
+            nprocs=world_size,
+        )
+
+    @parameterized.expand(
+        [
+            param(
+                "Test fetching 2 ports for world_size = 2 with master_node_rank = 0",
+                num_ports=2,
+                world_size=2,
+                master_node_rank=0,
+                ports=[1, 2],
+            ),
+            param(
+                "Test fetching 2 ports for world_size = 2 with master_node_rank = 1",
+                num_ports=2,
+                world_size=2,
+                master_node_rank=1,
+                ports=[3, 4],
+            ),
+        ]
+    )
+    def test_get_free_ports_from_master_node_two_ranks_custom_master_node_rank(
+        self, _name, num_ports, world_size, master_node_rank, ports
+    ):
+        init_process_group_init_method = get_process_group_init_method()
+        mp.spawn(
+            fn=_test_fetching_free_ports_from_master_node_with_master_node_rank,
+            args=(
+                world_size,
+                init_process_group_init_method,
+                num_ports,
+                master_node_rank,
+                ports,
+            ),
             nprocs=world_size,
         )
 
@@ -118,13 +244,42 @@ class TestDistributedNetworkingUtils(unittest.TestCase):
             get_free_ports_from_master_node(num_ports=1)
 
     def test_get_internal_ip_from_master_node(self):
-        port = get_free_port()
-        init_process_group_init_method = f"tcp://127.0.0.1:{port}"
+        init_process_group_init_method = get_process_group_init_method()
         expected_host_ip = subprocess.check_output(["hostname", "-i"]).decode().strip()
         world_size = 2
         mp.spawn(
             fn=_test_get_internal_ip_from_master_node_in_dist_context,
             args=(world_size, init_process_group_init_method, expected_host_ip),
+            nprocs=world_size,
+        )
+
+    @parameterized.expand(
+        [
+            param(
+                "Getting internal IP from master node with master_node_rank = 0",
+                world_size=2,
+                master_node_rank=0,
+            ),
+            param(
+                "Getting internal IP from master node with master_node_rank = 1",
+                world_size=2,
+                master_node_rank=1,
+            ),
+        ]
+    )
+    def test_get_internal_ip_from_master_node_with_master_node_rank(
+        self, _, world_size, master_node_rank
+    ):
+        init_process_group_init_method = get_process_group_init_method()
+        expected_host_ip = subprocess.check_output(["hostname", "-i"]).decode().strip()
+        mp.spawn(
+            fn=_test_get_internal_ip_from_master_node_in_dist_context_with_master_node_rank,
+            args=(
+                world_size,
+                init_process_group_init_method,
+                expected_host_ip,
+                master_node_rank,
+            ),
             nprocs=world_size,
         )
 


### PR DESCRIPTION
**Scope of work done**

 We do this so in server/client mode we can have a "training" pg for both server and client, but have each server and client communicate with their respective leaders.
 
 e.g for us to determine the ip/port on "training cluster leader" (global rank = 2).

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->
<img width="3358" height="1890" alt="image" src="https://github.com/user-attachments/assets/50e8760a-da82-42cb-9a49-3d0bb84401d3" />

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
