### PR TITLE
Add utils to fetch edge types for graph store mode

### DIFF
--- a/python/gigl/distributed/graph_store/storage_utils.py
+++ b/python/gigl/distributed/graph_store/storage_utils.py
@@ -133,7 +133,7 @@ def get_node_ids_for_rank(
     elif isinstance(_dataset.node_ids, dict):
         if node_type is None:
             raise ValueError(
-                f"node_type must be not None for a heterogeneous dataset. Got {node_type}. All node types in the dataset are: {_dataset.node_ids.keys()}"
+                f"node_type must be not None for a heterogeneous dataset. Got {node_type}."
             )
         nodes = _dataset.node_ids[node_type]
     else:
@@ -141,3 +141,17 @@ def get_node_ids_for_rank(
             f"Node ids must be a torch.Tensor or a dict[NodeType, torch.Tensor], got {type(_dataset.node_ids)}"
         )
     return shard_nodes_by_process(nodes, rank, world_size)
+
+
+def get_edge_types() -> Optional[list[EdgeType]]:
+    """Get the edge types from the registered dataset.
+
+    Returns:
+        The edge types in the dataset, None if the dataset is homogeneous.
+    """
+    if _dataset is None:
+        raise _NO_DATASET_ERROR
+    if isinstance(_dataset.graph, dict):
+        return list(_dataset.graph.keys())
+    else:
+        return None

--- a/python/tests/integration/distributed/graph_store/graph_store_integration_test.py
+++ b/python/tests/integration/distributed/graph_store/graph_store_integration_test.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import unittest
+from typing import Optional
 from unittest import mock
 
 import torch
@@ -20,6 +21,7 @@ from gigl.env.distributed import (
     COMPUTE_CLUSTER_LOCAL_WORLD_SIZE_ENV_KEY,
     GraphStoreInfo,
 )
+from gigl.src.common.types.graph_data import EdgeType
 from gigl.src.mocking.lib.versioning import get_mocked_dataset_artifact_metadata
 from gigl.src.mocking.mocking_assets.mocked_datasets_for_pipeline_tests import (
     CORA_USER_DEFINED_NODE_ANCHOR_MOCKED_DATASET_INFO,
@@ -57,6 +59,7 @@ def _run_client_process(
     cluster_info: GraphStoreInfo,
     mp_sharing_dict: dict[str, torch.Tensor],
     expected_sampler_input: dict[int, list[torch.Tensor]],
+    expected_edge_types: Optional[list[EdgeType]],
 ) -> None:
     init_compute_process(client_rank, cluster_info, compute_world_backend="gloo")
 
@@ -104,6 +107,10 @@ def _run_client_process(
     ).get_node_ids()
     _assert_sampler_input(cluster_info, simple_sampler_input, expected_sampler_input)
 
+    assert (
+        remote_dist_dataset.get_edge_types() == expected_edge_types
+    ), f"Expected edge types {expected_edge_types}, got {remote_dist_dataset.get_edge_types()}"
+
     shutdown_compute_proccess()
 
 
@@ -111,6 +118,7 @@ def _client_process(
     client_rank: int,
     cluster_info: GraphStoreInfo,
     expected_sampler_input: dict[int, list[torch.Tensor]],
+    expected_edge_types: Optional[list[EdgeType]],
 ) -> None:
     logger.info(
         f"Initializing client node {client_rank} / {cluster_info.num_compute_nodes}. OS rank: {os.environ['RANK']}, OS world size: {os.environ['WORLD_SIZE']}, local client rank: {client_rank}"
@@ -128,6 +136,7 @@ def _client_process(
                 cluster_info,  # cluster_info
                 mp_sharing_dict,  # mp_sharing_dict
                 expected_sampler_input,  # expected_sampler_input
+                expected_edge_types,  # expected_edge_types
             ],
         )
         client_processes.append(client_process)
@@ -199,7 +208,7 @@ def _get_expected_input_nodes_by_rank(
     return dict(expected_sampler_input)
 
 
-class TestUtils(unittest.TestCase):
+class GraphStoreIntegrationTest(unittest.TestCase):
     def test_graph_store_locally(self):
         # Simulating two server machine, two compute machines.
         # Each machine has one process.
@@ -252,6 +261,7 @@ class TestUtils(unittest.TestCase):
                         i,  # client_rank
                         cluster_info,  # cluster_info
                         expected_sampler_input,  # expected_sampler_input
+                        None,  # expected_edge_types - None for homogeneous dataset
                     ],
                 )
                 client_process.start()

--- a/python/tests/unit/distributed/graph_store/storage_utils_test.py
+++ b/python/tests/unit/distributed/graph_store/storage_utils_test.py
@@ -293,6 +293,23 @@ class TestRemoteDataset(unittest.TestCase):
         edge_feature_info = storage_utils.get_edge_feature_info()
         self.assertEqual(edge_feature_info, dataset.edge_feature_info)
 
+    def test_get_edge_types_homogeneous(self) -> None:
+        """Test get_edge_types with a homogeneous dataset."""
+        dataset = self._create_homogeneous_dataset()
+        storage_utils.register_dataset(dataset)
+        edge_types = storage_utils.get_edge_types()
+        self.assertIsNone(edge_types)
+
+    def test_get_edge_types_heterogeneous(self) -> None:
+        """Test get_edge_types with a heterogeneous dataset."""
+        dataset = self._create_heterogeneous_dataset()
+        storage_utils.register_dataset(dataset)
+        edge_types = storage_utils.get_edge_types()
+        self.assertEqual(
+            edge_types,
+            [(_USER, Relation("to"), _STORY), (_STORY, Relation("to"), _USER)],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Scope of work done**

We need to fetch edge types so we can patch the fanout correctly. 

I was originally going to use `edge_feature_info` but it intentionally does not include edge types which do not have features (ex, label edge types)

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
