### PR TITLE
[Update Deps] Proto compile working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,6 +310,7 @@ compile_protos:
 	--proto_path=proto \
 	--python_out=./python \
 	--mypy_out=./python \
+	--plugin=protoc-gen-mypy=.venv/bin/protoc-gen-mypy \
 	proto/snapchat/research/gbml/*.proto
 
 	tools/scalapbc/scalapbc-0.11.11/bin/scalapbc \


### PR DESCRIPTION
Following, https://github.com/Snapchat/GiGL/pull/414

Proto compile now does not work for python as mypy lib path needs to be specified which is now installed in venv.