### PR TITLE
Unreferenced partitioned_node_labels fix

### DIFF
--- a/python/gigl/distributed/dist_partitioner.py
+++ b/python/gigl/distributed/dist_partitioner.py
@@ -1678,6 +1678,7 @@ class DistPartitioner:
             )
         else:
             partitioned_node_features = None
+            partitioned_node_labels = None
 
         if self._positive_label_edge_index is not None:
             partitioned_positive_edge_index = self.partition_labels(


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->

In the `partition` method of the `DistPartitioner` class, the following statement exists:
`if self._node_feat is not None or self._node_labels is not None:`

If this statement is false, the `else` block doesn't initialize `partitioned_node_labels`, and this causes a variable reference before assignment error when we try to return this value.

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

No

***Updated Changelog.md?*** NO

***Ready for code review?:*** YES
