### PR TITLE
Add FeatureFlag for not populating embedding field

### DIFF
--- a/python/gigl/src/common/types/pb_wrappers/gbml_config.py
+++ b/python/gigl/src/common/types/pb_wrappers/gbml_config.py
@@ -469,6 +469,9 @@ class GbmlConfigPbWrapper:
         """
         Allows access to should_populate_predictions_path under GbmlConfig
 
+        This flag defaults to False, but can be set to True to populate the predictions path in the InferenceOutput for each entity type.
+        We default this to False since config populator currently does not populate the predictions path for link prediction tasks.
+
         This flag is a temporary workaround to populate the extra embeddings for the same entity type
 
         Returns:
@@ -478,6 +481,26 @@ class GbmlConfigPbWrapper:
             strtobool(
                 dict(self.gbml_config_pb.feature_flags).get(
                     "should_populate_predictions_path", "False"
+                )
+            )
+        )
+
+    @property
+    def should_populate_embeddings_path(self) -> bool:
+        """
+        Allows access to should_populate_embeddings_path under GbmlConfig
+
+        This flag defaults to True, but can be set to False to skip populating embedding paths in InferenceOutput.
+        We default this to True since config populator currently always by default populates the embeddings path
+        for both link prediction and node classification tasks.
+
+        Returns:
+            bool: Whether to populate embeddings path in the InferenceOutput for each entity type
+        """
+        return bool(
+            strtobool(
+                dict(self.gbml_config_pb.feature_flags).get(
+                    "should_populate_embeddings_path", "True"
                 )
             )
         )

--- a/python/gigl/src/config_populator/config_populator.py
+++ b/python/gigl/src/config_populator/config_populator.py
@@ -336,18 +336,21 @@ class ConfigPopulator:
             gbml_config_pb=self.template_gbml_config
         )
         for node_type in inferencer_node_types:
-            embeddings_path = bq_constants.get_embeddings_table(
-                applied_task_identifier=self.applied_task_identifier,
-                node_type=node_type,
-            )
+            embeddings_path: Optional[str] = None
             predictions_path: Optional[str] = None
+
+            if template_gbml_config_pb_wrapper.should_populate_embeddings_path:
+                embeddings_path = bq_constants.get_embeddings_table(
+                    applied_task_identifier=self.applied_task_identifier,
+                    node_type=node_type,
+                )
 
             if (
                 self.task_metadata_pb_wrapper.task_metadata_type
                 == TaskMetadataType.NODE_BASED_TASK
                 or template_gbml_config_pb_wrapper.should_populate_predictions_path
             ):
-                # TODO: currently, we are overloading the predictions path to store extra embeddings.
+                # TODO: currently, we are overloading the predictions path to store extra embeddings for link prediction.
                 # consider extending InferenceOutput's definition for this purpose.
                 predictions_path = bq_constants.get_predictions_table(
                     applied_task_identifier=self.applied_task_identifier,

--- a/python/tests/unit/main.py
+++ b/python/tests/unit/main.py
@@ -2,7 +2,7 @@ import sys
 
 import gigl.src.common.constants.local_fs as local_fs_constants
 from gigl.common import LocalUri
-from gigl.common.utils.test_utils import run_tests
+from gigl.common.utils.test_utils import parse_args, run_tests
 
 
 def run(pattern: str = "*_test.py") -> bool:
@@ -16,5 +16,5 @@ def run(pattern: str = "*_test.py") -> bool:
 
 
 if __name__ == "__main__":
-    was_successful: bool = run(pattern="config_populator_functionality_test.py")
+    was_successful: bool = run(pattern=parse_args().test_file_pattern)
     sys.exit(not was_successful)

--- a/python/tests/unit/main.py
+++ b/python/tests/unit/main.py
@@ -2,7 +2,7 @@ import sys
 
 import gigl.src.common.constants.local_fs as local_fs_constants
 from gigl.common import LocalUri
-from gigl.common.utils.test_utils import parse_args, run_tests
+from gigl.common.utils.test_utils import run_tests
 
 
 def run(pattern: str = "*_test.py") -> bool:
@@ -16,5 +16,5 @@ def run(pattern: str = "*_test.py") -> bool:
 
 
 if __name__ == "__main__":
-    was_successful: bool = run(pattern=parse_args().test_file_pattern)
+    was_successful: bool = run(pattern="config_populator_functionality_test.py")
     sys.exit(not was_successful)


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- Adds a GbmlConfigPbWrapper property for skipping embedding path population in the frozen config during `config_populator`
- Adds tests to ensure the embedding path is not populated with this feature flag
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
