### PR TITLE
Add types to SortedDict and add tests

### DIFF
--- a/python/gigl/common/collections/sorted_dict.py
+++ b/python/gigl/common/collections/sorted_dict.py
@@ -129,6 +129,9 @@ class SortedDict(Mapping[KT, VT]):
         Returns:
             Iterator[KT]: An iterator over the dictionary keys in sorted order
         """
+        # TODO(kmonte): This is incorrect if we update during iteration.
+        # We should figure out what the correct behavior is.
+        # For now, this should be fine.
         self.__sort_dict_if_needed()
         return iter(self.__dict)
 

--- a/python/tests/unit/common/collections/sorted_dict_test.py
+++ b/python/tests/unit/common/collections/sorted_dict_test.py
@@ -43,26 +43,12 @@ class TestSortedDict(unittest.TestCase):
         keys = list(sd)
         self.assertEqual(keys, self.sorted_keys)
 
-    def test_keys_are_sorted(self) -> None:
-        """Test that keys() method returns sorted keys."""
-        sd: SortedDict[str, int] = SortedDict(self.unsorted_data)
-        keys = list(sd.keys())
-        self.assertEqual(keys, self.sorted_keys)
-
     def test_items_are_sorted_by_key(self) -> None:
         """Test that items() method returns items sorted by key."""
         sd: SortedDict[str, int] = SortedDict(self.unsorted_data)
         items = list(sd.items())
         expected = [("a", 2), ("b", 4), ("m", 3), ("z", 1)]
         self.assertEqual(items, expected)
-
-    def test_values_in_sorted_key_order(self) -> None:
-        """Test that values() method returns values in sorted key order."""
-        sd: SortedDict[str, int] = SortedDict(self.unsorted_data)
-        values = list(sd.values())
-        # Values should correspond to sorted keys: a=2, b=4, m=3, z=1
-        expected = [2, 4, 3, 1]
-        self.assertEqual(values, expected)
 
     def test_getitem(self) -> None:
         """Test item access via bracket notation."""
@@ -215,18 +201,6 @@ class TestSortedDict(unittest.TestCase):
         # Iterate again
         second_keys = list(sd.keys())
         self.assertEqual(second_keys, ["a", "b", "c"])
-
-    def test_multiple_iterations_consistent(self) -> None:
-        """Test that multiple iterations return consistent sorted order."""
-        sd: SortedDict[str, int] = SortedDict(self.unsorted_data)
-
-        first_iteration = list(sd.keys())
-        second_iteration = list(sd.keys())
-        third_iteration = list(sd.keys())
-
-        self.assertEqual(first_iteration, second_iteration)
-        self.assertEqual(second_iteration, third_iteration)
-        self.assertEqual(first_iteration, self.sorted_keys)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Scope of work done**

We should probably start using `SortedDict` more generally, it's useful for distributed setups when we need order to be conistent.

Updated the class with types and also some unit tests :)

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
