### PR TITLE
Update splitter names to have `Dist` prefix

### DIFF
--- a/python/gigl/distributed/dataset_factory.py
+++ b/python/gigl/distributed/dataset_factory.py
@@ -44,8 +44,8 @@ from gigl.src.common.types.graph_data import EdgeType
 from gigl.src.common.types.pb_wrappers.gbml_config import GbmlConfigPbWrapper
 from gigl.src.common.types.pb_wrappers.task_metadata import TaskMetadataType
 from gigl.utils.data_splitters import (
-    DistHashedNodeAnchorLinkSplitter,
-    DistHashedNodeSplitter,
+    DistNodeAnchorLinkSplitter,
+    DistNodeSplitter,
     NodeAnchorLinkSplitter,
     NodeSplitter,
     select_ssl_positive_label_edges,
@@ -118,8 +118,8 @@ def _load_and_build_partitioned_dataset(
             # This assert is required while `select_ssl_positive_label_edges` exists out of any splitter. Once this is in transductive splitter,
             # we can remove this assert.
             assert isinstance(
-                splitter, DistHashedNodeAnchorLinkSplitter
-            ), f"Only {DistHashedNodeAnchorLinkSplitter.__name__} supports self-supervised positive label selection, got {type(splitter)}"
+                splitter, DistNodeAnchorLinkSplitter
+            ), f"Only {DistNodeAnchorLinkSplitter.__name__} supports self-supervised positive label selection, got {type(splitter)}"
             positive_label_edges = {}
             for supervision_edge_type in splitter._supervision_edge_types:
                 positive_label_edges[
@@ -282,13 +282,13 @@ def _build_dataset_process(
         master_port=rpc_port,
         num_rpc_threads=16,
     )
-    # DistHashedNodeAnchorLinkSplitter and DistHashedNodeSplitter require rpc to be initialized, so we initialize it here.
+    # DistNodeAnchorLinkSplitter and DistNodeSplitter require rpc to be initialized, so we initialize it here.
     should_teardown_process_group = False
 
     # TODO (mkolodner-sc): Address this code smell to better determine whether we have a distributed splitter without referencing
     # the protocol derivatives directly.
-    if isinstance(splitter, DistHashedNodeAnchorLinkSplitter) or isinstance(
-        splitter, DistHashedNodeSplitter
+    if isinstance(splitter, DistNodeAnchorLinkSplitter) or isinstance(
+        splitter, DistNodeSplitter
     ):
         should_teardown_process_group = True
         torch.distributed.init_process_group(
@@ -548,7 +548,7 @@ def build_dataset_from_task_config_uri(
                 else None  # Pass in None, which uses the default homogeneous edge type for the splitter
             )
             # TODO(kmonte): Maybe we should enable `should_convert_labels_to_edges` as a flag?
-            splitter = DistHashedNodeAnchorLinkSplitter(
+            splitter = DistNodeAnchorLinkSplitter(
                 sampling_direction=sample_edge_direction,
                 supervision_edge_types=supervision_edge_types,
                 should_convert_labels_to_edges=True,
@@ -563,7 +563,7 @@ def build_dataset_from_task_config_uri(
             task_metadata_pb_wrapper.task_metadata_type
             == TaskMetadataType.NODE_BASED_TASK
         ):
-            splitter = DistHashedNodeSplitter(
+            splitter = DistNodeSplitter(
                 num_val=num_val,
                 num_test=num_test,
             )

--- a/python/gigl/utils/data_splitters.py
+++ b/python/gigl/utils/data_splitters.py
@@ -160,7 +160,7 @@ def _fast_hash(x: torch.Tensor) -> torch.Tensor:
     return x
 
 
-class DistHashedNodeAnchorLinkSplitter:
+class DistNodeAnchorLinkSplitter:
     """Selects train, val, and test nodes based on some provided edge index.
 
     NOTE: This splitter must be called when a Torch distributed process group is initialized.
@@ -192,7 +192,7 @@ class DistHashedNodeAnchorLinkSplitter:
         supervision_edge_types: Optional[list[EdgeType]] = None,
         should_convert_labels_to_edges: bool = True,
     ):
-        """Initializes the DistHashedNodeAnchorLinkSplitter.
+        """Initializes the DistNodeAnchorLinkSplitter.
 
         Args:
             sampling_direction (Union[Literal["in", "out"], str]): The direction to sample the nodes. Either "in" or "out".
@@ -396,7 +396,7 @@ class DistHashedNodeAnchorLinkSplitter:
         return self._should_convert_labels_to_edges
 
 
-class DistHashedNodeSplitter:
+class DistNodeSplitter:
     """Selects train, val, and test nodes based on provided node IDs directly.
 
     NOTE: This splitter must be called when a Torch distributed process group is initialized.
@@ -407,9 +407,9 @@ class DistHashedNodeSplitter:
     In node-based splitting, each node will be placed into exactly one split based on its hash value.
     This is simpler than edge-based splitting as it doesn't require extracting anchor nodes from edges.
 
-    Additionally, the DistHashedNodeSplitter does not de-dup repeated node ids. This means that if there are repeated node ids
+    Additionally, the DistNodeSplitter does not de-dup repeated node ids. This means that if there are repeated node ids
     which are passed in, the same number of repeated node ids are included in the output, all of which are put into the same split.
-    This differs from the DistHashedNodeAnchorLinkSplitter, which does de-dup the repeated source or destination nodes that appear from the
+    This differs from the DistNodeAnchorLinkSplitter, which does de-dup the repeated source or destination nodes that appear from the
     labeled edges.
 
 
@@ -426,7 +426,7 @@ class DistHashedNodeSplitter:
         num_test: float = 0.1,
         hash_function: Callable[[torch.Tensor], torch.Tensor] = _fast_hash,
     ):
-        """Initializes the DistHashedNodeSplitter.
+        """Initializes the DistNodeSplitter.
 
         Args:
             num_val (float): The percentage of nodes to use for validation. Defaults to 0.1 (10%).
@@ -500,20 +500,20 @@ class DistHashedNodeSplitter:
             return splits[DEFAULT_HOMOGENEOUS_NODE_TYPE]
 
 
-class HashedNodeAnchorLinkSplitter(DistHashedNodeAnchorLinkSplitter):
+class HashedNodeAnchorLinkSplitter(DistNodeAnchorLinkSplitter):
     def __init__(self, *args, **kwargs):
         logger.warning(
             "gigl.utils.data_splitters.HashedNodeAnchorLinkSplitter is deprecated and will be removed in a future release. "
-            "Please use the `gigl.utils.data_splitters.DistHashedNodeAnchorLinkSplitter` class instead."
+            "Please use the `gigl.utils.data_splitters.DistNodeAnchorLinkSplitter` class instead."
         )
         super(HashedNodeAnchorLinkSplitter, self).__init__(*args, **kwargs)
 
 
-class HashedNodeSplitter(DistHashedNodeSplitter):
+class HashedNodeSplitter(DistNodeSplitter):
     def __init__(self, *args, **kwargs):
         logger.warning(
             "gigl.utils.data_splitters.HashedNodeSplitter is deprecated and will be removed in a future release. "
-            "Please use the `gigl.utils.data_splitters.DistHashedNodeSplitter` class instead."
+            "Please use the `gigl.utils.data_splitters.DistNodeSplitter` class instead."
         )
         super(HashedNodeSplitter, self).__init__(*args, **kwargs)
 

--- a/python/tests/integration/distributed/distributed_dataset_test.py
+++ b/python/tests/integration/distributed/distributed_dataset_test.py
@@ -22,10 +22,7 @@ from gigl.types.graph import (
     DEFAULT_HOMOGENEOUS_EDGE_TYPE,
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
 )
-from gigl.utils.data_splitters import (
-    DistHashedNodeAnchorLinkSplitter,
-    NodeAnchorLinkSplitter,
-)
+from gigl.utils.data_splitters import DistNodeAnchorLinkSplitter, NodeAnchorLinkSplitter
 from tests.test_assets.distributed.run_distributed_dataset import (
     run_distributed_dataset,
 )
@@ -160,7 +157,7 @@ class DistDatasetTestCase(unittest.TestCase):
                 "Test GLT Dataset Split with homogeneous toy NABLP dataset",
                 mocked_dataset_info=TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
                 is_heterogeneous=False,
-                split_fn=DistHashedNodeAnchorLinkSplitter(
+                split_fn=DistNodeAnchorLinkSplitter(
                     sampling_direction="out", should_convert_labels_to_edges=False
                 ),
             ),
@@ -168,7 +165,7 @@ class DistDatasetTestCase(unittest.TestCase):
                 "Test GLT Dataset Load in parallel with heterogeneous toy dataset",
                 mocked_dataset_info=HETEROGENEOUS_TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
                 is_heterogeneous=True,
-                split_fn=DistHashedNodeAnchorLinkSplitter(
+                split_fn=DistNodeAnchorLinkSplitter(
                     sampling_direction="out",
                     supervision_edge_types=[
                         EdgeType(NodeType("story"), Relation("to"), NodeType("user"))
@@ -180,7 +177,7 @@ class DistDatasetTestCase(unittest.TestCase):
                 "Test GLT Dataset Load in parallel with heterogeneous toy NABLP dataset - two supervision edge types",
                 mocked_dataset_info=HETEROGENEOUS_TOY_GRAPH_NODE_ANCHOR_MOCKED_DATASET_INFO,
                 is_heterogeneous=True,
-                split_fn=DistHashedNodeAnchorLinkSplitter(
+                split_fn=DistNodeAnchorLinkSplitter(
                     sampling_direction="out",
                     num_test=1,
                     num_val=1,

--- a/python/tests/unit/distributed/dist_ablp_neighborloader_test.py
+++ b/python/tests/unit/distributed/dist_ablp_neighborloader_test.py
@@ -35,7 +35,7 @@ from gigl.types.graph import (
     to_heterogeneous_node,
     to_homogeneous,
 )
-from gigl.utils.data_splitters import DistHashedNodeAnchorLinkSplitter
+from gigl.utils.data_splitters import DistNodeAnchorLinkSplitter
 from tests.test_assets.distributed.utils import (
     assert_tensor_equality,
     get_process_group_init_method,
@@ -566,7 +566,7 @@ class DistABLPLoaderTest(unittest.TestCase):
             tfrecord_uri_pattern=".*.tfrecord(.gz)?$",
         )
 
-        splitter = DistHashedNodeAnchorLinkSplitter(
+        splitter = DistNodeAnchorLinkSplitter(
             sampling_direction="in", should_convert_labels_to_edges=True
         )
 
@@ -612,7 +612,7 @@ class DistABLPLoaderTest(unittest.TestCase):
             gbml_config_pb_wrapper.task_metadata_pb_wrapper.get_supervision_edge_types()
         )
 
-        splitter = DistHashedNodeAnchorLinkSplitter(
+        splitter = DistNodeAnchorLinkSplitter(
             sampling_direction="in",
             supervision_edge_types=supervision_edge_types,
             should_convert_labels_to_edges=True,
@@ -685,7 +685,7 @@ class DistABLPLoaderTest(unittest.TestCase):
             gbml_config_pb_wrapper.task_metadata_pb_wrapper.get_supervision_edge_types()
         )
 
-        splitter = DistHashedNodeAnchorLinkSplitter(
+        splitter = DistNodeAnchorLinkSplitter(
             sampling_direction="in",
             supervision_edge_types=supervision_edge_types,
             should_convert_labels_to_edges=True,

--- a/python/tests/unit/distributed/distributed_dataset_test.py
+++ b/python/tests/unit/distributed/distributed_dataset_test.py
@@ -42,7 +42,7 @@ from gigl.types.graph import (
     GraphPartitionData,
     PartitionOutput,
 )
-from gigl.utils.data_splitters import DistHashedNodeSplitter
+from gigl.utils.data_splitters import DistNodeSplitter
 from tests.test_assets.distributed.run_distributed_dataset import (
     run_distributed_dataset,
 )
@@ -636,14 +636,14 @@ class DistributedDatasetTestCase(unittest.TestCase):
             ),
             param(
                 "Test building homogeneous dataset with splitter",
-                splitter=DistHashedNodeSplitter(num_val=0.1, num_test=0.1),
+                splitter=DistNodeSplitter(num_val=0.1, num_test=0.1),
             ),
         ]
     )
     def test_build_and_split_cora_dataset_with_node_labels(
         self,
         _,
-        splitter: Optional[DistHashedNodeSplitter],
+        splitter: Optional[DistNodeSplitter],
     ):
         """Test that node labels are properly loaded and accessible for datasets with node labels."""
         port = gigl.distributed.utils.get_free_port()

--- a/python/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/python/tests/unit/distributed/distributed_neighborloader_test.py
@@ -32,10 +32,7 @@ from gigl.types.graph import (
     message_passing_to_positive_label,
     to_homogeneous,
 )
-from gigl.utils.data_splitters import (
-    DistHashedNodeAnchorLinkSplitter,
-    DistHashedNodeSplitter,
-)
+from gigl.utils.data_splitters import DistNodeAnchorLinkSplitter, DistNodeSplitter
 from gigl.utils.iterator import InfiniteIterator
 from tests.test_assets.distributed.run_distributed_dataset import (
     run_distributed_dataset,
@@ -421,7 +418,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             tfrecord_uri_pattern=".*.tfrecord(.gz)?$",
         )
 
-        splitter = DistHashedNodeAnchorLinkSplitter(
+        splitter = DistNodeAnchorLinkSplitter(
             sampling_direction="in", should_convert_labels_to_edges=True
         )
 
@@ -553,7 +550,7 @@ class DistributedNeighborLoaderTest(unittest.TestCase):
             tfrecord_uri_pattern=".*.tfrecord(.gz)?$",
         )
 
-        splitter = DistHashedNodeSplitter()
+        splitter = DistNodeSplitter()
 
         dataset = build_dataset(
             serialized_graph_metadata=serialized_graph_metadata,


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- Addressing tech debt from this comment https://github.com/Snapchat/GiGL/pull/273#discussion_r2283701400, where it was proposed to rename splitters with a `Dist` prefix so that it is more clear they require distributed setup
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
