### PR TITLE
Add utility to down_sample node ids based on label

### DIFF
--- a/python/gigl/utils/down_sampler.py
+++ b/python/gigl/utils/down_sampler.py
@@ -11,42 +11,6 @@ from gigl.src.common.types.graph_data import NodeType
 logger = Logger()
 
 
-def down_sample_node_ids_from_labels(
-    node_ids: torch.Tensor,
-    id2idx: torch.Tensor,
-    node_label_feats: torch.Tensor,
-    label_filter_fn: Callable[[torch.Tensor], torch.Tensor] = lambda x: x >= 0,
-) -> torch.Tensor:
-    """
-    Downsample the provided node ids based on the provided node labels. Downsampling means that
-    we will sample a subset of the node ids to use for any downstream purpose. The node label values will be used to
-    determine what gets downsampled, and can be customized with the `label_filter_fn` argument.
-    By default, this will filter out negative label values from the node ids.
-
-    Args:
-        node_ids (torch.Tensor): The node ids to down_sample Should be a 1D tensor of shape (N,).
-        id2idx (torch.Tensor): Mapping from node IDs to indices in the feature tensor. Should be a 1D tensor of shape (max_node_id,).
-        node_label_feats (torch.Tensor): The node label features. Should be a 2D tensor of shape (N, 1), where N is the number of nodes.
-        label_filter_fn (Callable[[torch.Tensor], torch.Tensor]): A callable that takes a tensor of labels of shape [N, 1]
-            and returns a boolean mask of the same [N, 1] shape, indicating which labels should be included. By default,
-            filters out negative values.
-    Returns:
-        torch.Tensor: The down_sampled node ids of shape [M,], where M is the number of down_sampled node ids.
-            Only nodes with valid labels are included in the output.
-    """
-
-    # Use id2idx to get the feature indices directly
-    feature_indices = id2idx[node_ids]
-
-    # Apply the label filter function
-    labels_to_include = label_filter_fn(node_label_feats[feature_indices]).squeeze(-1)
-
-    # Return the down_sampled valid node ids
-    down_sampled_valid_node_ids = node_ids[labels_to_include]
-
-    return down_sampled_valid_node_ids
-
-
 def down_sample_node_ids_from_dataset_labels(
     dataset: DistDataset,
     node_ids: torch.Tensor,
@@ -80,13 +44,8 @@ def down_sample_node_ids_from_dataset_labels(
     else:
         labels = dataset.node_labels
 
-    assert labels.size(0) == node_ids.size(0)
+    labels_to_include = label_filter_fn(labels[node_ids]).squeeze(-1)
 
-    down_sampled_node_ids = down_sample_node_ids_from_labels(
-        node_ids=node_ids,
-        id2idx=labels.id2index,
-        node_label_feats=labels.feature_tensor,
-        label_filter_fn=label_filter_fn,
-    )
+    down_sampled_node_ids = node_ids[labels_to_include]
 
     return down_sampled_node_ids

--- a/python/tests/unit/utils/down_sampler_test.py
+++ b/python/tests/unit/utils/down_sampler_test.py
@@ -8,35 +8,11 @@ from parameterized import param, parameterized
 
 from gigl.distributed.dist_dataset import DistDataset
 from gigl.src.common.types.graph_data import NodeType
-from gigl.utils.down_sampler import (
-    down_sample_node_ids_from_dataset_labels,
-    down_sample_node_ids_from_labels,
-)
+from gigl.utils.down_sampler import down_sample_node_ids_from_dataset_labels
 from tests.test_assets.distributed.utils import assert_tensor_equality
 
 
 class TestNodeLabelDownSampler(unittest.TestCase):
-    def test_basic_down_sampling(self):
-        """Test basic homogeneous down_sampling with default >= 0 filter."""
-
-        node_ids = torch.tensor([0, 20, 10, 3])
-
-        node_label_feats = torch.tensor([1, -1, 2, 4, 1, 6, -1, -2]).unsqueeze(1)
-        node_label_ids = torch.tensor([10, 6, 20, 4, 3, 15, 1, 0])
-
-        id2index = id2idx(node_label_ids)
-
-        down_sampled_node_ids = down_sample_node_ids_from_labels(
-            node_ids=node_ids,
-            id2idx=id2index,
-            node_label_feats=node_label_feats,
-        )
-
-        # 0 has a negative label values and should be excluded. The remaining node ids have positive label values (20 -> 2, 10 -> 1, 3 -> 1) and should be included
-        expected_down_sampled_node_ids = torch.tensor([20, 10, 3])
-
-        assert_tensor_equality(down_sampled_node_ids, expected_down_sampled_node_ids)
-
     @parameterized.expand(
         [
             param(


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- Introduces a utility which downsamples node ids based on labels. This will get called in the training/inference loop by the user if they want to downsample their node IDs.
- Adds tests for introduced utilities
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
