### PR TITLE
Be able to check for None flag and empty string flag

### DIFF
--- a/python/gigl/orchestration/kubeflow/runner.py
+++ b/python/gigl/orchestration/kubeflow/runner.py
@@ -146,7 +146,10 @@ def _assert_required_flags(args: argparse.Namespace) -> None:
     for flag in required_flags:
         if not hasattr(args, flag):
             missing_flags.append(flag)
-        elif not getattr(args, flag):
+        flag = getattr(args, flag)
+        if flag is None:
+            missing_flags.append(flag)
+        elif not flag:
             missing_values.append(flag)
 
     if missing_flags:

--- a/python/tests/unit/orchestration/kubeflow/kfp_runner_test.py
+++ b/python/tests/unit/orchestration/kubeflow/kfp_runner_test.py
@@ -78,11 +78,8 @@ class KFPRunnerTest(unittest.TestCase):
                 "--task_config_uri=",
             ]
         )
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(ValueError):
             _assert_required_flags(args)
-
-        self.assertIn("Missing values for the following flags", str(context.exception))
-        self.assertIn("task_config_uri", str(context.exception))
 
     def test_assert_required_flags_none_value(self):
         """Test that _assert_required_flags raises ValueError when a required flag has no value."""
@@ -94,11 +91,8 @@ class KFPRunnerTest(unittest.TestCase):
                 "--resource_config_uri=gs://bucket/resource_config.yaml",
             ]
         )
-        with self.assertRaises(ValueError) as context:
+        with self.assertRaises(ValueError):
             _assert_required_flags(args)
-
-        self.assertIn("Missing values for the following flags", str(context.exception))
-        self.assertIn("task_config_uri", str(context.exception))
 
     def test_assert_required_flags_success(self):
         """Test that _assert_required_flags succeeds when all required flags are present."""


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

Do this so we can error check on both `None` (e.g. unsupplied) flags and empty (e,g, --my_flag="") flags.

Without this change,  the code would error out if a required flag was None since we do `len(None)` and we don't get good error messages. 

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
