### PR TITLE
Remove GLT imports from our example code

### DIFF
--- a/examples/link_prediction/heterogeneous_inference.py
+++ b/examples/link_prediction/heterogeneous_inference.py
@@ -28,7 +28,6 @@ import torch
 import torch.distributed
 import torch.multiprocessing as mp
 from examples.link_prediction.models import init_example_gigl_heterogeneous_model
-from graphlearn_torch.distributed import shutdown_rpc
 
 import gigl.distributed
 import gigl.distributed.utils
@@ -280,9 +279,6 @@ def _inference_process(
     logger.info(
         f"--- All machines local rank {local_rank} finished inference for node type {inference_node_type}. Deleted data loader"
     )
-
-    # Clean up for a graceful exit
-    shutdown_rpc()
 
 
 def _run_example_inference(

--- a/examples/link_prediction/homogeneous_inference.py
+++ b/examples/link_prediction/homogeneous_inference.py
@@ -26,7 +26,6 @@ import time
 import torch
 import torch.multiprocessing as mp
 from examples.link_prediction.models import init_example_gigl_homogeneous_model
-from graphlearn_torch.distributed import shutdown_rpc
 
 import gigl.distributed
 import gigl.distributed.utils
@@ -266,9 +265,6 @@ def _inference_process(
     logger.info(
         f"--- All machines local rank {local_rank} finished inference. Deleted data loader"
     )
-
-    # Clean up for a graceful exit
-    shutdown_rpc()
 
 
 def _run_example_inference(


### PR DESCRIPTION
**Scope of work done**

We should avoid having public usages of the GLT apis as much as possible.
Swapping away from the usages in our examples.

See some [job logs
](https://console.cloud.google.com/logs/query;query=resource.labels.job_id%3D%223689487184844292096%22%20timestamp%3E%3D%222025-11-18T18:42:59.111266Z%22;cursorTimestamp=2025-11-18T18:52:06.332085034Z;duration=PT30M?project=external-snap-ci-github-gigl)  [inference](https://console.cloud.google.com/logs/query;query=resource.labels.job_id%3D%226960226414222114816%22%20timestamp%3E%3D%222025-11-18T18:59:31.681164Z%22;cursorTimestamp=2025-11-18T19:07:53.780731735Z;duration=PT30M?project=external-snap-ci-github-gigl) which are still fine. 
<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
