### PR TITLE
Gowalla BigQuery loader script

### DIFF
--- a/python/gigl/scripts/load_gowalla_to_bq.py
+++ b/python/gigl/scripts/load_gowalla_to_bq.py
@@ -26,19 +26,19 @@ from typing import Final, Iterator
 import google.cloud.bigquery as bigquery
 import requests
 
-from gigl.common import LocalUri, UriFactory
+from gigl.common import UriFactory
 from gigl.common.logger import Logger
 from gigl.src.common.utils.bq import BqUtils
 
 logger = Logger()
 
 # Default URLs for the gowalla dataset files
-DEFAULT_TRAIN_URL: Final[str] = (
-    "https://raw.githubusercontent.com/xiangwang1223/neural_graph_collaborative_filtering/master/Data/gowalla/train.txt"
-)
-DEFAULT_TEST_URL: Final[str] = (
-    "https://raw.githubusercontent.com/xiangwang1223/neural_graph_collaborative_filtering/master/Data/gowalla/test.txt"
-)
+DEFAULT_TRAIN_URL: Final[
+    str
+] = "https://raw.githubusercontent.com/xiangwang1223/neural_graph_collaborative_filtering/master/Data/gowalla/train.txt"
+DEFAULT_TEST_URL: Final[
+    str
+] = "https://raw.githubusercontent.com/xiangwang1223/neural_graph_collaborative_filtering/master/Data/gowalla/test.txt"
 
 # Default column names for the edge table
 DEFAULT_SRC_COLUMN: Final[str] = "from_user_id"
@@ -299,6 +299,7 @@ def main():
         dst_column=args.dst_column,
         recreate_table=not args.no_recreate_table,
     )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

- This is simply a script that reads and parses a subset of the [Gowalla dataset](https://snap.stanford.edu/data/loc-gowalla.html) from [here](https://github.com/xiangwang1223/neural_graph_collaborative_filtering/tree/master/Data/gowalla), as used in the LightGCN paper
- Then, the script loads the data as an edge table to `BigQuery`
- This script can be customized and used for other graphs in `.txt` format

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

- No

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
