### PR TITLE
Add Bipartite Implementation for LightGCN

### DIFF
--- a/python/tests/unit/nn/models_test.py
+++ b/python/tests/unit/nn/models_test.py
@@ -506,8 +506,8 @@ class TestLightGCN(unittest.TestCase):
             anchor_node_ids=anchor_node_ids,
         )
 
-        # Check shapes - should only return embeddings for anchor nodes
-        self.assertEqual(output_with_anchors[NodeType("user")].shape, (1, self.embedding_dim))
+        # Check that only user embeddings are returned
+        self.assertEqual(output_with_anchors.keys(), set([NodeType("user")]))
 
         # Check values - should match the corresponding rows from full output
         self.assertTrue(


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

- Added Heterogeneous functionality for LightGCN, using `HeteroData` input to `forward`

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

- Added unit test to check final embeddings for bipartite user-item graph
- Added unit test to check anchor-node functionality for a bipartite user-item graph

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
