### PR TITLE
Add longer timeout to v1 trainer

### DIFF
--- a/python/gigl/src/training/v1/lib/training_process.py
+++ b/python/gigl/src/training/v1/lib/training_process.py
@@ -52,6 +52,12 @@ from gigl.src.training.v1.lib.base_trainer import BaseTrainer
 
 logger = Logger()
 
+# Without longer timeout, we can see the cluster failing as Vertex AI
+# will start the jobs in a scattered manner, so we may timeout waiting
+# for all machines to come online.
+# TODO(kmonte): We should parameterize this timeout.
+_PROCESS_GROUP_TIMEOUT = datetime.timedelta(minutes=45)
+
 
 @profileit(
     metric_name=TIMER_TRAINER_EXPORT_INFERENCE_ASSETS_S,
@@ -355,16 +361,11 @@ class GnnTrainingProcess:
         use_cuda = device.type != "cpu"
         if should_distribute():
             distributed_backend = get_distributed_backend(use_cuda=use_cuda)
-            # Without longer timeout, we can see the cluster failing as Vertex AI
-            # will start the jobs in a scattered manner, so we may timeout waiting
-            # for all machines to come online.
-            # TODO(kmonte): We should parameterize this timeout.
-            timeout = datetime.timedelta(minutes=45)
             logger.info(
-                f"Using distributed PyTorch with {distributed_backend}, timeout {timeout}"
+                f"Using distributed PyTorch with {distributed_backend}, timeout {_PROCESS_GROUP_TIMEOUT}"
             )
             torch.distributed.init_process_group(
-                backend=distributed_backend, timeout=timeout
+                backend=distributed_backend, timeout=_PROCESS_GROUP_TIMEOUT
             )
             logger.info("Successfully initiated distributed backend!")
 


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
 
Vertex AI may start the training jobs in a scattered manner, e.g. rank 0 starts at time 0, rank 10 starts at time 11, and so rank 0 timesout and crashes.

We should probably parameterize this in the future but in practice the 45 minute timeout is sufficient here.

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

Tested internally succsefully.

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
