### PR TITLE
Id embedding training loop heterogeneous

### DIFF
--- a/examples/id_embeddings/heterogeneous_training.py
+++ b/examples/id_embeddings/heterogeneous_training.py
@@ -1003,7 +1003,7 @@ def _run_example_training(
     learning_rate = float(trainer_args.get("learning_rate", "0.01"))
     weight_decay = float(trainer_args.get("weight_decay", "0.0005"))
     num_max_train_batches = int(trainer_args.get("num_max_train_batches", "1000"))
-    num_max_train_batches = 1000
+    num_max_train_batches = 5000
     num_val_batches = int(trainer_args.get("num_val_batches", "100"))
     val_every_n_batch = int(trainer_args.get("val_every_n_batch", "50"))
 


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

This is my training loop for LightGCN on the gowalla dataset.
There are a number of issues I can't seem to figure out:

1. The dataloaders seem to fail when training (usually at the 17th batch). There is no error it just hangs at line `587`
2. The loss doesn't decrease

I have tried many things to address the loss:

1. Adding a sparse optimizer from TorchRec (RowWiseAdagrad)
2. Added Xavier uniform initialization after discovering the initial embeddings were too small, and thus would not propagate.
3. After the above didn't work, decided to scale up the embeddings after the forward pass, under the assumption that the convolution was shrinking the embeddings too much

I use this command to run the training locally:
`PYTHONWARNINGS=ignore WORLD_SIZE=1 RANK=0 MASTER_ADDR="localhost" MASTER_PORT=20000 python -m GiGL.examples.id_embeddings.heterogeneous_training --task_config_uri="gs://gigl-perm-dev-assets/swong3_gowalla_data_preprocessor_24/config_populator/frozen_gbml_config.yaml"`

The parameters are derived from the task config, but I will list them here for reference:
`Got training args local_world_size=1,         num_neighbors={user-to_train-item: [10, 10], user-to_test-item: [0, 0], item-to_train-user: [15, 15], item-to_test-user: [0, 0]},         sampling_workers_per_process=4,         main_batch_size=16,         random_batch_size=16,         embedding_dim=64,         num_layers=2,         num_random_negs_per_pos=1,         l2_lambda=0.0,         sampling_worker_shared_channel_size=4GB,         process_start_gap_seconds=0,         log_every_n_batch=50,         learning_rate=0.01,         weight_decay=0.0005,         num_max_train_batches=1000,         num_val_batches=100,         val_every_n_batch=50`


<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
