### PR TITLE
Add functionallity to select number of servers to sample from

### DIFF
--- a/gigl/distributed/graph_store/dist_server.py
+++ b/gigl/distributed/graph_store/dist_server.py
@@ -281,14 +281,14 @@ class DistServer:
 
         Args:
             request: The node-fetch request, including split, node type,
-                and optional split_idx/num_splits for partitioning.
+                and optional rank/world_size for partitioning.
 
         Returns:
             The node ids.
 
         Raises:
             ValueError:
-                * If split_idx and num_splits are not provided together
+                * If rank and world_size are not provided together
                 * If the split is invalid
                 * If the node ids are not a torch.Tensor or a dict[NodeType, torch.Tensor]
                 * If the node type is provided for a homogeneous dataset
@@ -302,16 +302,16 @@ class DistServer:
         return self._get_node_ids(
             split=request.split,
             node_type=request.node_type,
-            split_idx=request.split_idx,
-            num_splits=request.num_splits,
+            rank=request.rank,
+            world_size=request.world_size,
         )
 
     def _get_node_ids(
         self,
         split: Optional[Union[Literal["train", "val", "test"], str]],
         node_type: Optional[NodeType],
-        split_idx: Optional[int] = None,
-        num_splits: Optional[int] = None,
+        rank: Optional[int] = None,
+        world_size: Optional[int] = None,
     ) -> torch.Tensor:
         """Core implementation for fetching node IDs by split, type, and partitioning.
 
@@ -320,10 +320,10 @@ class DistServer:
                 ``"test"``, or ``None`` for all nodes).
             node_type: The node type to select. Must be ``None`` for
                 homogeneous datasets.
-            split_idx: Which partition to return (0-indexed). Must be
-                provided together with ``num_splits``.
-            num_splits: Total number of partitions. Must be provided
-                together with ``split_idx``.
+            rank: Which partition to return (0-indexed). Must be
+                provided together with ``world_size``.
+            world_size: Total number of partitions. Must be provided
+                together with ``rank``.
 
         Returns:
             The node IDs tensor, optionally partitioned.
@@ -333,10 +333,10 @@ class DistServer:
                 invalid, or the node type is inconsistent with the dataset
                 type (homogeneous vs. heterogeneous).
         """
-        if (split_idx is None) ^ (num_splits is None):
+        if (rank is None) ^ (world_size is None):
             raise ValueError(
-                "split_idx and num_splits must be provided together. "
-                f"Received split_idx={split_idx}, num_splits={num_splits}"
+                "rank and world_size must be provided together. "
+                f"Received rank={rank}, world_size={world_size}"
             )
 
         if split == "train":
@@ -364,8 +364,8 @@ class DistServer:
                 f"node_type was not provided, so node ids must be a torch.Tensor (e.g. a homogeneous dataset), got {type(nodes)}."
             )
 
-        if split_idx is not None and num_splits is not None:
-            return torch.tensor_split(nodes, num_splits)[split_idx]
+        if rank is not None and world_size is not None:
+            return torch.tensor_split(nodes, world_size)[rank]
         return nodes
 
     def get_edge_types(self) -> Optional[list[EdgeType]]:
@@ -398,8 +398,8 @@ class DistServer:
 
         Args:
             request: The ABLP fetch request, including split, node type,
-                supervision edge type, and optional split_idx/num_splits
-                for partitioning.
+                supervision edge type, and optional rank/world_size for
+                partitioning.
 
         Returns:
             A tuple containing the anchor nodes, the positive labels, and the negative labels.
@@ -414,13 +414,13 @@ class DistServer:
         anchors = self._get_node_ids(
             split=request.split,
             node_type=request.node_type,
-            split_idx=request.split_idx,
-            num_splits=request.num_splits,
+            rank=request.rank,
+            world_size=request.world_size,
         )
         positive_label_edge_type, negative_label_edge_type = select_label_edge_types(
             request.supervision_edge_type, self.dataset.get_edge_types()
         )
-        # When num_splits > num_nodes, tensor_split produces empty partitions.
+        # When world_size > num_nodes, tensor_split produces empty partitions.
         # Guard prevents get_labels_for_anchor_nodes from failing on empty input.
         if anchors.numel() == 0:
             empty_positive_labels = torch.empty(0, 0, dtype=torch.int64)

--- a/gigl/distributed/graph_store/dist_server.py
+++ b/gigl/distributed/graph_store/dist_server.py
@@ -40,7 +40,6 @@ from gigl.distributed.graph_store.messages import (
 )
 from gigl.distributed.sampler import ABLPNodeSamplerInput
 from gigl.distributed.sampler_options import SamplerOptions
-from gigl.distributed.utils.neighborloader import shard_nodes_by_process
 from gigl.src.common.types.graph_data import EdgeType, NodeType
 from gigl.types.graph import FeatureInfo, select_label_edge_types
 from gigl.utils.data_splitters import get_labels_for_anchor_nodes
@@ -52,27 +51,6 @@ r""" Interval (in seconds) to check exit status of server.
 logger = Logger()
 
 R = TypeVar("R")
-
-
-def _slice_nodes_for_shard(
-    nodes: torch.Tensor, shard_index: int, num_shards: int
-) -> torch.Tensor:
-    """Return a contiguous local shard with ``torch.tensor_split`` semantics."""
-    if num_shards <= 0:
-        raise ValueError(f"num_shards must be > 0, received {num_shards}")
-    if shard_index < 0 or shard_index >= num_shards:
-        raise ValueError(
-            "shard_index must be in [0, num_shards). "
-            f"Received shard_index={shard_index}, num_shards={num_shards}"
-        )
-
-    num_nodes = nodes.size(0)
-    base_shard_size = num_nodes // num_shards
-    remainder = num_nodes % num_shards
-    start = shard_index * base_shard_size + min(shard_index, remainder)
-    length = base_shard_size + (1 if shard_index < remainder else 0)
-    end = start + length
-    return nodes[start:end]
 
 
 class DistServer:
@@ -303,14 +281,14 @@ class DistServer:
 
         Args:
             request: The node-fetch request, including split, node type,
-                and round-robin rank/world_size.
+                and optional split_idx/num_splits for partitioning.
 
         Returns:
             The node ids.
 
         Raises:
             ValueError:
-                * If the rank and world_size are not provided together
+                * If split_idx and num_splits are not provided together
                 * If the split is invalid
                 * If the node ids are not a torch.Tensor or a dict[NodeType, torch.Tensor]
                 * If the node type is provided for a homogeneous dataset
@@ -324,59 +302,41 @@ class DistServer:
         return self._get_node_ids(
             split=request.split,
             node_type=request.node_type,
-            rank=request.rank,
-            world_size=request.world_size,
-            shard_index=request.shard_index,
-            num_shards=request.num_shards,
+            split_idx=request.split_idx,
+            num_splits=request.num_splits,
         )
 
     def _get_node_ids(
         self,
         split: Optional[Union[Literal["train", "val", "test"], str]],
         node_type: Optional[NodeType],
-        rank: Optional[int] = None,
-        world_size: Optional[int] = None,
-        shard_index: Optional[int] = None,
-        num_shards: Optional[int] = None,
+        split_idx: Optional[int] = None,
+        num_splits: Optional[int] = None,
     ) -> torch.Tensor:
-        """Core implementation for fetching node IDs by split, type, and sharding.
+        """Core implementation for fetching node IDs by split, type, and partitioning.
 
         Args:
             split: The dataset split to fetch from (``"train"``, ``"val"``,
                 ``"test"``, or ``None`` for all nodes).
             node_type: The node type to select. Must be ``None`` for
                 homogeneous datasets.
-            rank: Round-robin rank for sharding. Must be provided together
-                with ``world_size``.
-            world_size: Total number of processes for sharding. Must be
-                provided together with ``rank``.
-            shard_index: Local shard index for storage-rank-local sharding.
-                Must be provided together with ``num_shards``.
-            num_shards: Total number of local shards for this storage rank.
-                Must be provided together with ``shard_index``.
+            split_idx: Which partition to return (0-indexed). Must be
+                provided together with ``num_splits``.
+            num_splits: Total number of partitions. Must be provided
+                together with ``split_idx``.
 
         Returns:
-            The node IDs tensor, optionally sharded by rank.
+            The node IDs tensor, optionally partitioned.
 
         Raises:
-            ValueError: If the sharding inputs are invalid, the split is
+            ValueError: If the split parameters are invalid, the split is
                 invalid, or the node type is inconsistent with the dataset
                 type (homogeneous vs. heterogeneous).
         """
-        if (rank is None) ^ (world_size is None):
+        if (split_idx is None) ^ (num_splits is None):
             raise ValueError(
-                "rank and world_size must be provided together. "
-                f"Received rank={rank}, world_size={world_size}"
-            )
-        if (shard_index is None) ^ (num_shards is None):
-            raise ValueError(
-                "shard_index and num_shards must be provided together. "
-                f"Received shard_index={shard_index}, num_shards={num_shards}"
-            )
-        if rank is not None and shard_index is not None:
-            raise ValueError(
-                "rank/world_size and shard_index/num_shards are mutually exclusive. "
-                f"Received rank={rank}, world_size={world_size}, shard_index={shard_index}, num_shards={num_shards}"
+                "split_idx and num_splits must be provided together. "
+                f"Received split_idx={split_idx}, num_splits={num_splits}"
             )
 
         if split == "train":
@@ -404,10 +364,8 @@ class DistServer:
                 f"node_type was not provided, so node ids must be a torch.Tensor (e.g. a homogeneous dataset), got {type(nodes)}."
             )
 
-        if rank is not None and world_size is not None:
-            return shard_nodes_by_process(nodes, rank, world_size)
-        if shard_index is not None and num_shards is not None:
-            return _slice_nodes_for_shard(nodes, shard_index, num_shards)
+        if split_idx is not None and num_splits is not None:
+            return torch.tensor_split(nodes, num_splits)[split_idx]
         return nodes
 
     def get_edge_types(self) -> Optional[list[EdgeType]]:
@@ -436,17 +394,15 @@ class DistServer:
         self,
         request: FetchABLPInputRequest,
     ) -> tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
-        """Get the ABLP (Anchor Based Link Prediction) input for a specific rank in distributed processing.
-
-        Note: rank and world_size here are for the process group we're *fetching for*, not the process group we're *fetching from*.
-        e.g. if our compute cluster is of world size 4, and we have 2 storage nodes, then the world size this gets called with is 4, not 2.
+        """Get the ABLP (Anchor Based Link Prediction) input for distributed processing.
 
         Args:
             request: The ABLP fetch request, including split, node type,
-                supervision edge type, and round-robin rank/world_size.
+                supervision edge type, and optional split_idx/num_splits
+                for partitioning.
 
         Returns:
-            A tuple containing the anchor nodes for the rank, the positive labels, and the negative labels.
+            A tuple containing the anchor nodes, the positive labels, and the negative labels.
             The positive labels are of shape [N, M], where N is the number of anchor nodes and M is the number of positive labels.
             The negative labels are of shape [N, M], where N is the number of anchor nodes and M is the number of negative labels.
             The negative labels may be None if no negative labels are available.
@@ -458,14 +414,14 @@ class DistServer:
         anchors = self._get_node_ids(
             split=request.split,
             node_type=request.node_type,
-            rank=request.rank,
-            world_size=request.world_size,
-            shard_index=request.shard_index,
-            num_shards=request.num_shards,
+            split_idx=request.split_idx,
+            num_splits=request.num_splits,
         )
         positive_label_edge_type, negative_label_edge_type = select_label_edge_types(
             request.supervision_edge_type, self.dataset.get_edge_types()
         )
+        # When num_splits > num_nodes, tensor_split produces empty partitions.
+        # Guard prevents get_labels_for_anchor_nodes from failing on empty input.
         if anchors.numel() == 0:
             empty_positive_labels = torch.empty(0, 0, dtype=torch.int64)
             empty_negative_labels = (

--- a/gigl/distributed/graph_store/dist_server.py
+++ b/gigl/distributed/graph_store/dist_server.py
@@ -54,6 +54,27 @@ logger = Logger()
 R = TypeVar("R")
 
 
+def _slice_nodes_for_shard(
+    nodes: torch.Tensor, shard_index: int, num_shards: int
+) -> torch.Tensor:
+    """Return a contiguous local shard with ``torch.tensor_split`` semantics."""
+    if num_shards <= 0:
+        raise ValueError(f"num_shards must be > 0, received {num_shards}")
+    if shard_index < 0 or shard_index >= num_shards:
+        raise ValueError(
+            "shard_index must be in [0, num_shards). "
+            f"Received shard_index={shard_index}, num_shards={num_shards}"
+        )
+
+    num_nodes = nodes.size(0)
+    base_shard_size = num_nodes // num_shards
+    remainder = num_nodes % num_shards
+    start = shard_index * base_shard_size + min(shard_index, remainder)
+    length = base_shard_size + (1 if shard_index < remainder else 0)
+    end = start + length
+    return nodes[start:end]
+
+
 class DistServer:
     r"""A server that supports launching remote sampling workers for
     training clients.
@@ -305,6 +326,8 @@ class DistServer:
             node_type=request.node_type,
             rank=request.rank,
             world_size=request.world_size,
+            shard_index=request.shard_index,
+            num_shards=request.num_shards,
         )
 
     def _get_node_ids(
@@ -313,6 +336,8 @@ class DistServer:
         node_type: Optional[NodeType],
         rank: Optional[int] = None,
         world_size: Optional[int] = None,
+        shard_index: Optional[int] = None,
+        num_shards: Optional[int] = None,
     ) -> torch.Tensor:
         """Core implementation for fetching node IDs by split, type, and sharding.
 
@@ -325,19 +350,33 @@ class DistServer:
                 with ``world_size``.
             world_size: Total number of processes for sharding. Must be
                 provided together with ``rank``.
+            shard_index: Local shard index for storage-rank-local sharding.
+                Must be provided together with ``num_shards``.
+            num_shards: Total number of local shards for this storage rank.
+                Must be provided together with ``shard_index``.
 
         Returns:
             The node IDs tensor, optionally sharded by rank.
 
         Raises:
-            ValueError: If rank/world_size are not provided together, the
-                split is invalid, or the node type is inconsistent with
-                the dataset type (homogeneous vs. heterogeneous).
+            ValueError: If the sharding inputs are invalid, the split is
+                invalid, or the node type is inconsistent with the dataset
+                type (homogeneous vs. heterogeneous).
         """
         if (rank is None) ^ (world_size is None):
             raise ValueError(
                 "rank and world_size must be provided together. "
                 f"Received rank={rank}, world_size={world_size}"
+            )
+        if (shard_index is None) ^ (num_shards is None):
+            raise ValueError(
+                "shard_index and num_shards must be provided together. "
+                f"Received shard_index={shard_index}, num_shards={num_shards}"
+            )
+        if rank is not None and shard_index is not None:
+            raise ValueError(
+                "rank/world_size and shard_index/num_shards are mutually exclusive. "
+                f"Received rank={rank}, world_size={world_size}, shard_index={shard_index}, num_shards={num_shards}"
             )
 
         if split == "train":
@@ -367,6 +406,8 @@ class DistServer:
 
         if rank is not None and world_size is not None:
             return shard_nodes_by_process(nodes, rank, world_size)
+        if shard_index is not None and num_shards is not None:
+            return _slice_nodes_for_shard(nodes, shard_index, num_shards)
         return nodes
 
     def get_edge_types(self) -> Optional[list[EdgeType]]:
@@ -419,10 +460,20 @@ class DistServer:
             node_type=request.node_type,
             rank=request.rank,
             world_size=request.world_size,
+            shard_index=request.shard_index,
+            num_shards=request.num_shards,
         )
         positive_label_edge_type, negative_label_edge_type = select_label_edge_types(
             request.supervision_edge_type, self.dataset.get_edge_types()
         )
+        if anchors.numel() == 0:
+            empty_positive_labels = torch.empty(0, 0, dtype=torch.int64)
+            empty_negative_labels = (
+                torch.empty(0, 0, dtype=torch.int64)
+                if negative_label_edge_type is not None
+                else None
+            )
+            return anchors, empty_positive_labels, empty_negative_labels
         positive_labels, negative_labels = get_labels_for_anchor_nodes(
             self.dataset, anchors, positive_label_edge_type, negative_label_edge_type
         )

--- a/gigl/distributed/graph_store/dist_server.py
+++ b/gigl/distributed/graph_store/dist_server.py
@@ -420,16 +420,6 @@ class DistServer:
         positive_label_edge_type, negative_label_edge_type = select_label_edge_types(
             request.supervision_edge_type, self.dataset.get_edge_types()
         )
-        # When world_size > num_nodes, tensor_split produces empty partitions.
-        # Guard prevents get_labels_for_anchor_nodes from failing on empty input.
-        if anchors.numel() == 0:
-            empty_positive_labels = torch.empty(0, 0, dtype=torch.int64)
-            empty_negative_labels = (
-                torch.empty(0, 0, dtype=torch.int64)
-                if negative_label_edge_type is not None
-                else None
-            )
-            return anchors, empty_positive_labels, empty_negative_labels
         positive_labels, negative_labels = get_labels_for_anchor_nodes(
             self.dataset, anchors, positive_label_edge_type, negative_label_edge_type
         )

--- a/gigl/distributed/graph_store/messages.py
+++ b/gigl/distributed/graph_store/messages.py
@@ -6,32 +6,32 @@ from typing import Literal, Optional, Union
 from gigl.src.common.types.graph_data import EdgeType, NodeType
 
 
-def _validate_split_params(
-    split_idx: Optional[int],
-    num_splits: Optional[int],
+def _validate_sharding_params(
+    rank: Optional[int],
+    world_size: Optional[int],
 ) -> None:
-    """Validate that split parameters are consistent.
+    """Validate that sharding parameters are consistent.
 
     Args:
-        split_idx: The index of the split to select.
-        num_splits: The total number of splits.
+        rank: Which partition to select (0-indexed).
+        world_size: Total number of partitions.
 
     Raises:
-        ValueError: If only one of ``split_idx``/``num_splits`` is provided,
+        ValueError: If only one of ``rank``/``world_size`` is provided,
             or if the values are out of range.
     """
-    if (split_idx is None) ^ (num_splits is None):
+    if (rank is None) ^ (world_size is None):
         raise ValueError(
-            "split_idx and num_splits must be provided together. "
-            f"Received split_idx={split_idx}, num_splits={num_splits}"
+            "rank and world_size must be provided together. "
+            f"Received rank={rank}, world_size={world_size}"
         )
-    if split_idx is not None and num_splits is not None:
-        if num_splits <= 0:
-            raise ValueError(f"num_splits must be > 0, received {num_splits}")
-        if split_idx < 0 or split_idx >= num_splits:
+    if rank is not None and world_size is not None:
+        if world_size <= 0:
+            raise ValueError(f"world_size must be > 0, received {world_size}")
+        if rank < 0 or rank >= world_size:
             raise ValueError(
-                "split_idx must be in [0, num_splits). "
-                f"Received split_idx={split_idx}, num_splits={num_splits}"
+                "rank must be in [0, world_size). "
+                f"Received rank={rank}, world_size={world_size}"
             )
 
 
@@ -40,10 +40,10 @@ class FetchNodesRequest:
     """Request for fetching node IDs from a storage server.
 
     Args:
-        split_idx: Which partition of the node IDs to return (0-indexed).
-            Must be provided together with ``num_splits``.
-        num_splits: Total number of partitions.
-            Must be provided together with ``split_idx``.
+        rank: Which partition of the node IDs to return (0-indexed).
+            Must be provided together with ``world_size``.
+        world_size: Total number of partitions.
+            Must be provided together with ``rank``.
         split: The split of the dataset to get node ids from.
         node_type: The type of nodes to get node ids for.
 
@@ -54,27 +54,27 @@ class FetchNodesRequest:
 
         Fetch partition 0 of 4 from training nodes:
 
-        >>> FetchNodesRequest(split_idx=0, num_splits=4, split="train")
+        >>> FetchNodesRequest(rank=0, world_size=4, split="train")
 
         Fetch nodes of a specific type:
 
         >>> FetchNodesRequest(node_type="user")
     """
 
-    split_idx: Optional[int] = None
-    num_splits: Optional[int] = None
+    rank: Optional[int] = None
+    world_size: Optional[int] = None
     split: Optional[Union[Literal["train", "val", "test"], str]] = None
     node_type: Optional[NodeType] = None
 
     def validate(self) -> None:
-        """Validate that the request has consistent split parameters.
+        """Validate that the request has consistent sharding parameters.
 
         Raises:
-            ValueError: If split parameters are partially specified or out of range.
+            ValueError: If sharding parameters are partially specified or out of range.
         """
-        _validate_split_params(
-            split_idx=self.split_idx,
-            num_splits=self.num_splits,
+        _validate_sharding_params(
+            rank=self.rank,
+            world_size=self.world_size,
         )
 
 
@@ -86,10 +86,10 @@ class FetchABLPInputRequest:
         split: The split of the dataset to get ABLP input from.
         node_type: The type of anchor nodes to retrieve.
         supervision_edge_type: The edge type used for supervision.
-        split_idx: Which partition of the anchor nodes to return (0-indexed).
-            Must be provided together with ``num_splits``.
-        num_splits: Total number of partitions.
-            Must be provided together with ``split_idx``.
+        rank: Which partition of the anchor nodes to return (0-indexed).
+            Must be provided together with ``world_size``.
+        world_size: Total number of partitions.
+            Must be provided together with ``rank``.
 
     Examples:
         Fetch training ABLP input without splitting:
@@ -98,22 +98,22 @@ class FetchABLPInputRequest:
 
         Fetch partition 0 of 4 from training ABLP input:
 
-        >>> FetchABLPInputRequest(split="train", node_type="user", supervision_edge_type=("user", "to", "item"), split_idx=0, num_splits=4)
+        >>> FetchABLPInputRequest(split="train", node_type="user", supervision_edge_type=("user", "to", "item"), rank=0, world_size=4)
     """
 
     split: Union[Literal["train", "val", "test"], str]
     node_type: NodeType
     supervision_edge_type: EdgeType
-    split_idx: Optional[int] = None
-    num_splits: Optional[int] = None
+    rank: Optional[int] = None
+    world_size: Optional[int] = None
 
     def validate(self) -> None:
-        """Validate that the request has consistent split parameters.
+        """Validate that the request has consistent sharding parameters.
 
         Raises:
-            ValueError: If split parameters are partially specified or out of range.
+            ValueError: If sharding parameters are partially specified or out of range.
         """
-        _validate_split_params(
-            split_idx=self.split_idx,
-            num_splits=self.num_splits,
+        _validate_sharding_params(
+            rank=self.rank,
+            world_size=self.world_size,
         )

--- a/gigl/distributed/graph_store/messages.py
+++ b/gigl/distributed/graph_store/messages.py
@@ -6,35 +6,32 @@ from typing import Literal, Optional, Union
 from gigl.src.common.types.graph_data import EdgeType, NodeType
 
 
-def _validate_sharding_mode(
-    rank: Optional[int],
-    world_size: Optional[int],
-    shard_index: Optional[int],
-    num_shards: Optional[int],
+def _validate_split_params(
+    split_idx: Optional[int],
+    num_splits: Optional[int],
 ) -> None:
-    """Validate that requests use at most one sharding mode."""
-    if (rank is None) ^ (world_size is None):
+    """Validate that split parameters are consistent.
+
+    Args:
+        split_idx: The index of the split to select.
+        num_splits: The total number of splits.
+
+    Raises:
+        ValueError: If only one of ``split_idx``/``num_splits`` is provided,
+            or if the values are out of range.
+    """
+    if (split_idx is None) ^ (num_splits is None):
         raise ValueError(
-            "rank and world_size must be provided together. "
-            f"Received rank={rank}, world_size={world_size}"
+            "split_idx and num_splits must be provided together. "
+            f"Received split_idx={split_idx}, num_splits={num_splits}"
         )
-    if (shard_index is None) ^ (num_shards is None):
-        raise ValueError(
-            "shard_index and num_shards must be provided together. "
-            f"Received shard_index={shard_index}, num_shards={num_shards}"
-        )
-    if rank is not None and shard_index is not None:
-        raise ValueError(
-            "rank/world_size and shard_index/num_shards are mutually exclusive. "
-            f"Received rank={rank}, world_size={world_size}, shard_index={shard_index}, num_shards={num_shards}"
-        )
-    if shard_index is not None and num_shards is not None:
-        if num_shards <= 0:
-            raise ValueError(f"num_shards must be > 0, received {num_shards}")
-        if shard_index < 0 or shard_index >= num_shards:
+    if split_idx is not None and num_splits is not None:
+        if num_splits <= 0:
+            raise ValueError(f"num_splits must be > 0, received {num_splits}")
+        if split_idx < 0 or split_idx >= num_splits:
             raise ValueError(
-                "shard_index must be in [0, num_shards). "
-                f"Received shard_index={shard_index}, num_shards={num_shards}"
+                "split_idx must be in [0, num_splits). "
+                f"Received split_idx={split_idx}, num_splits={num_splits}"
             )
 
 
@@ -43,49 +40,41 @@ class FetchNodesRequest:
     """Request for fetching node IDs from a storage server.
 
     Args:
-        rank: The rank of the process requesting node ids.
-            Must be provided together with ``world_size``.
-        world_size: The total number of processes in the distributed setup.
-            Must be provided together with ``rank``.
-        shard_index: The local shard index to fetch from this storage rank.
-            Must be provided together with ``num_shards``.
-        num_shards: The total number of local shards for this storage rank.
-            Must be provided together with ``shard_index``.
+        split_idx: Which partition of the node IDs to return (0-indexed).
+            Must be provided together with ``num_splits``.
+        num_splits: Total number of partitions.
+            Must be provided together with ``split_idx``.
         split: The split of the dataset to get node ids from.
         node_type: The type of nodes to get node ids for.
 
     Examples:
-        Fetch all nodes without sharding:
+        Fetch all nodes without splitting:
 
         >>> FetchNodesRequest()
 
-        Fetch training nodes for rank 0 of 4:
+        Fetch partition 0 of 4 from training nodes:
 
-        >>> FetchNodesRequest(rank=0, world_size=4, split="train")
+        >>> FetchNodesRequest(split_idx=0, num_splits=4, split="train")
 
         Fetch nodes of a specific type:
 
         >>> FetchNodesRequest(node_type="user")
     """
 
-    rank: Optional[int] = None
-    world_size: Optional[int] = None
-    shard_index: Optional[int] = None
-    num_shards: Optional[int] = None
+    split_idx: Optional[int] = None
+    num_splits: Optional[int] = None
     split: Optional[Union[Literal["train", "val", "test"], str]] = None
     node_type: Optional[NodeType] = None
 
     def validate(self) -> None:
-        """Validate that the request has a consistent sharding mode.
+        """Validate that the request has consistent split parameters.
 
         Raises:
-            ValueError: If the request mixes or partially specifies sharding modes.
+            ValueError: If split parameters are partially specified or out of range.
         """
-        _validate_sharding_mode(
-            rank=self.rank,
-            world_size=self.world_size,
-            shard_index=self.shard_index,
-            num_shards=self.num_shards,
+        _validate_split_params(
+            split_idx=self.split_idx,
+            num_splits=self.num_splits,
         )
 
 
@@ -97,42 +86,34 @@ class FetchABLPInputRequest:
         split: The split of the dataset to get ABLP input from.
         node_type: The type of anchor nodes to retrieve.
         supervision_edge_type: The edge type used for supervision.
-        rank: The rank of the process requesting ABLP input.
-            Must be provided together with ``world_size``.
-        world_size: The total number of processes in the distributed setup.
-            Must be provided together with ``rank``.
-        shard_index: The local shard index to fetch from this storage rank.
-            Must be provided together with ``num_shards``.
-        num_shards: The total number of local shards for this storage rank.
-            Must be provided together with ``shard_index``.
+        split_idx: Which partition of the anchor nodes to return (0-indexed).
+            Must be provided together with ``num_splits``.
+        num_splits: Total number of partitions.
+            Must be provided together with ``split_idx``.
 
     Examples:
-        Fetch training ABLP input without sharding:
+        Fetch training ABLP input without splitting:
 
-        >>> FetchABLPRequest(split="train", node_type="user", supervision_edge_type=("user", "to", "item"))
+        >>> FetchABLPInputRequest(split="train", node_type="user", supervision_edge_type=("user", "to", "item"))
 
-        Fetch training ABLP input for rank 0 of 4:
+        Fetch partition 0 of 4 from training ABLP input:
 
-        >>> FetchABLPRequest(split="train", node_type="user", supervision_edge_type=("user", "to", "item"), rank=0, world_size=4)
+        >>> FetchABLPInputRequest(split="train", node_type="user", supervision_edge_type=("user", "to", "item"), split_idx=0, num_splits=4)
     """
 
     split: Union[Literal["train", "val", "test"], str]
     node_type: NodeType
     supervision_edge_type: EdgeType
-    rank: Optional[int] = None
-    world_size: Optional[int] = None
-    shard_index: Optional[int] = None
-    num_shards: Optional[int] = None
+    split_idx: Optional[int] = None
+    num_splits: Optional[int] = None
 
     def validate(self) -> None:
-        """Validate that the request has a consistent sharding mode.
+        """Validate that the request has consistent split parameters.
 
         Raises:
-            ValueError: If the request mixes or partially specifies sharding modes.
+            ValueError: If split parameters are partially specified or out of range.
         """
-        _validate_sharding_mode(
-            rank=self.rank,
-            world_size=self.world_size,
-            shard_index=self.shard_index,
-            num_shards=self.num_shards,
+        _validate_split_params(
+            split_idx=self.split_idx,
+            num_splits=self.num_splits,
         )

--- a/gigl/distributed/graph_store/messages.py
+++ b/gigl/distributed/graph_store/messages.py
@@ -6,6 +6,38 @@ from typing import Literal, Optional, Union
 from gigl.src.common.types.graph_data import EdgeType, NodeType
 
 
+def _validate_sharding_mode(
+    rank: Optional[int],
+    world_size: Optional[int],
+    shard_index: Optional[int],
+    num_shards: Optional[int],
+) -> None:
+    """Validate that requests use at most one sharding mode."""
+    if (rank is None) ^ (world_size is None):
+        raise ValueError(
+            "rank and world_size must be provided together. "
+            f"Received rank={rank}, world_size={world_size}"
+        )
+    if (shard_index is None) ^ (num_shards is None):
+        raise ValueError(
+            "shard_index and num_shards must be provided together. "
+            f"Received shard_index={shard_index}, num_shards={num_shards}"
+        )
+    if rank is not None and shard_index is not None:
+        raise ValueError(
+            "rank/world_size and shard_index/num_shards are mutually exclusive. "
+            f"Received rank={rank}, world_size={world_size}, shard_index={shard_index}, num_shards={num_shards}"
+        )
+    if shard_index is not None and num_shards is not None:
+        if num_shards <= 0:
+            raise ValueError(f"num_shards must be > 0, received {num_shards}")
+        if shard_index < 0 or shard_index >= num_shards:
+            raise ValueError(
+                "shard_index must be in [0, num_shards). "
+                f"Received shard_index={shard_index}, num_shards={num_shards}"
+            )
+
+
 @dataclass(frozen=True)
 class FetchNodesRequest:
     """Request for fetching node IDs from a storage server.
@@ -15,6 +47,10 @@ class FetchNodesRequest:
             Must be provided together with ``world_size``.
         world_size: The total number of processes in the distributed setup.
             Must be provided together with ``rank``.
+        shard_index: The local shard index to fetch from this storage rank.
+            Must be provided together with ``num_shards``.
+        num_shards: The total number of local shards for this storage rank.
+            Must be provided together with ``shard_index``.
         split: The split of the dataset to get node ids from.
         node_type: The type of nodes to get node ids for.
 
@@ -34,20 +70,23 @@ class FetchNodesRequest:
 
     rank: Optional[int] = None
     world_size: Optional[int] = None
+    shard_index: Optional[int] = None
+    num_shards: Optional[int] = None
     split: Optional[Union[Literal["train", "val", "test"], str]] = None
     node_type: Optional[NodeType] = None
 
     def validate(self) -> None:
-        """Validate that the request has consistent rank/world_size.
+        """Validate that the request has a consistent sharding mode.
 
         Raises:
-            ValueError: If only one of ``rank`` or ``world_size`` is provided.
+            ValueError: If the request mixes or partially specifies sharding modes.
         """
-        if (self.rank is None) ^ (self.world_size is None):
-            raise ValueError(
-                "rank and world_size must be provided together. "
-                f"Received rank={self.rank}, world_size={self.world_size}"
-            )
+        _validate_sharding_mode(
+            rank=self.rank,
+            world_size=self.world_size,
+            shard_index=self.shard_index,
+            num_shards=self.num_shards,
+        )
 
 
 @dataclass(frozen=True)
@@ -62,6 +101,10 @@ class FetchABLPInputRequest:
             Must be provided together with ``world_size``.
         world_size: The total number of processes in the distributed setup.
             Must be provided together with ``rank``.
+        shard_index: The local shard index to fetch from this storage rank.
+            Must be provided together with ``num_shards``.
+        num_shards: The total number of local shards for this storage rank.
+            Must be provided together with ``shard_index``.
 
     Examples:
         Fetch training ABLP input without sharding:
@@ -78,15 +121,18 @@ class FetchABLPInputRequest:
     supervision_edge_type: EdgeType
     rank: Optional[int] = None
     world_size: Optional[int] = None
+    shard_index: Optional[int] = None
+    num_shards: Optional[int] = None
 
     def validate(self) -> None:
-        """Validate that the request has consistent rank/world_size.
+        """Validate that the request has a consistent sharding mode.
 
         Raises:
-            ValueError: If only one of ``rank`` or ``world_size`` is provided.
+            ValueError: If the request mixes or partially specifies sharding modes.
         """
-        if (self.rank is None) ^ (self.world_size is None):
-            raise ValueError(
-                "rank and world_size must be provided together. "
-                f"Received rank={self.rank}, world_size={self.world_size}"
-            )
+        _validate_sharding_mode(
+            rank=self.rank,
+            world_size=self.world_size,
+            shard_index=self.shard_index,
+            num_shards=self.num_shards,
+        )

--- a/gigl/distributed/graph_store/remote_dist_dataset.py
+++ b/gigl/distributed/graph_store/remote_dist_dataset.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Literal, Optional, Union, cast
 
 import torch
@@ -23,12 +24,26 @@ from gigl.utils.sampling import ABLPInputNodes
 logger = Logger()
 
 
+@dataclass(frozen=True)
+class StorageRankShardAssignment:
+    """Describes how a compute rank should shard data from a single storage rank.
+
+    Args:
+        rank: This compute rank's shard index among the compute ranks sharing
+            the storage rank (0-indexed).
+        world_size: Total number of compute ranks sharing the storage rank.
+    """
+
+    rank: int
+    world_size: int
+
+
 def _plan_storage_rank_shards_for_compute_rank(
     rank: int,
     world_size: int,
     num_storage_nodes: int,
     num_assigned_storage_ranks: int,
-) -> tuple[dict[int, list[int]], dict[int, list[int]], dict[int, tuple[int, int]]]:
+) -> dict[int, StorageRankShardAssignment]:
     """Plan which storage ranks a compute rank contacts and its local shard within each.
 
     Each compute rank is assigned ``num_assigned_storage_ranks`` storage ranks
@@ -50,12 +65,9 @@ def _plan_storage_rank_shards_for_compute_rank(
         num_assigned_storage_ranks: Number of storage ranks each compute rank contacts.
 
     Returns:
-        A 3-tuple:
-            - compute_rank_to_storage_ranks: Maps every compute rank to its assigned storage ranks.
-            - storage_rank_to_compute_ranks: Maps every storage rank to the compute ranks that contact it.
-            - storage_rank_to_local_shard: For the given ``rank`` only, maps each assigned storage rank
-              to ``(shard_index, num_shards)`` where ``shard_index`` is this rank's position among
-              the compute ranks sharing that storage rank.
+        A dict mapping each assigned storage rank to a
+        :class:`StorageRankShardAssignment` describing this compute rank's
+        shard within that storage rank.
 
     Raises:
         ValueError: If arguments are out of range or coverage cannot be guaranteed.
@@ -99,19 +111,15 @@ def _plan_storage_rank_shards_for_compute_rank(
         for storage_rank in storage_ranks:
             storage_rank_to_compute_ranks[storage_rank].append(compute_rank)
 
-    storage_rank_to_local_shard: dict[int, tuple[int, int]] = {}
+    result: dict[int, StorageRankShardAssignment] = {}
     for storage_rank in compute_rank_to_storage_ranks[rank]:
         assigned_compute_ranks = storage_rank_to_compute_ranks[storage_rank]
-        storage_rank_to_local_shard[storage_rank] = (
-            assigned_compute_ranks.index(rank),
-            len(assigned_compute_ranks),
+        result[storage_rank] = StorageRankShardAssignment(
+            rank=assigned_compute_ranks.index(rank),
+            world_size=len(assigned_compute_ranks),
         )
 
-    return (
-        compute_rank_to_storage_ranks,
-        storage_rank_to_compute_ranks,
-        storage_rank_to_local_shard,
-    )
+    return result
 
 
 class RemoteDistDataset:
@@ -273,17 +281,13 @@ class RemoteDistDataset:
                     f"Received rank={rank}, world_size={world_size}, "
                     f"num_assigned_storage_ranks={num_assigned_storage_ranks}"
                 )
-            (
-                compute_rank_to_storage_ranks,
-                _,
-                storage_rank_to_local_shard,
-            ) = _plan_storage_rank_shards_for_compute_rank(
+            shard_assignments = _plan_storage_rank_shards_for_compute_rank(
                 rank=rank,
                 world_size=world_size,
                 num_storage_nodes=self.cluster_info.num_storage_nodes,
                 num_assigned_storage_ranks=num_assigned_storage_ranks,
             )
-            requested_storage_ranks = compute_rank_to_storage_ranks[rank]
+            requested_storage_ranks = list(shard_assignments.keys())
         else:
             requested_storage_ranks = list(range(self.cluster_info.num_storage_nodes))
 
@@ -306,12 +310,12 @@ class RemoteDistDataset:
                 requests.append(request)
         else:
             for storage_rank in requested_storage_ranks:
-                shard_index, num_shards = storage_rank_to_local_shard[storage_rank]
+                assignment = shard_assignments[storage_rank]
                 request = FetchNodesRequest(
                     split=split,
                     node_type=node_type,
-                    rank=shard_index,
-                    world_size=num_shards,
+                    rank=assignment.rank,
+                    world_size=assignment.world_size,
                 )
                 request.validate()
                 requests.append(request)
@@ -503,17 +507,13 @@ class RemoteDistDataset:
                     f"Received rank={rank}, world_size={world_size}, "
                     f"num_assigned_storage_ranks={num_assigned_storage_ranks}"
                 )
-            (
-                compute_rank_to_storage_ranks,
-                _,
-                storage_rank_to_local_shard,
-            ) = _plan_storage_rank_shards_for_compute_rank(
+            shard_assignments = _plan_storage_rank_shards_for_compute_rank(
                 rank=rank,
                 world_size=world_size,
                 num_storage_nodes=self.cluster_info.num_storage_nodes,
                 num_assigned_storage_ranks=num_assigned_storage_ranks,
             )
-            requested_storage_ranks = compute_rank_to_storage_ranks[rank]
+            requested_storage_ranks = list(shard_assignments.keys())
         else:
             requested_storage_ranks = list(range(self.cluster_info.num_storage_nodes))
 
@@ -536,13 +536,13 @@ class RemoteDistDataset:
                 requests.append(request)
         else:
             for storage_rank in requested_storage_ranks:
-                shard_index, num_shards = storage_rank_to_local_shard[storage_rank]
+                assignment = shard_assignments[storage_rank]
                 request = FetchABLPInputRequest(
                     split=split,
                     node_type=node_type,
                     supervision_edge_type=supervision_edge_type,
-                    rank=shard_index,
-                    world_size=num_shards,
+                    rank=assignment.rank,
+                    world_size=assignment.world_size,
                 )
                 request.validate()
                 requests.append(request)

--- a/gigl/distributed/graph_store/remote_dist_dataset.py
+++ b/gigl/distributed/graph_store/remote_dist_dataset.py
@@ -297,8 +297,8 @@ class RemoteDistDataset:
         if num_assigned_storage_ranks is None:
             for storage_rank in requested_storage_ranks:
                 request = FetchNodesRequest(
-                    split_idx=rank,
-                    num_splits=world_size,
+                    rank=rank,
+                    world_size=world_size,
                     split=split,
                     node_type=node_type,
                 )
@@ -310,8 +310,8 @@ class RemoteDistDataset:
                 request = FetchNodesRequest(
                     split=split,
                     node_type=node_type,
-                    split_idx=shard_index,
-                    num_splits=num_shards,
+                    rank=shard_index,
+                    world_size=num_shards,
                 )
                 request.validate()
                 requests.append(request)
@@ -527,8 +527,8 @@ class RemoteDistDataset:
             for storage_rank in requested_storage_ranks:
                 request = FetchABLPInputRequest(
                     split=split,
-                    split_idx=rank,
-                    num_splits=world_size,
+                    rank=rank,
+                    world_size=world_size,
                     node_type=node_type,
                     supervision_edge_type=supervision_edge_type,
                 )
@@ -541,8 +541,8 @@ class RemoteDistDataset:
                     split=split,
                     node_type=node_type,
                     supervision_edge_type=supervision_edge_type,
-                    split_idx=shard_index,
-                    num_splits=num_shards,
+                    rank=shard_index,
+                    world_size=num_shards,
                 )
                 request.validate()
                 requests.append(request)

--- a/gigl/distributed/graph_store/remote_dist_dataset.py
+++ b/gigl/distributed/graph_store/remote_dist_dataset.py
@@ -23,6 +23,67 @@ from gigl.utils.sampling import ABLPInputNodes
 logger = Logger()
 
 
+def _plan_storage_rank_shards_for_compute_rank(
+    rank: int,
+    world_size: int,
+    num_storage_nodes: int,
+    num_assigned_storage_ranks: int,
+) -> tuple[dict[int, list[int]], dict[int, list[int]], dict[int, tuple[int, int]]]:
+    """Plan storage-rank assignments and local shard ownership for one compute rank."""
+    if world_size <= 0:
+        raise ValueError(f"world_size must be > 0, received {world_size}")
+    if num_storage_nodes <= 0:
+        raise ValueError(f"num_storage_nodes must be > 0, received {num_storage_nodes}")
+    if rank < 0 or rank >= world_size:
+        raise ValueError(
+            f"rank must be in [0, world_size), received rank={rank}, world_size={world_size}"
+        )
+    if (
+        num_assigned_storage_ranks <= 0
+        or num_assigned_storage_ranks > num_storage_nodes
+    ):
+        raise ValueError(
+            "num_assigned_storage_ranks must be in [1, num_storage_nodes], "
+            f"received num_assigned_storage_ranks={num_assigned_storage_ranks}, num_storage_nodes={num_storage_nodes}"
+        )
+    if world_size * num_assigned_storage_ranks < num_storage_nodes:
+        raise ValueError(
+            "world_size * num_assigned_storage_ranks must be >= num_storage_nodes "
+            "to guarantee exact coverage. "
+            f"Received world_size={world_size}, num_assigned_storage_ranks={num_assigned_storage_ranks}, "
+            f"num_storage_nodes={num_storage_nodes}"
+        )
+
+    compute_rank_to_storage_ranks: dict[int, list[int]] = {}
+    for compute_rank in range(world_size):
+        start_storage_rank = (compute_rank * num_storage_nodes) // world_size
+        compute_rank_to_storage_ranks[compute_rank] = [
+            (start_storage_rank + offset) % num_storage_nodes
+            for offset in range(num_assigned_storage_ranks)
+        ]
+
+    storage_rank_to_compute_ranks: dict[int, list[int]] = {
+        storage_rank: [] for storage_rank in range(num_storage_nodes)
+    }
+    for compute_rank, storage_ranks in compute_rank_to_storage_ranks.items():
+        for storage_rank in storage_ranks:
+            storage_rank_to_compute_ranks[storage_rank].append(compute_rank)
+
+    storage_rank_to_local_shard: dict[int, tuple[int, int]] = {}
+    for storage_rank in compute_rank_to_storage_ranks[rank]:
+        assigned_compute_ranks = storage_rank_to_compute_ranks[storage_rank]
+        storage_rank_to_local_shard[storage_rank] = (
+            assigned_compute_ranks.index(rank),
+            len(assigned_compute_ranks),
+        )
+
+    return (
+        compute_rank_to_storage_ranks,
+        storage_rank_to_compute_ranks,
+        storage_rank_to_local_shard,
+    )
+
+
 class RemoteDistDataset:
     def __init__(
         self,
@@ -169,30 +230,77 @@ class RemoteDistDataset:
         world_size: Optional[int] = None,
         node_type: Optional[NodeType] = None,
         split: Optional[Literal["train", "val", "test"]] = None,
+        num_assigned_storage_ranks: Optional[int] = None,
     ) -> dict[int, torch.Tensor]:
         """Fetches node ids from the storage nodes for the current compute node (machine)."""
-        futures: list[torch.futures.Future[torch.Tensor]] = []
+        requested_storage_ranks: list[int]
+        requests: list[FetchNodesRequest] = []
+
+        if num_assigned_storage_ranks is not None:
+            if rank is None or world_size is None:
+                raise ValueError(
+                    "num_assigned_storage_ranks requires rank and world_size. "
+                    f"Received rank={rank}, world_size={world_size}, "
+                    f"num_assigned_storage_ranks={num_assigned_storage_ranks}"
+                )
+            (
+                compute_rank_to_storage_ranks,
+                _,
+                storage_rank_to_local_shard,
+            ) = _plan_storage_rank_shards_for_compute_rank(
+                rank=rank,
+                world_size=world_size,
+                num_storage_nodes=self.cluster_info.num_storage_nodes,
+                num_assigned_storage_ranks=num_assigned_storage_ranks,
+            )
+            requested_storage_ranks = compute_rank_to_storage_ranks[rank]
+        else:
+            requested_storage_ranks = list(range(self.cluster_info.num_storage_nodes))
+
         node_type = self._infer_node_type_if_homogeneous_with_label_edges(node_type)
 
         logger.info(
-            f"Getting node ids for rank {rank} / {world_size} with node type {node_type} and split {split}"
+            f"Getting node ids for rank {rank} / {world_size} with node type {node_type}, "
+            f"split {split}, and num_assigned_storage_ranks {num_assigned_storage_ranks}"
         )
 
-        for server_rank in range(self.cluster_info.num_storage_nodes):
+        if num_assigned_storage_ranks is None:
+            for storage_rank in requested_storage_ranks:
+                request = FetchNodesRequest(
+                    rank=rank,
+                    world_size=world_size,
+                    split=split,
+                    node_type=node_type,
+                )
+                request.validate()
+                requests.append(request)
+        else:
+            for storage_rank in requested_storage_ranks:
+                shard_index, num_shards = storage_rank_to_local_shard[storage_rank]
+                request = FetchNodesRequest(
+                    split=split,
+                    node_type=node_type,
+                    shard_index=shard_index,
+                    num_shards=num_shards,
+                )
+                request.validate()
+                requests.append(request)
+
+        futures: list[torch.futures.Future[torch.Tensor]] = []
+        for storage_rank, request in zip(requested_storage_ranks, requests):
             futures.append(
                 async_request_server(
-                    server_rank,
+                    storage_rank,
                     DistServer.get_node_ids,
-                    FetchNodesRequest(
-                        rank=rank,
-                        world_size=world_size,
-                        split=split,
-                        node_type=node_type,
-                    ),
+                    request,
                 )
             )
-            node_ids = torch.futures.wait_all(futures)
-        return {server_rank: node_ids for server_rank, node_ids in enumerate(node_ids)}
+
+        node_ids = torch.futures.wait_all(futures)
+        return {
+            storage_rank: node_id
+            for storage_rank, node_id in zip(requested_storage_ranks, node_ids)
+        }
 
     def fetch_node_ids(
         self,
@@ -200,6 +308,7 @@ class RemoteDistDataset:
         world_size: Optional[int] = None,
         split: Optional[Literal["train", "val", "test"]] = None,
         node_type: Optional[NodeType] = None,
+        num_assigned_storage_ranks: Optional[int] = None,
     ) -> dict[int, torch.Tensor]:
         """
         Fetches node ids from the storage nodes for the current compute node (machine).
@@ -215,9 +324,14 @@ class RemoteDistDataset:
                 If provided, the dataset must have `train_node_ids`, `val_node_ids`, and `test_node_ids` properties.
             node_type (Optional[NodeType]): The type of nodes to get.
                 Must be provided for heterogeneous datasets.
+            num_assigned_storage_ranks (Optional[int]): If provided, limit this compute rank
+                to exactly this many storage ranks while preserving exact global coverage.
+                Requires ``rank`` and ``world_size``.
 
         Returns:
-            dict[int, torch.Tensor]: A dict mapping storage rank to node ids.
+            dict[int, torch.Tensor]: A dict mapping storage rank to node ids. When
+                ``num_assigned_storage_ranks`` is set, only the assigned storage
+                ranks are returned.
 
         Examples:
             Suppose we have 2 storage nodes and 2 compute nodes, with 16 total nodes.
@@ -260,12 +374,25 @@ class RemoteDistDataset:
                 1: tensor([8, 9])   # First 2 of 4 training nodes from storage rank 1
             }
 
+            Limit a compute rank to only 1 assigned storage rank:
+
+            >>> dataset.fetch_node_ids(rank=0, world_size=4, num_assigned_storage_ranks=1)
+            {
+                0: tensor([...])  # Only storage rank 0 is queried for compute rank 0
+            }
+
         Note:
             When `split=None`, all nodes are queryable. This means nodes from any split
             (train, val, or test) may be returned. This is useful when you need to sample
             neighbors during inference, as neighbor nodes may belong to any split.
         """
-        return self._fetch_node_ids(rank, world_size, node_type, split)
+        return self._fetch_node_ids(
+            rank=rank,
+            world_size=world_size,
+            node_type=node_type,
+            split=split,
+            num_assigned_storage_ranks=num_assigned_storage_ranks,
+        )
 
     def fetch_free_ports_on_storage_cluster(self, num_ports: int) -> list[int]:
         """
@@ -312,36 +439,81 @@ class RemoteDistDataset:
         world_size: Optional[int] = None,
         node_type: NodeType = DEFAULT_HOMOGENEOUS_NODE_TYPE,
         supervision_edge_type: EdgeType = DEFAULT_HOMOGENEOUS_EDGE_TYPE,
+        num_assigned_storage_ranks: Optional[int] = None,
     ) -> dict[int, tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]]:
         """Fetches ABLP input from the storage nodes for the current compute node (machine)."""
+        requested_storage_ranks: list[int]
+        requests: list[FetchABLPInputRequest] = []
+
+        if num_assigned_storage_ranks is not None:
+            if rank is None or world_size is None:
+                raise ValueError(
+                    "num_assigned_storage_ranks requires rank and world_size. "
+                    f"Received rank={rank}, world_size={world_size}, "
+                    f"num_assigned_storage_ranks={num_assigned_storage_ranks}"
+                )
+            (
+                compute_rank_to_storage_ranks,
+                _,
+                storage_rank_to_local_shard,
+            ) = _plan_storage_rank_shards_for_compute_rank(
+                rank=rank,
+                world_size=world_size,
+                num_storage_nodes=self.cluster_info.num_storage_nodes,
+                num_assigned_storage_ranks=num_assigned_storage_ranks,
+            )
+            requested_storage_ranks = compute_rank_to_storage_ranks[rank]
+        else:
+            requested_storage_ranks = list(range(self.cluster_info.num_storage_nodes))
+
+        logger.info(
+            f"Getting ABLP input for rank {rank} / {world_size} with node type {node_type}, "
+            f"split {split}, supervision edge type {supervision_edge_type}, "
+            f"and num_assigned_storage_ranks {num_assigned_storage_ranks}"
+        )
+
+        if num_assigned_storage_ranks is None:
+            for storage_rank in requested_storage_ranks:
+                request = FetchABLPInputRequest(
+                    split=split,
+                    rank=rank,
+                    world_size=world_size,
+                    node_type=node_type,
+                    supervision_edge_type=supervision_edge_type,
+                )
+                request.validate()
+                requests.append(request)
+        else:
+            for storage_rank in requested_storage_ranks:
+                shard_index, num_shards = storage_rank_to_local_shard[storage_rank]
+                request = FetchABLPInputRequest(
+                    split=split,
+                    node_type=node_type,
+                    supervision_edge_type=supervision_edge_type,
+                    shard_index=shard_index,
+                    num_shards=num_shards,
+                )
+                request.validate()
+                requests.append(request)
+
         futures: list[
             torch.futures.Future[
                 tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]
             ]
         ] = []
-        logger.info(
-            f"Getting ABLP input for rank {rank} / {world_size} with node type {node_type}, "
-            f"split {split}, and supervision edge type {supervision_edge_type}"
-        )
-
-        for server_rank in range(self.cluster_info.num_storage_nodes):
+        for storage_rank, request in zip(requested_storage_ranks, requests):
             futures.append(
                 async_request_server(
-                    server_rank,
+                    storage_rank,
                     DistServer.get_ablp_input,
-                    FetchABLPInputRequest(
-                        split=split,
-                        rank=rank,
-                        world_size=world_size,
-                        node_type=node_type,
-                        supervision_edge_type=supervision_edge_type,
-                    ),
+                    request,
                 )
             )
-            ablp_inputs = torch.futures.wait_all(futures)
+
+        ablp_inputs = torch.futures.wait_all(futures)
         return {
-            server_rank: ablp_input
-            for server_rank, ablp_input in enumerate(ablp_inputs)
+            storage_rank: ablp_input
+            for storage_rank, ablp_input in zip(requested_storage_ranks, ablp_inputs)
         }
 
     # TODO(#488) - support multiple supervision edge types
@@ -352,6 +524,7 @@ class RemoteDistDataset:
         world_size: Optional[int] = None,
         anchor_node_type: Optional[NodeType] = None,
         supervision_edge_type: Optional[EdgeType] = None,
+        num_assigned_storage_ranks: Optional[int] = None,
     ) -> dict[int, ABLPInputNodes]:
         """
         Fetches ABLP (Anchor Based Link Prediction) input from the storage nodes.
@@ -379,6 +552,9 @@ class RemoteDistDataset:
                 Must be provided for heterogeneous graphs.
                 Must be None for labeled homogeneous graphs.
                 Defaults to None.
+            num_assigned_storage_ranks (Optional[int]): If provided, limit this compute
+                rank to exactly this many storage ranks while preserving exact global
+                coverage. Requires ``rank`` and ``world_size``.
 
         Returns:
             dict[int, ABLPInputNodes]:
@@ -387,6 +563,8 @@ class RemoteDistDataset:
                 - anchor_nodes: 1D tensor of anchor node IDs for the split.
                 - positive_labels: Dict mapping positive label EdgeType to a 2D tensor [N, M].
                 - negative_labels: Optional dict mapping negative label EdgeType to a 2D tensor [N, M].
+                When ``num_assigned_storage_ranks`` is set, only the assigned storage
+                ranks are returned.
 
         Examples:
             Suppose we have 1 storage node with users [0, 1, 2, 3, 4] where:
@@ -430,6 +608,7 @@ class RemoteDistDataset:
             world_size=world_size,
             node_type=evaluated_anchor_node_type,
             supervision_edge_type=evaluated_supervision_edge_type,
+            num_assigned_storage_ranks=num_assigned_storage_ranks,
         )
         return {
             server_rank: ABLPInputNodes(

--- a/gigl/distributed/graph_store/remote_dist_dataset.py
+++ b/gigl/distributed/graph_store/remote_dist_dataset.py
@@ -39,8 +39,8 @@ class StorageRankShardAssignment:
 
 
 def _plan_storage_rank_shards_for_compute_rank(
-    rank: int,
-    world_size: int,
+    rank: Optional[int],
+    world_size: Optional[int],
     num_storage_nodes: int,
     num_assigned_storage_ranks: int,
 ) -> dict[int, StorageRankShardAssignment]:
@@ -55,8 +55,8 @@ def _plan_storage_rank_shards_for_compute_rank(
     ensuring exact global coverage.
 
     Args:
-        rank: The current compute rank.
-        world_size: Total number of compute ranks.
+        rank: The current compute rank. Must not be ``None``.
+        world_size: Total number of compute ranks. Must not be ``None``.
         num_storage_nodes: Total number of storage nodes in the cluster.
         num_assigned_storage_ranks: Number of storage ranks each compute rank contacts.
 
@@ -66,8 +66,14 @@ def _plan_storage_rank_shards_for_compute_rank(
         shard within that storage rank.
 
     Raises:
-        ValueError: If arguments are out of range or coverage cannot be guaranteed.
+        ValueError: If arguments are out of range, ``None``, or coverage cannot be guaranteed.
     """
+    if rank is None or world_size is None:
+        raise ValueError(
+            "num_assigned_storage_ranks requires rank and world_size. "
+            f"Received rank={rank}, world_size={world_size}, "
+            f"num_assigned_storage_ranks={num_assigned_storage_ranks}"
+        )
     if world_size <= 0:
         raise ValueError(f"world_size must be > 0, received {world_size}")
     if num_storage_nodes <= 0:
@@ -92,6 +98,8 @@ def _plan_storage_rank_shards_for_compute_rank(
             f"num_storage_nodes={num_storage_nodes}"
         )
 
+    # Assign each compute rank its storage ranks via round-robin from an evenly-spaced start.
+    # e.g. 3 compute, 4 storage, 2 assigned: {c0: [s0,s1], c1: [s1,s2], c2: [s2,s3]}
     compute_rank_to_storage_ranks: dict[int, list[int]] = {}
     for compute_rank in range(world_size):
         start_storage_rank = (compute_rank * num_storage_nodes) // world_size
@@ -100,6 +108,8 @@ def _plan_storage_rank_shards_for_compute_rank(
             for offset in range(num_assigned_storage_ranks)
         ]
 
+    # Invert the mapping to find which compute ranks share each storage rank.
+    # e.g. {s0: [c0], s1: [c0,c1], s2: [c1,c2], s3: [c2]}
     storage_rank_to_compute_ranks: dict[int, list[int]] = {
         storage_rank: [] for storage_rank in range(num_storage_nodes)
     }
@@ -107,6 +117,8 @@ def _plan_storage_rank_shards_for_compute_rank(
         for storage_rank in storage_ranks:
             storage_rank_to_compute_ranks[storage_rank].append(compute_rank)
 
+    # For this rank's assigned storage ranks, determine its shard index and shard count.
+    # e.g. rank=c1 contacts [s1,s2]: s1 shared by [c0,c1] → shard 1/2, s2 shared by [c1,c2] → shard 0/2
     result: dict[int, StorageRankShardAssignment] = {}
     for storage_rank in compute_rank_to_storage_ranks[rank]:
         assigned_compute_ranks = storage_rank_to_compute_ranks[storage_rank]
@@ -269,12 +281,6 @@ class RemoteDistDataset:
         """Fetches node ids from the storage nodes for the current compute node (machine)."""
 
         if num_assigned_storage_ranks is not None:
-            if rank is None or world_size is None:
-                raise ValueError(
-                    "num_assigned_storage_ranks requires rank and world_size. "
-                    f"Received rank={rank}, world_size={world_size}, "
-                    f"num_assigned_storage_ranks={num_assigned_storage_ranks}"
-                )
             shard_assignments = _plan_storage_rank_shards_for_compute_rank(
                 rank=rank,
                 world_size=world_size,
@@ -293,27 +299,25 @@ class RemoteDistDataset:
         )
 
         requests: list[FetchNodesRequest] = []
-        if num_assigned_storage_ranks is None:
-            for storage_rank in requested_storage_ranks:
-                request = FetchNodesRequest(
-                    rank=rank,
-                    world_size=world_size,
-                    split=split,
-                    node_type=node_type,
-                )
-                request.validate()
-                requests.append(request)
-        else:
-            for storage_rank in requested_storage_ranks:
+        for storage_rank in requested_storage_ranks:
+            effective_rank: Optional[int]
+            effective_world_size: Optional[int]
+            if num_assigned_storage_ranks is not None:
                 assignment = shard_assignments[storage_rank]
-                request = FetchNodesRequest(
-                    split=split,
-                    node_type=node_type,
-                    rank=assignment.rank,
-                    world_size=assignment.world_size,
+                effective_rank, effective_world_size = (
+                    assignment.rank,
+                    assignment.world_size,
                 )
-                request.validate()
-                requests.append(request)
+            else:
+                effective_rank, effective_world_size = rank, world_size
+            request = FetchNodesRequest(
+                split=split,
+                node_type=node_type,
+                rank=effective_rank,
+                world_size=effective_world_size,
+            )
+            request.validate()
+            requests.append(request)
 
         futures: list[torch.futures.Future[torch.Tensor]] = []
         for storage_rank, request in zip(requested_storage_ranks, requests):
@@ -496,12 +500,6 @@ class RemoteDistDataset:
         requests: list[FetchABLPInputRequest] = []
 
         if num_assigned_storage_ranks is not None:
-            if rank is None or world_size is None:
-                raise ValueError(
-                    "num_assigned_storage_ranks requires rank and world_size. "
-                    f"Received rank={rank}, world_size={world_size}, "
-                    f"num_assigned_storage_ranks={num_assigned_storage_ranks}"
-                )
             shard_assignments = _plan_storage_rank_shards_for_compute_rank(
                 rank=rank,
                 world_size=world_size,
@@ -518,29 +516,26 @@ class RemoteDistDataset:
             f"and num_assigned_storage_ranks {num_assigned_storage_ranks}"
         )
 
-        if num_assigned_storage_ranks is None:
-            for storage_rank in requested_storage_ranks:
-                request = FetchABLPInputRequest(
-                    split=split,
-                    rank=rank,
-                    world_size=world_size,
-                    node_type=node_type,
-                    supervision_edge_type=supervision_edge_type,
-                )
-                request.validate()
-                requests.append(request)
-        else:
-            for storage_rank in requested_storage_ranks:
+        for storage_rank in requested_storage_ranks:
+            effective_rank: Optional[int]
+            effective_world_size: Optional[int]
+            if num_assigned_storage_ranks is not None:
                 assignment = shard_assignments[storage_rank]
-                request = FetchABLPInputRequest(
-                    split=split,
-                    node_type=node_type,
-                    supervision_edge_type=supervision_edge_type,
-                    rank=assignment.rank,
-                    world_size=assignment.world_size,
+                effective_rank, effective_world_size = (
+                    assignment.rank,
+                    assignment.world_size,
                 )
-                request.validate()
-                requests.append(request)
+            else:
+                effective_rank, effective_world_size = rank, world_size
+            request = FetchABLPInputRequest(
+                split=split,
+                node_type=node_type,
+                supervision_edge_type=supervision_edge_type,
+                rank=effective_rank,
+                world_size=effective_world_size,
+            )
+            request.validate()
+            requests.append(request)
 
         futures: list[
             torch.futures.Future[

--- a/gigl/distributed/graph_store/remote_dist_dataset.py
+++ b/gigl/distributed/graph_store/remote_dist_dataset.py
@@ -271,8 +271,6 @@ class RemoteDistDataset:
         num_assigned_storage_ranks: Optional[int] = None,
     ) -> dict[int, torch.Tensor]:
         """Fetches node ids from the storage nodes for the current compute node (machine)."""
-        requested_storage_ranks: list[int]
-        requests: list[FetchNodesRequest] = []
 
         if num_assigned_storage_ranks is not None:
             if rank is None or world_size is None:
@@ -287,7 +285,7 @@ class RemoteDistDataset:
                 num_storage_nodes=self.cluster_info.num_storage_nodes,
                 num_assigned_storage_ranks=num_assigned_storage_ranks,
             )
-            requested_storage_ranks = list(shard_assignments.keys())
+            requested_storage_ranks: list[int] = list(shard_assignments.keys())
         else:
             requested_storage_ranks = list(range(self.cluster_info.num_storage_nodes))
 
@@ -298,6 +296,7 @@ class RemoteDistDataset:
             f"split {split}, and num_assigned_storage_ranks {num_assigned_storage_ranks}"
         )
 
+        requests: list[FetchNodesRequest] = []
         if num_assigned_storage_ranks is None:
             for storage_rank in requested_storage_ranks:
                 request = FetchNodesRequest(
@@ -366,7 +365,7 @@ class RemoteDistDataset:
                 to guarantee all storage nodes are sampled from.
 
                 Typical values are 1-4. Lower values reduce cross-cluster network fanout
-                at the cost of potentially less balanced data distribution per compute rank.
+                at the cost of potentially starving compute ranks if there are more storage nodes than the number of compute ranks.
                 ``None`` (the default) contacts all storage nodes.
 
         Returns:
@@ -603,10 +602,16 @@ class RemoteDistDataset:
                 Must be provided for heterogeneous graphs.
                 Must be None for labeled homogeneous graphs.
                 Defaults to None.
-            num_assigned_storage_ranks (Optional[int]): If provided, limit this compute
-                rank to exactly this many storage ranks while preserving exact global
-                coverage. Requires ``rank`` and ``world_size``.
+            num_assigned_storage_ranks (Optional[int]): If provided, limit this compute rank
+                to exactly this many storage ranks while preserving exact global coverage.
+                Requires ``rank`` and ``world_size``.
 
+                Must satisfy ``world_size * num_assigned_storage_ranks >= num_storage_nodes``
+                to guarantee all storage nodes are sampled from.
+
+                Typical values are 1-4. Lower values reduce cross-cluster network fanout
+                at the cost of potentially starving compute ranks if there are more storage nodes than the number of compute ranks.
+                ``None`` (the default) contacts all storage nodes.
         Returns:
             dict[int, ABLPInputNodes]:
                 A dict mapping storage rank to an ABLPInputNodes containing:

--- a/gigl/distributed/graph_store/remote_dist_dataset.py
+++ b/gigl/distributed/graph_store/remote_dist_dataset.py
@@ -374,11 +374,25 @@ class RemoteDistDataset:
                 1: tensor([8, 9])   # First 2 of 4 training nodes from storage rank 1
             }
 
-            Limit a compute rank to only 1 assigned storage rank:
+            Limit each compute rank to 1 assigned storage rank (4 compute ranks, 2 storage nodes).
+            Ranks 0-1 are assigned to storage 0; ranks 2-3 are assigned to storage 1.
+            Each storage node's data is contiguously split among its assigned compute ranks:
 
             >>> dataset.fetch_node_ids(rank=0, world_size=4, num_assigned_storage_ranks=1)
             {
-                0: tensor([...])  # Only storage rank 0 is queried for compute rank 0
+                0: tensor([0, 1, 2, 3])       # Storage 0, shard 0 of 2
+            }
+            >>> dataset.fetch_node_ids(rank=1, world_size=4, num_assigned_storage_ranks=1)
+            {
+                0: tensor([4, 5, 6, 7])       # Storage 0, shard 1 of 2
+            }
+            >>> dataset.fetch_node_ids(rank=2, world_size=4, num_assigned_storage_ranks=1)
+            {
+                1: tensor([8, 9, 10, 11])     # Storage 1, shard 0 of 2
+            }
+            >>> dataset.fetch_node_ids(rank=3, world_size=4, num_assigned_storage_ranks=1)
+            {
+                1: tensor([12, 13, 14, 15])   # Storage 1, shard 1 of 2
             }
 
         Note:
@@ -584,6 +598,37 @@ class RemoteDistDataset:
             }
 
             For labeled homogeneous graphs, anchor_node_type will be DEFAULT_HOMOGENEOUS_NODE_TYPE.
+
+            Limit each compute rank to 1 assigned storage rank (2 compute ranks, 2 storage nodes).
+            Suppose we have 2 storage nodes with train anchors and labels:
+
+                Storage rank 0: train anchors=[0, 1, 2]
+                Storage rank 1: train anchors=[3, 4]
+
+            >>> dataset.fetch_ablp_input(
+            ...     split="train", rank=0, world_size=2,
+            ...     anchor_node_type=USER, supervision_edge_type=USER_TO_ITEM,
+            ...     num_assigned_storage_ranks=1,
+            ... )
+            {
+                0: ABLPInputNodes(
+                    anchor_nodes=tensor([0, 1, 2]),
+                    labels={("user", "to_positive", "item"): (pos_labels, neg_labels)},
+                    anchor_node_type="user",
+                )
+            }
+            >>> dataset.fetch_ablp_input(
+            ...     split="train", rank=1, world_size=2,
+            ...     anchor_node_type=USER, supervision_edge_type=USER_TO_ITEM,
+            ...     num_assigned_storage_ranks=1,
+            ... )
+            {
+                1: ABLPInputNodes(
+                    anchor_nodes=tensor([3, 4]),
+                    labels={("user", "to_positive", "item"): (pos_labels, neg_labels)},
+                    anchor_node_type="user",
+                )
+            }
 
         """
 

--- a/gigl/distributed/graph_store/remote_dist_dataset.py
+++ b/gigl/distributed/graph_store/remote_dist_dataset.py
@@ -29,7 +29,37 @@ def _plan_storage_rank_shards_for_compute_rank(
     num_storage_nodes: int,
     num_assigned_storage_ranks: int,
 ) -> tuple[dict[int, list[int]], dict[int, list[int]], dict[int, tuple[int, int]]]:
-    """Plan storage-rank assignments and local shard ownership for one compute rank."""
+    """Plan which storage ranks a compute rank contacts and its local shard within each.
+
+    Each compute rank is assigned ``num_assigned_storage_ranks`` storage ranks
+    using a round-robin scheme starting from an evenly-spaced offset
+    (``compute_rank * num_storage_nodes // world_size``).
+
+    The reverse mapping tells us how many compute ranks share each storage rank.
+    For the given ``rank``, its local shard within a shared storage rank is its
+    position in the sorted list of compute ranks assigned to that storage rank.
+
+    The constraint ``world_size * num_assigned_storage_ranks >= num_storage_nodes``
+    guarantees that every storage rank is contacted by at least one compute rank,
+    ensuring exact global coverage.
+
+    Args:
+        rank: The current compute rank.
+        world_size: Total number of compute ranks.
+        num_storage_nodes: Total number of storage nodes in the cluster.
+        num_assigned_storage_ranks: Number of storage ranks each compute rank contacts.
+
+    Returns:
+        A 3-tuple:
+            - compute_rank_to_storage_ranks: Maps every compute rank to its assigned storage ranks.
+            - storage_rank_to_compute_ranks: Maps every storage rank to the compute ranks that contact it.
+            - storage_rank_to_local_shard: For the given ``rank`` only, maps each assigned storage rank
+              to ``(shard_index, num_shards)`` where ``shard_index`` is this rank's position among
+              the compute ranks sharing that storage rank.
+
+    Raises:
+        ValueError: If arguments are out of range or coverage cannot be guaranteed.
+    """
     if world_size <= 0:
         raise ValueError(f"world_size must be > 0, received {world_size}")
     if num_storage_nodes <= 0:
@@ -49,7 +79,7 @@ def _plan_storage_rank_shards_for_compute_rank(
     if world_size * num_assigned_storage_ranks < num_storage_nodes:
         raise ValueError(
             "world_size * num_assigned_storage_ranks must be >= num_storage_nodes "
-            "to guarantee exact coverage. "
+            "to guarantee all storage nodes are sampled from. "
             f"Received world_size={world_size}, num_assigned_storage_ranks={num_assigned_storage_ranks}, "
             f"num_storage_nodes={num_storage_nodes}"
         )
@@ -267,8 +297,8 @@ class RemoteDistDataset:
         if num_assigned_storage_ranks is None:
             for storage_rank in requested_storage_ranks:
                 request = FetchNodesRequest(
-                    rank=rank,
-                    world_size=world_size,
+                    split_idx=rank,
+                    num_splits=world_size,
                     split=split,
                     node_type=node_type,
                 )
@@ -280,8 +310,8 @@ class RemoteDistDataset:
                 request = FetchNodesRequest(
                     split=split,
                     node_type=node_type,
-                    shard_index=shard_index,
-                    num_shards=num_shards,
+                    split_idx=shard_index,
+                    num_splits=num_shards,
                 )
                 request.validate()
                 requests.append(request)
@@ -327,6 +357,13 @@ class RemoteDistDataset:
             num_assigned_storage_ranks (Optional[int]): If provided, limit this compute rank
                 to exactly this many storage ranks while preserving exact global coverage.
                 Requires ``rank`` and ``world_size``.
+
+                Must satisfy ``world_size * num_assigned_storage_ranks >= num_storage_nodes``
+                to guarantee all storage nodes are sampled from.
+
+                Typical values are 1-4. Lower values reduce cross-cluster network fanout
+                at the cost of potentially less balanced data distribution per compute rank.
+                ``None`` (the default) contacts all storage nodes.
 
         Returns:
             dict[int, torch.Tensor]: A dict mapping storage rank to node ids. When
@@ -490,8 +527,8 @@ class RemoteDistDataset:
             for storage_rank in requested_storage_ranks:
                 request = FetchABLPInputRequest(
                     split=split,
-                    rank=rank,
-                    world_size=world_size,
+                    split_idx=rank,
+                    num_splits=world_size,
                     node_type=node_type,
                     supervision_edge_type=supervision_edge_type,
                 )
@@ -504,8 +541,8 @@ class RemoteDistDataset:
                     split=split,
                     node_type=node_type,
                     supervision_edge_type=supervision_edge_type,
-                    shard_index=shard_index,
-                    num_shards=num_shards,
+                    split_idx=shard_index,
+                    num_splits=num_shards,
                 )
                 request.validate()
                 requests.append(request)

--- a/gigl/distributed/graph_store/remote_dist_dataset.py
+++ b/gigl/distributed/graph_store/remote_dist_dataset.py
@@ -50,10 +50,6 @@ def _plan_storage_rank_shards_for_compute_rank(
     using a round-robin scheme starting from an evenly-spaced offset
     (``compute_rank * num_storage_nodes // world_size``).
 
-    The reverse mapping tells us how many compute ranks share each storage rank.
-    For the given ``rank``, its local shard within a shared storage rank is its
-    position in the sorted list of compute ranks assigned to that storage rank.
-
     The constraint ``world_size * num_assigned_storage_ranks >= num_storage_nodes``
     guarantees that every storage rank is contacted by at least one compute rank,
     ensuring exact global coverage.

--- a/tests/integration/distributed/graph_store/graph_store_integration_test.py
+++ b/tests/integration/distributed/graph_store/graph_store_integration_test.py
@@ -28,7 +28,6 @@ from gigl.distributed.graph_store.storage_utils import (
     build_storage_dataset,
     run_storage_server,
 )
-from gigl.distributed.utils.neighborloader import shard_nodes_by_process
 from gigl.distributed.utils.networking import get_free_port, get_free_ports
 from gigl.distributed.utils.partition_book import build_partition_book, get_ids_on_rank
 from gigl.env.distributed import (
@@ -809,13 +808,11 @@ def _get_expected_input_nodes_by_rank(
     ] = collections.defaultdict(dict)
     for server_rank in range(cluster_info.num_storage_nodes):
         server_nodes = get_ids_on_rank(partition_book=partition_book, rank=server_rank)
+        splits = torch.tensor_split(
+            server_nodes, cluster_info.compute_cluster_world_size
+        )
         for global_rank in range(cluster_info.compute_cluster_world_size):
-            generated_nodes = shard_nodes_by_process(
-                input_nodes=server_nodes,
-                local_process_rank=global_rank,
-                local_process_world_size=cluster_info.compute_cluster_world_size,
-            )
-            expected_sampler_input[global_rank][server_rank] = generated_nodes
+            expected_sampler_input[global_rank][server_rank] = splits[global_rank]
     return dict(expected_sampler_input)
 
 

--- a/tests/integration/distributed/graph_store/graph_store_integration_test.py
+++ b/tests/integration/distributed/graph_store/graph_store_integration_test.py
@@ -180,11 +180,15 @@ def _build_neighbor_loader(
 def _assert_sampler_input(
     cluster_info: GraphStoreInfo,
     sampler_input: dict[int, torch.Tensor],
-    expected_sampler_input: dict[int, list[torch.Tensor]],
+    expected_sampler_input: dict[int, dict[int, torch.Tensor]],
 ) -> None:
     rank_expected_sampler_input = expected_sampler_input[torch.distributed.get_rank()]
-    assert len(sampler_input) == len(rank_expected_sampler_input)
-    for server_rank, expected in enumerate(rank_expected_sampler_input):
+    assert set(sampler_input) == set(rank_expected_sampler_input), (
+        f"Expected storage ranks {sorted(rank_expected_sampler_input)}, "
+        f"got {sorted(sampler_input)}"
+    )
+    for server_rank in sorted(rank_expected_sampler_input):
+        expected = rank_expected_sampler_input[server_rank]
         assert_tensor_equality(sampler_input[server_rank], expected)
 
 
@@ -524,8 +528,9 @@ def _run_compute_tests(
     client_rank: int,
     cluster_info: GraphStoreInfo,
     node_type: Optional[NodeType],
-    expected_sampler_input: dict[int, list[torch.Tensor]],
+    expected_sampler_input: dict[int, dict[int, torch.Tensor]],
     expected_edge_types: Optional[list[EdgeType]],
+    num_assigned_storage_ranks: Optional[int] = None,
 ) -> None:
     """Process target for "compute" nodes.
 
@@ -572,6 +577,7 @@ def _run_compute_tests(
         node_type=node_type,
         rank=torch.distributed.get_rank(),
         world_size=torch.distributed.get_world_size(),
+        num_assigned_storage_ranks=num_assigned_storage_ranks,
     )
     _assert_sampler_input(cluster_info, sampler_input, expected_sampler_input)
 
@@ -612,7 +618,12 @@ def _run_compute_tests(
         cluster_info=cluster_info,
         local_seen=_concat_seed_tensors(loaded_batches),
         local_expected=_concat_seed_tensors(
-            expected_sampler_input[torch.distributed.get_rank()]
+            [
+                expected_sampler_input[torch.distributed.get_rank()][server_rank]
+                for server_rank in sorted(
+                    expected_sampler_input[torch.distributed.get_rank()]
+                )
+            ]
         ),
     )
     loader.shutdown()
@@ -762,7 +773,7 @@ def _run_storage_main_process(args: ServerProcessArgs) -> None:
 
 def _get_expected_input_nodes_by_rank(
     num_nodes: int, cluster_info: GraphStoreInfo
-) -> dict[int, list[torch.Tensor]]:
+) -> dict[int, dict[int, torch.Tensor]]:
     """Get the expected sampler input for each compute rank.
 
     We generate the expected sampler input for each global rank by sharding the nodes across the global ranks.
@@ -788,12 +799,14 @@ def _get_expected_input_nodes_by_rank(
         cluster_info (GraphStoreInfo): The cluster information.
 
     Returns:
-        dict[int, list[torch.Tensor]]: The expected sampler input for each compute rank.
+        dict[int, dict[int, torch.Tensor]]: The expected sampler input for each compute rank.
     """
     partition_book = build_partition_book(
         num_entities=num_nodes, rank=0, world_size=cluster_info.num_storage_nodes
     )
-    expected_sampler_input = collections.defaultdict(list)
+    expected_sampler_input: dict[
+        int, dict[int, torch.Tensor]
+    ] = collections.defaultdict(dict)
     for server_rank in range(cluster_info.num_storage_nodes):
         server_nodes = get_ids_on_rank(partition_book=partition_book, rank=server_rank)
         for global_rank in range(cluster_info.compute_cluster_world_size):
@@ -802,8 +815,40 @@ def _get_expected_input_nodes_by_rank(
                 local_process_rank=global_rank,
                 local_process_world_size=cluster_info.compute_cluster_world_size,
             )
-            expected_sampler_input[global_rank].append(generated_nodes)
+            expected_sampler_input[global_rank][server_rank] = generated_nodes
     return dict(expected_sampler_input)
+
+
+def _get_expected_assigned_input_nodes_by_rank_for_homogeneous_graph_store_test(
+    num_nodes: int,
+    cluster_info: GraphStoreInfo,
+) -> dict[int, dict[int, torch.Tensor]]:
+    """Get expected sparse sampler input for the C=4, S=2, K=1 integration topology."""
+    if cluster_info.num_storage_nodes != 2:
+        raise ValueError(
+            "This helper only supports 2 storage nodes, "
+            f"received {cluster_info.num_storage_nodes}"
+        )
+    if cluster_info.compute_cluster_world_size != 4:
+        raise ValueError(
+            "This helper only supports compute world size 4, "
+            f"received {cluster_info.compute_cluster_world_size}"
+        )
+
+    partition_book = build_partition_book(
+        num_entities=num_nodes, rank=0, world_size=cluster_info.num_storage_nodes
+    )
+    storage_rank_zero_nodes = get_ids_on_rank(partition_book=partition_book, rank=0)
+    storage_rank_one_nodes = get_ids_on_rank(partition_book=partition_book, rank=1)
+    storage_rank_zero_shards = torch.tensor_split(storage_rank_zero_nodes, 2)
+    storage_rank_one_shards = torch.tensor_split(storage_rank_one_nodes, 2)
+
+    return {
+        0: {0: storage_rank_zero_shards[0]},
+        1: {0: storage_rank_zero_shards[1]},
+        2: {1: storage_rank_one_shards[0]},
+        3: {1: storage_rank_one_shards[1]},
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -957,6 +1002,24 @@ class GraphStoreIntegrationTest(TestCase):
             task_config_uri=cora_supervised_info.frozen_gbml_config_uri,
             compute_target=_run_compute_tests,
             compute_target_extra_args=(expected_sampler_input, None),
+        )
+
+    def test_graph_store_homogeneous_with_num_assigned_storage_ranks(self):
+        cora_supervised_info = get_mocked_dataset_artifact_metadata()[
+            CORA_USER_DEFINED_NODE_ANCHOR_MOCKED_DATASET_INFO.name
+        ]
+        cluster_info = self._create_cluster_info()
+        num_cora_nodes = 2708
+        expected_sampler_input = (
+            _get_expected_assigned_input_nodes_by_rank_for_homogeneous_graph_store_test(
+                num_cora_nodes, cluster_info
+            )
+        )
+        self._launch_graph_store_test(
+            cluster_info=cluster_info,
+            task_config_uri=cora_supervised_info.frozen_gbml_config_uri,
+            compute_target=_run_compute_tests,
+            compute_target_extra_args=(expected_sampler_input, None, 1),
         )
 
     def test_homogeneous_training(self):

--- a/tests/unit/distributed/dist_server_test.py
+++ b/tests/unit/distributed/dist_server_test.py
@@ -117,42 +117,42 @@ class TestRemoteDataset(TestCase):
         self.assertEqual(story_node_ids.shape[0], 5)
         self.assert_tensor_equality(story_node_ids, torch.arange(5))
 
-    def test_get_node_ids_with_multiple_splits(self) -> None:
-        """Test get_node_ids with multiple splits to verify partitioning."""
+    def test_get_node_ids_with_multiple_ranks(self) -> None:
+        """Test get_node_ids with multiple ranks to verify sharding."""
         dataset = create_homogeneous_dataset(
             edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
         )
         server = dist_server.DistServer(dataset)
 
         # Test with world_size=2
-        split_0_nodes = server.get_node_ids(
+        rank_0_nodes = server.get_node_ids(
             FetchNodesRequest(rank=0, world_size=2, node_type=None)
         )
-        split_1_nodes = server.get_node_ids(
+        rank_1_nodes = server.get_node_ids(
             FetchNodesRequest(rank=1, world_size=2, node_type=None)
         )
 
-        # Verify each split gets different nodes (tensor_split semantics)
-        self.assert_tensor_equality(split_0_nodes, torch.arange(5))
-        self.assert_tensor_equality(split_1_nodes, torch.arange(5, 10))
+        # Verify each rank gets different nodes
+        self.assert_tensor_equality(rank_0_nodes, torch.arange(5))
+        self.assert_tensor_equality(rank_1_nodes, torch.arange(5, 10))
 
-        # Test with world_size=3 (uneven split — tensor_split gives first shards extra)
-        split_0_nodes = server.get_node_ids(
+        # Test with world_size=3 (uneven split — tensor_split gives first ranks extra)
+        rank_0_nodes = server.get_node_ids(
             FetchNodesRequest(rank=0, world_size=3, node_type=None)
         )
-        split_1_nodes = server.get_node_ids(
+        rank_1_nodes = server.get_node_ids(
             FetchNodesRequest(rank=1, world_size=3, node_type=None)
         )
-        split_2_nodes = server.get_node_ids(
+        rank_2_nodes = server.get_node_ids(
             FetchNodesRequest(rank=2, world_size=3, node_type=None)
         )
 
-        # 10 nodes / 3 splits → [4, 3, 3] (tensor_split semantics)
-        self.assert_tensor_equality(split_0_nodes, torch.arange(4))
-        self.assert_tensor_equality(split_1_nodes, torch.arange(4, 7))
-        self.assert_tensor_equality(split_2_nodes, torch.arange(7, 10))
+        # 10 nodes / 3 ranks → [4, 3, 3] (tensor_split semantics)
+        self.assert_tensor_equality(rank_0_nodes, torch.arange(4))
+        self.assert_tensor_equality(rank_1_nodes, torch.arange(4, 7))
+        self.assert_tensor_equality(rank_2_nodes, torch.arange(7, 10))
 
-    def test_get_node_ids_split_params_must_be_provided_together(self) -> None:
+    def test_get_node_ids_rank_world_size_must_be_provided_together(self) -> None:
         """Test get_node_ids raises ValueError when rank/world_size not provided together."""
         dataset = create_homogeneous_dataset(
             edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
@@ -240,8 +240,8 @@ class TestRemoteDataset(TestCase):
         )
         self.assert_tensor_equality(test_nodes, torch.tensor([4]))
 
-    def test_get_node_ids_with_split_and_partitioning(self) -> None:
-        """Test get_node_ids with split and rank/world_size for partitioning."""
+    def test_get_node_ids_with_split_and_sharding(self) -> None:
+        """Test get_node_ids with split and rank/world_size for sharding."""
         create_test_process_group()
 
         positive_labels = {0: [0], 1: [1], 2: [2], 3: [3], 4: [4]}
@@ -254,17 +254,17 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
 
-        # Train split has [0, 1, 2], partition across 2 splits
-        # tensor_split gives first split the extra: [2, 1]
-        split_0_nodes = server.get_node_ids(
+        # Train split has [0, 1, 2], shard across 2 ranks
+        # tensor_split gives first rank the extra: [2, 1]
+        rank_0_nodes = server.get_node_ids(
             FetchNodesRequest(rank=0, world_size=2, node_type=USER, split="train")
         )
-        split_1_nodes = server.get_node_ids(
+        rank_1_nodes = server.get_node_ids(
             FetchNodesRequest(rank=1, world_size=2, node_type=USER, split="train")
         )
 
-        self.assert_tensor_equality(split_0_nodes, torch.tensor([0, 1]))
-        self.assert_tensor_equality(split_1_nodes, torch.tensor([2]))
+        self.assert_tensor_equality(rank_0_nodes, torch.tensor([0, 1]))
+        self.assert_tensor_equality(rank_1_nodes, torch.tensor([2]))
 
     def test_get_node_ids_invalid_split(self) -> None:
         """Test get_node_ids raises ValueError with invalid split."""
@@ -388,8 +388,8 @@ class TestRemoteDataset(TestCase):
                 assert neg_labels is not None
                 self.assert_tensor_equality(neg_labels, torch.tensor(expected_negative))
 
-    def test_get_ablp_input_multiple_splits(self) -> None:
-        """Test get_ablp_input with multiple splits to verify partitioning."""
+    def test_get_ablp_input_multiple_ranks(self) -> None:
+        """Test get_ablp_input with multiple ranks to verify sharding."""
         create_test_process_group()
         positive_labels = {
             0: [0, 1],
@@ -417,7 +417,10 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
 
-        # Get training input for split 0 of 2
+        # Note that the rank and world size here are for the process group we're *fetching for*, not the process group we're *fetching from*.
+        # e.g. if our compute cluster is of world size 4, and we have 2 storage nodes, then the world size this gets called with is 4, not 2.
+
+        # Get training input for rank 0 of 2
         anchor_nodes_0, pos_labels_0, neg_labels_0 = server.get_ablp_input(
             FetchABLPInputRequest(
                 split="train",
@@ -428,7 +431,7 @@ class TestRemoteDataset(TestCase):
             )
         )
 
-        # Get training input for split 1 of 2
+        # Get training input for rank 1 of 2
         anchor_nodes_1, pos_labels_1, neg_labels_1 = server.get_ablp_input(
             FetchABLPInputRequest(
                 split="train",
@@ -439,15 +442,15 @@ class TestRemoteDataset(TestCase):
             )
         )
 
-        # Train nodes [0, 1, 2, 3] split across 2 → [0, 1] and [2, 3]
-        split_0_user_ids = [0, 1]
-        split_1_user_ids = [2, 3]
-        self.assert_tensor_equality(anchor_nodes_0, torch.tensor(split_0_user_ids))
-        self.assert_tensor_equality(anchor_nodes_1, torch.tensor(split_1_user_ids))
+        # Train nodes [0, 1, 2, 3] should be split across ranks
+        rank_0_user_ids = [0, 1]
+        rank_1_user_ids = [2, 3]
+        self.assert_tensor_equality(anchor_nodes_0, torch.tensor(rank_0_user_ids))
+        self.assert_tensor_equality(anchor_nodes_1, torch.tensor(rank_1_user_ids))
 
-        # Verify positive labels for each split (order may vary due to CSR representation)
-        expected_positive_0 = [positive_labels[uid] for uid in split_0_user_ids]
-        expected_positive_1 = [positive_labels[uid] for uid in split_1_user_ids]
+        # Verify positive labels for each rank (order may vary due to CSR representation)
+        expected_positive_0 = [positive_labels[uid] for uid in rank_0_user_ids]
+        expected_positive_1 = [positive_labels[uid] for uid in rank_1_user_ids]
         self.assert_tensor_equality(
             pos_labels_0, torch.tensor(expected_positive_0), dim=1
         )
@@ -455,9 +458,9 @@ class TestRemoteDataset(TestCase):
             pos_labels_1, torch.tensor(expected_positive_1), dim=1
         )
 
-        # Verify negative labels for each split
-        expected_negative_0 = [negative_labels[uid] for uid in split_0_user_ids]
-        expected_negative_1 = [negative_labels[uid] for uid in split_1_user_ids]
+        # Verify negative labels for each rank
+        expected_negative_0 = [negative_labels[uid] for uid in rank_0_user_ids]
+        expected_negative_1 = [negative_labels[uid] for uid in rank_1_user_ids]
         assert neg_labels_0 is not None
         assert neg_labels_1 is not None
         self.assert_tensor_equality(neg_labels_0, torch.tensor(expected_negative_0))

--- a/tests/unit/distributed/dist_server_test.py
+++ b/tests/unit/distributed/dist_server_test.py
@@ -2,7 +2,6 @@ import torch
 from absl.testing import absltest
 
 from gigl.distributed.graph_store import dist_server
-from gigl.distributed.graph_store.dist_server import _slice_nodes_for_shard
 from gigl.distributed.graph_store.messages import (
     FetchABLPInputRequest,
     FetchNodesRequest,
@@ -87,9 +86,9 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
 
-        # Test with world_size=1, rank=0 (should get all nodes)
+        # Test with num_splits=1, split_idx=0 (should get all nodes)
         node_ids = server.get_node_ids(
-            FetchNodesRequest(rank=0, world_size=1, node_type=None)
+            FetchNodesRequest(split_idx=0, num_splits=1, node_type=None)
         )
         self.assertIsInstance(node_ids, torch.Tensor)
         self.assertEqual(node_ids.shape[0], 10)
@@ -104,7 +103,7 @@ class TestRemoteDataset(TestCase):
 
         # Test with USER node type
         user_node_ids = server.get_node_ids(
-            FetchNodesRequest(rank=0, world_size=1, node_type=USER)
+            FetchNodesRequest(split_idx=0, num_splits=1, node_type=USER)
         )
         self.assertIsInstance(user_node_ids, torch.Tensor)
         self.assertEqual(user_node_ids.shape[0], 5)
@@ -112,99 +111,59 @@ class TestRemoteDataset(TestCase):
 
         # Test with STORY node type
         story_node_ids = server.get_node_ids(
-            FetchNodesRequest(rank=0, world_size=1, node_type=STORY)
+            FetchNodesRequest(split_idx=0, num_splits=1, node_type=STORY)
         )
         self.assertIsInstance(story_node_ids, torch.Tensor)
         self.assertEqual(story_node_ids.shape[0], 5)
         self.assert_tensor_equality(story_node_ids, torch.arange(5))
 
-    def test_get_node_ids_with_multiple_ranks(self) -> None:
-        """Test get_node_ids with multiple ranks to verify sharding."""
+    def test_get_node_ids_with_multiple_splits(self) -> None:
+        """Test get_node_ids with multiple splits to verify partitioning."""
         dataset = create_homogeneous_dataset(
             edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
         )
         server = dist_server.DistServer(dataset)
 
-        # Test with world_size=2
-        rank_0_nodes = server.get_node_ids(
-            FetchNodesRequest(rank=0, world_size=2, node_type=None)
+        # Test with num_splits=2
+        split_0_nodes = server.get_node_ids(
+            FetchNodesRequest(split_idx=0, num_splits=2, node_type=None)
         )
-        rank_1_nodes = server.get_node_ids(
-            FetchNodesRequest(rank=1, world_size=2, node_type=None)
-        )
-
-        # Verify each rank gets different nodes
-        self.assert_tensor_equality(rank_0_nodes, torch.arange(5))
-        self.assert_tensor_equality(rank_1_nodes, torch.arange(5, 10))
-
-        # Test with world_size=3 (uneven split)
-        rank_0_nodes = server.get_node_ids(
-            FetchNodesRequest(rank=0, world_size=3, node_type=None)
-        )
-        rank_1_nodes = server.get_node_ids(
-            FetchNodesRequest(rank=1, world_size=3, node_type=None)
-        )
-        rank_2_nodes = server.get_node_ids(
-            FetchNodesRequest(rank=2, world_size=3, node_type=None)
+        split_1_nodes = server.get_node_ids(
+            FetchNodesRequest(split_idx=1, num_splits=2, node_type=None)
         )
 
-        self.assert_tensor_equality(rank_0_nodes, torch.arange(3))
-        self.assert_tensor_equality(rank_1_nodes, torch.arange(3, 6))
-        self.assert_tensor_equality(rank_2_nodes, torch.arange(6, 10))
+        # Verify each split gets different nodes (tensor_split semantics)
+        self.assert_tensor_equality(split_0_nodes, torch.arange(5))
+        self.assert_tensor_equality(split_1_nodes, torch.arange(5, 10))
 
-    def test_get_node_ids_rank_world_size_must_be_provided_together(self) -> None:
-        """Test get_node_ids raises ValueError when rank/world_size not provided together."""
-        dataset = create_homogeneous_dataset(
-            edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
+        # Test with num_splits=3 (uneven split — tensor_split gives first shards extra)
+        split_0_nodes = server.get_node_ids(
+            FetchNodesRequest(split_idx=0, num_splits=3, node_type=None)
         )
-        server = dist_server.DistServer(dataset)
-
-        with self.assertRaises(ValueError):
-            server.get_node_ids(FetchNodesRequest(rank=0, world_size=None))
-
-        with self.assertRaises(ValueError):
-            server.get_node_ids(FetchNodesRequest(rank=None, world_size=1))
-
-    def test_get_node_ids_local_sharding(self) -> None:
-        """Test get_node_ids supports explicit local shard requests."""
-        dataset = create_homogeneous_dataset(
-            edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
+        split_1_nodes = server.get_node_ids(
+            FetchNodesRequest(split_idx=1, num_splits=3, node_type=None)
         )
-        server = dist_server.DistServer(dataset)
-
-        shard_0_nodes = server.get_node_ids(
-            FetchNodesRequest(shard_index=0, num_shards=3)
-        )
-        shard_1_nodes = server.get_node_ids(
-            FetchNodesRequest(shard_index=1, num_shards=3)
-        )
-        shard_2_nodes = server.get_node_ids(
-            FetchNodesRequest(shard_index=2, num_shards=3)
+        split_2_nodes = server.get_node_ids(
+            FetchNodesRequest(split_idx=2, num_splits=3, node_type=None)
         )
 
-        self.assert_tensor_equality(shard_0_nodes, torch.arange(4))
-        self.assert_tensor_equality(shard_1_nodes, torch.arange(4, 7))
-        self.assert_tensor_equality(shard_2_nodes, torch.arange(7, 10))
+        # 10 nodes / 3 splits → [4, 3, 3] (tensor_split semantics)
+        self.assert_tensor_equality(split_0_nodes, torch.arange(4))
+        self.assert_tensor_equality(split_1_nodes, torch.arange(4, 7))
+        self.assert_tensor_equality(split_2_nodes, torch.arange(7, 10))
 
-    def test_get_node_ids_rejects_mixed_or_partial_sharding_modes(self) -> None:
-        """Test get_node_ids rejects invalid sharding mode combinations."""
+    def test_get_node_ids_split_params_must_be_provided_together(self) -> None:
+        """Test get_node_ids raises ValueError when split_idx/num_splits not provided together."""
         dataset = create_homogeneous_dataset(
             edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
         )
         server = dist_server.DistServer(dataset)
 
         with self.assertRaises(ValueError):
-            server.get_node_ids(FetchNodesRequest(shard_index=0, num_shards=None))
+            server.get_node_ids(FetchNodesRequest(split_idx=0, num_splits=None))
 
         with self.assertRaises(ValueError):
-            server.get_node_ids(
-                FetchNodesRequest(
-                    rank=0,
-                    world_size=2,
-                    shard_index=0,
-                    num_shards=2,
-                )
-            )
+            server.get_node_ids(FetchNodesRequest(split_idx=None, num_splits=1))
 
     def test_get_node_ids_with_homogeneous_dataset_and_node_type(self) -> None:
         """Test get_node_ids with a homogeneous dataset and a node type raises error."""
@@ -213,7 +172,9 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
         with self.assertRaises(ValueError):
-            server.get_node_ids(FetchNodesRequest(rank=0, world_size=1, node_type=USER))
+            server.get_node_ids(
+                FetchNodesRequest(split_idx=0, num_splits=1, node_type=USER)
+            )
 
     def test_get_node_ids_with_heterogeneous_dataset_and_no_node_type(
         self,
@@ -224,7 +185,9 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
         with self.assertRaises(ValueError):
-            server.get_node_ids(FetchNodesRequest(rank=0, world_size=1, node_type=None))
+            server.get_node_ids(
+                FetchNodesRequest(split_idx=0, num_splits=1, node_type=None)
+            )
 
     def test_get_node_ids_with_train_split(self) -> None:
         """Test get_node_ids returns only training nodes when split='train'."""
@@ -281,8 +244,8 @@ class TestRemoteDataset(TestCase):
         )
         self.assert_tensor_equality(test_nodes, torch.tensor([4]))
 
-    def test_get_node_ids_with_split_and_sharding(self) -> None:
-        """Test get_node_ids with split and rank/world_size for sharding."""
+    def test_get_node_ids_with_split_and_partitioning(self) -> None:
+        """Test get_node_ids with split and split_idx/num_splits for partitioning."""
         create_test_process_group()
 
         positive_labels = {0: [0], 1: [1], 2: [2], 3: [3], 4: [4]}
@@ -295,25 +258,17 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
 
-        # Train split has [0, 1, 2], shard across 2 ranks
-        rank_0_nodes = server.get_node_ids(
-            FetchNodesRequest(rank=0, world_size=2, node_type=USER, split="train")
+        # Train split has [0, 1, 2], partition across 2 splits
+        # tensor_split gives first split the extra: [2, 1]
+        split_0_nodes = server.get_node_ids(
+            FetchNodesRequest(split_idx=0, num_splits=2, node_type=USER, split="train")
         )
-        rank_1_nodes = server.get_node_ids(
-            FetchNodesRequest(rank=1, world_size=2, node_type=USER, split="train")
+        split_1_nodes = server.get_node_ids(
+            FetchNodesRequest(split_idx=1, num_splits=2, node_type=USER, split="train")
         )
 
-        self.assert_tensor_equality(rank_0_nodes, torch.tensor([0]))
-        self.assert_tensor_equality(rank_1_nodes, torch.tensor([1, 2]))
-
-    def test_slice_nodes_for_shard_returns_empty_for_high_shard_indices(self) -> None:
-        """Test local shard slicing matches tensor-split semantics for empty shards."""
-        nodes = torch.tensor([0, 1])
-
-        self.assert_tensor_equality(
-            _slice_nodes_for_shard(nodes, shard_index=2, num_shards=4),
-            torch.empty(0, dtype=torch.int64),
-        )
+        self.assert_tensor_equality(split_0_nodes, torch.tensor([0, 1]))
+        self.assert_tensor_equality(split_1_nodes, torch.tensor([2]))
 
     def test_get_node_ids_invalid_split(self) -> None:
         """Test get_node_ids raises ValueError with invalid split."""
@@ -414,8 +369,8 @@ class TestRemoteDataset(TestCase):
                 anchor_nodes, pos_labels, neg_labels = server.get_ablp_input(
                     FetchABLPInputRequest(
                         split=split,
-                        rank=0,
-                        world_size=1,
+                        split_idx=0,
+                        num_splits=1,
                         node_type=USER,
                         supervision_edge_type=USER_TO_STORY,
                     )
@@ -437,8 +392,8 @@ class TestRemoteDataset(TestCase):
                 assert neg_labels is not None
                 self.assert_tensor_equality(neg_labels, torch.tensor(expected_negative))
 
-    def test_get_ablp_input_multiple_ranks(self) -> None:
-        """Test get_ablp_input with multiple ranks to verify sharding."""
+    def test_get_ablp_input_multiple_splits(self) -> None:
+        """Test get_ablp_input with multiple splits to verify partitioning."""
         create_test_process_group()
         positive_labels = {
             0: [0, 1],
@@ -466,40 +421,37 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
 
-        # Get training input for rank 0 of 2
-
-        # Note that the rank and world size here are for the process group we're *fetching for*, not the process group we're *fetching from*.
-        # e.g. if our compute cluster is of world size 4, and we have 2 storage nodes, then the world size this gets called with is 4, not 2.
+        # Get training input for split 0 of 2
         anchor_nodes_0, pos_labels_0, neg_labels_0 = server.get_ablp_input(
             FetchABLPInputRequest(
                 split="train",
-                rank=0,
-                world_size=2,
+                split_idx=0,
+                num_splits=2,
                 node_type=USER,
                 supervision_edge_type=USER_TO_STORY,
             )
         )
 
-        # Get training input for rank 1 of 2
+        # Get training input for split 1 of 2
         anchor_nodes_1, pos_labels_1, neg_labels_1 = server.get_ablp_input(
             FetchABLPInputRequest(
                 split="train",
-                rank=1,
-                world_size=2,
+                split_idx=1,
+                num_splits=2,
                 node_type=USER,
                 supervision_edge_type=USER_TO_STORY,
             )
         )
 
-        # Train nodes [0, 1, 2, 3] should be split across ranks
-        rank_0_user_ids = [0, 1]
-        rank_1_user_ids = [2, 3]
-        self.assert_tensor_equality(anchor_nodes_0, torch.tensor(rank_0_user_ids))
-        self.assert_tensor_equality(anchor_nodes_1, torch.tensor(rank_1_user_ids))
+        # Train nodes [0, 1, 2, 3] split across 2 → [0, 1] and [2, 3]
+        split_0_user_ids = [0, 1]
+        split_1_user_ids = [2, 3]
+        self.assert_tensor_equality(anchor_nodes_0, torch.tensor(split_0_user_ids))
+        self.assert_tensor_equality(anchor_nodes_1, torch.tensor(split_1_user_ids))
 
-        # Verify positive labels for each rank (order may vary due to CSR representation)
-        expected_positive_0 = [positive_labels[uid] for uid in rank_0_user_ids]
-        expected_positive_1 = [positive_labels[uid] for uid in rank_1_user_ids]
+        # Verify positive labels for each split (order may vary due to CSR representation)
+        expected_positive_0 = [positive_labels[uid] for uid in split_0_user_ids]
+        expected_positive_1 = [positive_labels[uid] for uid in split_1_user_ids]
         self.assert_tensor_equality(
             pos_labels_0, torch.tensor(expected_positive_0), dim=1
         )
@@ -507,9 +459,9 @@ class TestRemoteDataset(TestCase):
             pos_labels_1, torch.tensor(expected_positive_1), dim=1
         )
 
-        # Verify negative labels for each rank
-        expected_negative_0 = [negative_labels[uid] for uid in rank_0_user_ids]
-        expected_negative_1 = [negative_labels[uid] for uid in rank_1_user_ids]
+        # Verify negative labels for each split
+        expected_negative_0 = [negative_labels[uid] for uid in split_0_user_ids]
+        expected_negative_1 = [negative_labels[uid] for uid in split_1_user_ids]
         assert neg_labels_0 is not None
         assert neg_labels_1 is not None
         self.assert_tensor_equality(neg_labels_0, torch.tensor(expected_negative_0))
@@ -535,8 +487,8 @@ class TestRemoteDataset(TestCase):
             server.get_ablp_input(
                 FetchABLPInputRequest(
                     split="invalid",
-                    rank=0,
-                    world_size=1,
+                    split_idx=0,
+                    num_splits=1,
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
                 )
@@ -568,8 +520,8 @@ class TestRemoteDataset(TestCase):
         anchor_nodes, pos_labels, neg_labels = server.get_ablp_input(
             FetchABLPInputRequest(
                 split="train",
-                rank=0,
-                world_size=1,
+                split_idx=0,
+                num_splits=1,
                 node_type=USER,
                 supervision_edge_type=USER_TO_STORY,
             )
@@ -605,8 +557,8 @@ class TestRemoteDataset(TestCase):
                 split="train",
                 node_type=USER,
                 supervision_edge_type=USER_TO_STORY,
-                shard_index=3,
-                num_shards=4,
+                split_idx=3,
+                num_splits=4,
             )
         )
 

--- a/tests/unit/distributed/dist_server_test.py
+++ b/tests/unit/distributed/dist_server_test.py
@@ -2,6 +2,7 @@ import torch
 from absl.testing import absltest
 
 from gigl.distributed.graph_store import dist_server
+from gigl.distributed.graph_store.dist_server import _slice_nodes_for_shard
 from gigl.distributed.graph_store.messages import (
     FetchABLPInputRequest,
     FetchNodesRequest,
@@ -164,6 +165,47 @@ class TestRemoteDataset(TestCase):
         with self.assertRaises(ValueError):
             server.get_node_ids(FetchNodesRequest(rank=None, world_size=1))
 
+    def test_get_node_ids_local_sharding(self) -> None:
+        """Test get_node_ids supports explicit local shard requests."""
+        dataset = create_homogeneous_dataset(
+            edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
+        )
+        server = dist_server.DistServer(dataset)
+
+        shard_0_nodes = server.get_node_ids(
+            FetchNodesRequest(shard_index=0, num_shards=3)
+        )
+        shard_1_nodes = server.get_node_ids(
+            FetchNodesRequest(shard_index=1, num_shards=3)
+        )
+        shard_2_nodes = server.get_node_ids(
+            FetchNodesRequest(shard_index=2, num_shards=3)
+        )
+
+        self.assert_tensor_equality(shard_0_nodes, torch.arange(4))
+        self.assert_tensor_equality(shard_1_nodes, torch.arange(4, 7))
+        self.assert_tensor_equality(shard_2_nodes, torch.arange(7, 10))
+
+    def test_get_node_ids_rejects_mixed_or_partial_sharding_modes(self) -> None:
+        """Test get_node_ids rejects invalid sharding mode combinations."""
+        dataset = create_homogeneous_dataset(
+            edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
+        )
+        server = dist_server.DistServer(dataset)
+
+        with self.assertRaises(ValueError):
+            server.get_node_ids(FetchNodesRequest(shard_index=0, num_shards=None))
+
+        with self.assertRaises(ValueError):
+            server.get_node_ids(
+                FetchNodesRequest(
+                    rank=0,
+                    world_size=2,
+                    shard_index=0,
+                    num_shards=2,
+                )
+            )
+
     def test_get_node_ids_with_homogeneous_dataset_and_node_type(self) -> None:
         """Test get_node_ids with a homogeneous dataset and a node type raises error."""
         dataset = create_homogeneous_dataset(
@@ -263,6 +305,15 @@ class TestRemoteDataset(TestCase):
 
         self.assert_tensor_equality(rank_0_nodes, torch.tensor([0]))
         self.assert_tensor_equality(rank_1_nodes, torch.tensor([1, 2]))
+
+    def test_slice_nodes_for_shard_returns_empty_for_high_shard_indices(self) -> None:
+        """Test local shard slicing matches tensor-split semantics for empty shards."""
+        nodes = torch.tensor([0, 1])
+
+        self.assert_tensor_equality(
+            _slice_nodes_for_shard(nodes, shard_index=2, num_shards=4),
+            torch.empty(0, dtype=torch.int64),
+        )
 
     def test_get_node_ids_invalid_split(self) -> None:
         """Test get_node_ids raises ValueError with invalid split."""
@@ -533,6 +584,36 @@ class TestRemoteDataset(TestCase):
 
         # Negative labels should be None
         self.assertIsNone(neg_labels)
+
+    def test_get_ablp_input_empty_local_shard_returns_empty_labels(self) -> None:
+        """Test get_ablp_input returns empty tensors for an empty assigned shard."""
+        create_test_process_group()
+        positive_labels = {0: [0, 1], 1: [1, 2], 10: [10, 11], 11: [11, 12]}
+        negative_labels = {0: [2], 1: [3], 10: [12], 11: [13]}
+        dataset = create_heterogeneous_dataset_for_ablp(
+            positive_labels=positive_labels,
+            negative_labels=negative_labels,
+            train_node_ids=[0, 1],
+            val_node_ids=[10],
+            test_node_ids=[11],
+            edge_indices=DEFAULT_HETEROGENEOUS_EDGE_INDICES,
+        )
+        server = dist_server.DistServer(dataset)
+
+        anchor_nodes, pos_labels, neg_labels = server.get_ablp_input(
+            FetchABLPInputRequest(
+                split="train",
+                node_type=USER,
+                supervision_edge_type=USER_TO_STORY,
+                shard_index=3,
+                num_shards=4,
+            )
+        )
+
+        self.assert_tensor_equality(anchor_nodes, torch.empty(0, dtype=torch.int64))
+        self.assert_tensor_equality(pos_labels, torch.empty(0, 0, dtype=torch.int64))
+        assert neg_labels is not None
+        self.assert_tensor_equality(neg_labels, torch.empty(0, 0, dtype=torch.int64))
 
 
 if __name__ == "__main__":

--- a/tests/unit/distributed/dist_server_test.py
+++ b/tests/unit/distributed/dist_server_test.py
@@ -86,9 +86,9 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
 
-        # Test with num_splits=1, split_idx=0 (should get all nodes)
+        # Test with world_size=1, rank=0 (should get all nodes)
         node_ids = server.get_node_ids(
-            FetchNodesRequest(split_idx=0, num_splits=1, node_type=None)
+            FetchNodesRequest(rank=0, world_size=1, node_type=None)
         )
         self.assertIsInstance(node_ids, torch.Tensor)
         self.assertEqual(node_ids.shape[0], 10)
@@ -103,7 +103,7 @@ class TestRemoteDataset(TestCase):
 
         # Test with USER node type
         user_node_ids = server.get_node_ids(
-            FetchNodesRequest(split_idx=0, num_splits=1, node_type=USER)
+            FetchNodesRequest(rank=0, world_size=1, node_type=USER)
         )
         self.assertIsInstance(user_node_ids, torch.Tensor)
         self.assertEqual(user_node_ids.shape[0], 5)
@@ -111,7 +111,7 @@ class TestRemoteDataset(TestCase):
 
         # Test with STORY node type
         story_node_ids = server.get_node_ids(
-            FetchNodesRequest(split_idx=0, num_splits=1, node_type=STORY)
+            FetchNodesRequest(rank=0, world_size=1, node_type=STORY)
         )
         self.assertIsInstance(story_node_ids, torch.Tensor)
         self.assertEqual(story_node_ids.shape[0], 5)
@@ -124,27 +124,27 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
 
-        # Test with num_splits=2
+        # Test with world_size=2
         split_0_nodes = server.get_node_ids(
-            FetchNodesRequest(split_idx=0, num_splits=2, node_type=None)
+            FetchNodesRequest(rank=0, world_size=2, node_type=None)
         )
         split_1_nodes = server.get_node_ids(
-            FetchNodesRequest(split_idx=1, num_splits=2, node_type=None)
+            FetchNodesRequest(rank=1, world_size=2, node_type=None)
         )
 
         # Verify each split gets different nodes (tensor_split semantics)
         self.assert_tensor_equality(split_0_nodes, torch.arange(5))
         self.assert_tensor_equality(split_1_nodes, torch.arange(5, 10))
 
-        # Test with num_splits=3 (uneven split — tensor_split gives first shards extra)
+        # Test with world_size=3 (uneven split — tensor_split gives first shards extra)
         split_0_nodes = server.get_node_ids(
-            FetchNodesRequest(split_idx=0, num_splits=3, node_type=None)
+            FetchNodesRequest(rank=0, world_size=3, node_type=None)
         )
         split_1_nodes = server.get_node_ids(
-            FetchNodesRequest(split_idx=1, num_splits=3, node_type=None)
+            FetchNodesRequest(rank=1, world_size=3, node_type=None)
         )
         split_2_nodes = server.get_node_ids(
-            FetchNodesRequest(split_idx=2, num_splits=3, node_type=None)
+            FetchNodesRequest(rank=2, world_size=3, node_type=None)
         )
 
         # 10 nodes / 3 splits → [4, 3, 3] (tensor_split semantics)
@@ -153,17 +153,17 @@ class TestRemoteDataset(TestCase):
         self.assert_tensor_equality(split_2_nodes, torch.arange(7, 10))
 
     def test_get_node_ids_split_params_must_be_provided_together(self) -> None:
-        """Test get_node_ids raises ValueError when split_idx/num_splits not provided together."""
+        """Test get_node_ids raises ValueError when rank/world_size not provided together."""
         dataset = create_homogeneous_dataset(
             edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
         )
         server = dist_server.DistServer(dataset)
 
         with self.assertRaises(ValueError):
-            server.get_node_ids(FetchNodesRequest(split_idx=0, num_splits=None))
+            server.get_node_ids(FetchNodesRequest(rank=0, world_size=None))
 
         with self.assertRaises(ValueError):
-            server.get_node_ids(FetchNodesRequest(split_idx=None, num_splits=1))
+            server.get_node_ids(FetchNodesRequest(rank=None, world_size=1))
 
     def test_get_node_ids_with_homogeneous_dataset_and_node_type(self) -> None:
         """Test get_node_ids with a homogeneous dataset and a node type raises error."""
@@ -172,9 +172,7 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
         with self.assertRaises(ValueError):
-            server.get_node_ids(
-                FetchNodesRequest(split_idx=0, num_splits=1, node_type=USER)
-            )
+            server.get_node_ids(FetchNodesRequest(rank=0, world_size=1, node_type=USER))
 
     def test_get_node_ids_with_heterogeneous_dataset_and_no_node_type(
         self,
@@ -185,9 +183,7 @@ class TestRemoteDataset(TestCase):
         )
         server = dist_server.DistServer(dataset)
         with self.assertRaises(ValueError):
-            server.get_node_ids(
-                FetchNodesRequest(split_idx=0, num_splits=1, node_type=None)
-            )
+            server.get_node_ids(FetchNodesRequest(rank=0, world_size=1, node_type=None))
 
     def test_get_node_ids_with_train_split(self) -> None:
         """Test get_node_ids returns only training nodes when split='train'."""
@@ -245,7 +241,7 @@ class TestRemoteDataset(TestCase):
         self.assert_tensor_equality(test_nodes, torch.tensor([4]))
 
     def test_get_node_ids_with_split_and_partitioning(self) -> None:
-        """Test get_node_ids with split and split_idx/num_splits for partitioning."""
+        """Test get_node_ids with split and rank/world_size for partitioning."""
         create_test_process_group()
 
         positive_labels = {0: [0], 1: [1], 2: [2], 3: [3], 4: [4]}
@@ -261,10 +257,10 @@ class TestRemoteDataset(TestCase):
         # Train split has [0, 1, 2], partition across 2 splits
         # tensor_split gives first split the extra: [2, 1]
         split_0_nodes = server.get_node_ids(
-            FetchNodesRequest(split_idx=0, num_splits=2, node_type=USER, split="train")
+            FetchNodesRequest(rank=0, world_size=2, node_type=USER, split="train")
         )
         split_1_nodes = server.get_node_ids(
-            FetchNodesRequest(split_idx=1, num_splits=2, node_type=USER, split="train")
+            FetchNodesRequest(rank=1, world_size=2, node_type=USER, split="train")
         )
 
         self.assert_tensor_equality(split_0_nodes, torch.tensor([0, 1]))
@@ -369,8 +365,8 @@ class TestRemoteDataset(TestCase):
                 anchor_nodes, pos_labels, neg_labels = server.get_ablp_input(
                     FetchABLPInputRequest(
                         split=split,
-                        split_idx=0,
-                        num_splits=1,
+                        rank=0,
+                        world_size=1,
                         node_type=USER,
                         supervision_edge_type=USER_TO_STORY,
                     )
@@ -425,8 +421,8 @@ class TestRemoteDataset(TestCase):
         anchor_nodes_0, pos_labels_0, neg_labels_0 = server.get_ablp_input(
             FetchABLPInputRequest(
                 split="train",
-                split_idx=0,
-                num_splits=2,
+                rank=0,
+                world_size=2,
                 node_type=USER,
                 supervision_edge_type=USER_TO_STORY,
             )
@@ -436,8 +432,8 @@ class TestRemoteDataset(TestCase):
         anchor_nodes_1, pos_labels_1, neg_labels_1 = server.get_ablp_input(
             FetchABLPInputRequest(
                 split="train",
-                split_idx=1,
-                num_splits=2,
+                rank=1,
+                world_size=2,
                 node_type=USER,
                 supervision_edge_type=USER_TO_STORY,
             )
@@ -487,8 +483,8 @@ class TestRemoteDataset(TestCase):
             server.get_ablp_input(
                 FetchABLPInputRequest(
                     split="invalid",
-                    split_idx=0,
-                    num_splits=1,
+                    rank=0,
+                    world_size=1,
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
                 )
@@ -520,8 +516,8 @@ class TestRemoteDataset(TestCase):
         anchor_nodes, pos_labels, neg_labels = server.get_ablp_input(
             FetchABLPInputRequest(
                 split="train",
-                split_idx=0,
-                num_splits=1,
+                rank=0,
+                world_size=1,
                 node_type=USER,
                 supervision_edge_type=USER_TO_STORY,
             )
@@ -557,8 +553,8 @@ class TestRemoteDataset(TestCase):
                 split="train",
                 node_type=USER,
                 supervision_edge_type=USER_TO_STORY,
-                split_idx=3,
-                num_splits=4,
+                rank=3,
+                world_size=4,
             )
         )
 

--- a/tests/unit/distributed/graph_store/messages_test.py
+++ b/tests/unit/distributed/graph_store/messages_test.py
@@ -11,62 +11,62 @@ from tests.test_assets.test_case import TestCase
 class TestFetchNodesRequestValidation(TestCase):
     @parameterized.expand(
         [
-            param("both_provided", FetchNodesRequest(split_idx=0, num_splits=4)),
-            param("both_none", FetchNodesRequest(split_idx=None, num_splits=None)),
+            param("both_provided", FetchNodesRequest(rank=0, world_size=4)),
+            param("both_none", FetchNodesRequest(rank=None, world_size=None)),
             param("defaults", FetchNodesRequest()),
         ]
     )
     def test_validate_passes(self, _: str, request: FetchNodesRequest) -> None:
-        """Validation passes when split_idx and num_splits are both provided or both absent."""
+        """Validation passes when rank and world_size are both provided or both absent."""
         request.validate()
 
     @parameterized.expand(
         [
             param(
-                "split_idx_without_num_splits",
-                FetchNodesRequest(split_idx=0, num_splits=None),
+                "rank_without_world_size",
+                FetchNodesRequest(rank=0, world_size=None),
             ),
             param(
-                "num_splits_without_split_idx",
-                FetchNodesRequest(split_idx=None, num_splits=4),
+                "world_size_without_rank",
+                FetchNodesRequest(rank=None, world_size=4),
             ),
         ]
     )
     def test_validate_fails_when_split_params_mismatch(
         self, _: str, request: FetchNodesRequest
     ) -> None:
-        """Validation fails when only one of split_idx/num_splits is provided."""
+        """Validation fails when only one of rank/world_size is provided."""
         with self.assertRaises(ValueError):
             request.validate()
 
     @parameterized.expand(
         [
             param(
-                "num_splits_zero",
-                FetchNodesRequest(split_idx=0, num_splits=0),
+                "world_size_zero",
+                FetchNodesRequest(rank=0, world_size=0),
             ),
             param(
-                "num_splits_negative",
-                FetchNodesRequest(split_idx=0, num_splits=-1),
+                "world_size_negative",
+                FetchNodesRequest(rank=0, world_size=-1),
             ),
             param(
-                "split_idx_negative",
-                FetchNodesRequest(split_idx=-1, num_splits=4),
+                "rank_negative",
+                FetchNodesRequest(rank=-1, world_size=4),
             ),
             param(
-                "split_idx_equals_num_splits",
-                FetchNodesRequest(split_idx=4, num_splits=4),
+                "rank_equals_world_size",
+                FetchNodesRequest(rank=4, world_size=4),
             ),
             param(
-                "split_idx_exceeds_num_splits",
-                FetchNodesRequest(split_idx=5, num_splits=4),
+                "rank_exceeds_world_size",
+                FetchNodesRequest(rank=5, world_size=4),
             ),
         ]
     )
     def test_validate_fails_when_split_params_out_of_range(
         self, _: str, request: FetchNodesRequest
     ) -> None:
-        """Validation fails when split_idx or num_splits are out of valid range."""
+        """Validation fails when rank or world_size are out of valid range."""
         with self.assertRaises(ValueError):
             request.validate()
 
@@ -80,8 +80,8 @@ class TestFetchABLPRequestValidation(TestCase):
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    split_idx=0,
-                    num_splits=4,
+                    rank=0,
+                    world_size=4,
                 ),
             ),
             param(
@@ -90,8 +90,8 @@ class TestFetchABLPRequestValidation(TestCase):
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    split_idx=None,
-                    num_splits=None,
+                    rank=None,
+                    world_size=None,
                 ),
             ),
             param(
@@ -105,29 +105,29 @@ class TestFetchABLPRequestValidation(TestCase):
         ]
     )
     def test_validate_passes(self, _: str, request: FetchABLPInputRequest) -> None:
-        """Validation passes when split_idx and num_splits are both provided or both absent."""
+        """Validation passes when rank and world_size are both provided or both absent."""
         request.validate()
 
     @parameterized.expand(
         [
             param(
-                "split_idx_without_num_splits",
+                "rank_without_world_size",
                 FetchABLPInputRequest(
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    split_idx=0,
-                    num_splits=None,
+                    rank=0,
+                    world_size=None,
                 ),
             ),
             param(
-                "num_splits_without_split_idx",
+                "world_size_without_rank",
                 FetchABLPInputRequest(
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    split_idx=None,
-                    num_splits=4,
+                    rank=None,
+                    world_size=4,
                 ),
             ),
         ]
@@ -135,40 +135,40 @@ class TestFetchABLPRequestValidation(TestCase):
     def test_validate_fails_when_split_params_mismatch(
         self, _: str, request: FetchABLPInputRequest
     ) -> None:
-        """Validation fails when only one of split_idx/num_splits is provided."""
+        """Validation fails when only one of rank/world_size is provided."""
         with self.assertRaises(ValueError):
             request.validate()
 
     @parameterized.expand(
         [
             param(
-                "num_splits_zero",
+                "world_size_zero",
                 FetchABLPInputRequest(
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    split_idx=0,
-                    num_splits=0,
+                    rank=0,
+                    world_size=0,
                 ),
             ),
             param(
-                "split_idx_negative",
+                "rank_negative",
                 FetchABLPInputRequest(
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    split_idx=-1,
-                    num_splits=4,
+                    rank=-1,
+                    world_size=4,
                 ),
             ),
             param(
-                "split_idx_equals_num_splits",
+                "rank_equals_world_size",
                 FetchABLPInputRequest(
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    split_idx=4,
-                    num_splits=4,
+                    rank=4,
+                    world_size=4,
                 ),
             ),
         ]
@@ -176,7 +176,7 @@ class TestFetchABLPRequestValidation(TestCase):
     def test_validate_fails_when_split_params_out_of_range(
         self, _: str, request: FetchABLPInputRequest
     ) -> None:
-        """Validation fails when split_idx or num_splits are out of valid range."""
+        """Validation fails when rank or world_size are out of valid range."""
         with self.assertRaises(ValueError):
             request.validate()
 

--- a/tests/unit/distributed/graph_store/messages_test.py
+++ b/tests/unit/distributed/graph_store/messages_test.py
@@ -11,29 +11,62 @@ from tests.test_assets.test_case import TestCase
 class TestFetchNodesRequestValidation(TestCase):
     @parameterized.expand(
         [
-            param("both_provided", FetchNodesRequest(rank=0, world_size=4)),
-            param("both_none", FetchNodesRequest(rank=None, world_size=None)),
+            param("both_provided", FetchNodesRequest(split_idx=0, num_splits=4)),
+            param("both_none", FetchNodesRequest(split_idx=None, num_splits=None)),
             param("defaults", FetchNodesRequest()),
         ]
     )
     def test_validate_passes(self, _: str, request: FetchNodesRequest) -> None:
-        """Validation passes when rank and world_size are both provided or both absent."""
+        """Validation passes when split_idx and num_splits are both provided or both absent."""
         request.validate()
 
     @parameterized.expand(
         [
             param(
-                "rank_without_world_size", FetchNodesRequest(rank=0, world_size=None)
+                "split_idx_without_num_splits",
+                FetchNodesRequest(split_idx=0, num_splits=None),
             ),
             param(
-                "world_size_without_rank", FetchNodesRequest(rank=None, world_size=4)
+                "num_splits_without_split_idx",
+                FetchNodesRequest(split_idx=None, num_splits=4),
             ),
         ]
     )
-    def test_validate_fails_when_rank_world_size_mismatch(
+    def test_validate_fails_when_split_params_mismatch(
         self, _: str, request: FetchNodesRequest
     ) -> None:
-        """Validation fails when only one of rank/world_size is provided."""
+        """Validation fails when only one of split_idx/num_splits is provided."""
+        with self.assertRaises(ValueError):
+            request.validate()
+
+    @parameterized.expand(
+        [
+            param(
+                "num_splits_zero",
+                FetchNodesRequest(split_idx=0, num_splits=0),
+            ),
+            param(
+                "num_splits_negative",
+                FetchNodesRequest(split_idx=0, num_splits=-1),
+            ),
+            param(
+                "split_idx_negative",
+                FetchNodesRequest(split_idx=-1, num_splits=4),
+            ),
+            param(
+                "split_idx_equals_num_splits",
+                FetchNodesRequest(split_idx=4, num_splits=4),
+            ),
+            param(
+                "split_idx_exceeds_num_splits",
+                FetchNodesRequest(split_idx=5, num_splits=4),
+            ),
+        ]
+    )
+    def test_validate_fails_when_split_params_out_of_range(
+        self, _: str, request: FetchNodesRequest
+    ) -> None:
+        """Validation fails when split_idx or num_splits are out of valid range."""
         with self.assertRaises(ValueError):
             request.validate()
 
@@ -47,8 +80,8 @@ class TestFetchABLPRequestValidation(TestCase):
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    rank=0,
-                    world_size=4,
+                    split_idx=0,
+                    num_splits=4,
                 ),
             ),
             param(
@@ -57,8 +90,8 @@ class TestFetchABLPRequestValidation(TestCase):
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    rank=None,
-                    world_size=None,
+                    split_idx=None,
+                    num_splits=None,
                 ),
             ),
             param(
@@ -72,37 +105,78 @@ class TestFetchABLPRequestValidation(TestCase):
         ]
     )
     def test_validate_passes(self, _: str, request: FetchABLPInputRequest) -> None:
-        """Validation passes when rank and world_size are both provided or both absent."""
+        """Validation passes when split_idx and num_splits are both provided or both absent."""
         request.validate()
 
     @parameterized.expand(
         [
             param(
-                "rank_without_world_size",
+                "split_idx_without_num_splits",
                 FetchABLPInputRequest(
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    rank=0,
-                    world_size=None,
+                    split_idx=0,
+                    num_splits=None,
                 ),
             ),
             param(
-                "world_size_without_rank",
+                "num_splits_without_split_idx",
                 FetchABLPInputRequest(
                     split="train",
                     node_type=USER,
                     supervision_edge_type=USER_TO_STORY,
-                    rank=None,
-                    world_size=4,
+                    split_idx=None,
+                    num_splits=4,
                 ),
             ),
         ]
     )
-    def test_validate_fails_when_rank_world_size_mismatch(
+    def test_validate_fails_when_split_params_mismatch(
         self, _: str, request: FetchABLPInputRequest
     ) -> None:
-        """Validation fails when only one of rank/world_size is provided."""
+        """Validation fails when only one of split_idx/num_splits is provided."""
+        with self.assertRaises(ValueError):
+            request.validate()
+
+    @parameterized.expand(
+        [
+            param(
+                "num_splits_zero",
+                FetchABLPInputRequest(
+                    split="train",
+                    node_type=USER,
+                    supervision_edge_type=USER_TO_STORY,
+                    split_idx=0,
+                    num_splits=0,
+                ),
+            ),
+            param(
+                "split_idx_negative",
+                FetchABLPInputRequest(
+                    split="train",
+                    node_type=USER,
+                    supervision_edge_type=USER_TO_STORY,
+                    split_idx=-1,
+                    num_splits=4,
+                ),
+            ),
+            param(
+                "split_idx_equals_num_splits",
+                FetchABLPInputRequest(
+                    split="train",
+                    node_type=USER,
+                    supervision_edge_type=USER_TO_STORY,
+                    split_idx=4,
+                    num_splits=4,
+                ),
+            ),
+        ]
+    )
+    def test_validate_fails_when_split_params_out_of_range(
+        self, _: str, request: FetchABLPInputRequest
+    ) -> None:
+        """Validation fails when split_idx or num_splits are out of valid range."""
         with self.assertRaises(ValueError):
             request.validate()
 

--- a/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
+++ b/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
@@ -11,7 +11,10 @@ from absl.testing import absltest
 import gigl.distributed.graph_store.dist_server as dist_server_module
 from gigl.common import LocalUri
 from gigl.distributed.graph_store.dist_server import DistServer, _call_func_on_server
-from gigl.distributed.graph_store.remote_dist_dataset import RemoteDistDataset
+from gigl.distributed.graph_store.remote_dist_dataset import (
+    RemoteDistDataset,
+    _plan_storage_rank_shards_for_compute_rank,
+)
 from gigl.env.distributed import GraphStoreInfo
 from gigl.src.common.types.graph_data import EdgeType, NodeType
 from gigl.types.graph import (
@@ -122,6 +125,65 @@ def _patch_remote_requests(
         yield
 
 
+def _make_sync_request_server_side_effect(
+    servers_by_rank: dict[int, DistServer]
+) -> Callable[..., Any]:
+    """Route synchronous request_server calls to the server for the requested rank."""
+
+    def _side_effect(
+        server_rank: int, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> Any:
+        return func(servers_by_rank[server_rank], *args, **kwargs)
+
+    return _side_effect
+
+
+def _make_async_request_server_side_effect(
+    servers_by_rank: dict[int, DistServer]
+) -> Callable[..., torch.futures.Future]:
+    """Route async_request_server calls to the server for the requested rank."""
+
+    def _side_effect(
+        server_rank: int, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> torch.futures.Future:
+        future: torch.futures.Future = torch.futures.Future()
+        future.set_result(func(servers_by_rank[server_rank], *args, **kwargs))
+        return future
+
+    return _side_effect
+
+
+def _create_ablp_server_for_anchor_ids(
+    anchor_ids: list[int],
+    include_negative_labels: bool = True,
+) -> DistServer:
+    """Create a server whose train anchors are exactly ``anchor_ids``."""
+    if not dist.is_initialized():
+        create_test_process_group()
+
+    val_anchor_id = max(anchor_ids) + 100
+    test_anchor_id = max(anchor_ids) + 101
+    all_split_anchor_ids = anchor_ids + [val_anchor_id, test_anchor_id]
+    positive_labels = {
+        anchor_id: [anchor_id * 10, anchor_id * 10 + 1]
+        for anchor_id in all_split_anchor_ids
+    }
+    negative_labels = (
+        {anchor_id: [anchor_id * 10 + 2] for anchor_id in all_split_anchor_ids}
+        if include_negative_labels
+        else None
+    )
+    dataset = create_heterogeneous_dataset_for_ablp(
+        positive_labels=positive_labels,
+        negative_labels=negative_labels,
+        train_node_ids=anchor_ids,
+        val_node_ids=[val_anchor_id],
+        test_node_ids=[test_anchor_id],
+        edge_indices=DEFAULT_HETEROGENEOUS_EDGE_INDICES,
+    )
+    return DistServer(dataset)
+
+
 def _create_server_with_splits(
     edge_indices: Optional[dict] = None,
     src_node_type: NodeType = USER,
@@ -163,6 +225,131 @@ class RemoteDistDatasetTestBase(TestCase):
         dist_server_module._dist_server = None
         if dist.is_initialized():
             dist.destroy_process_group()
+
+
+class TestPlanStorageRankShards(TestCase):
+    def _assert_assignment_invariants(
+        self,
+        compute_rank_to_storage_ranks: dict[int, list[int]],
+        storage_rank_to_compute_ranks: dict[int, list[int]],
+        num_assigned_storage_ranks: int,
+    ) -> None:
+        for storage_ranks in compute_rank_to_storage_ranks.values():
+            self.assertLen(storage_ranks, num_assigned_storage_ranks)
+            self.assertLen(storage_ranks, len(set(storage_ranks)))
+
+        assignment_counts = [
+            len(storage_rank_to_compute_ranks[storage_rank])
+            for storage_rank in sorted(storage_rank_to_compute_ranks)
+        ]
+        self.assertTrue(all(count > 0 for count in assignment_counts))
+        self.assertLessEqual(max(assignment_counts) - min(assignment_counts), 1)
+
+    def test_plan_storage_rank_shards_for_c4_s4_k2(self) -> None:
+        (
+            compute_rank_to_storage_ranks,
+            storage_rank_to_compute_ranks,
+            storage_rank_to_local_shard,
+        ) = _plan_storage_rank_shards_for_compute_rank(
+            rank=3,
+            world_size=4,
+            num_storage_nodes=4,
+            num_assigned_storage_ranks=2,
+        )
+
+        self.assertEqual(
+            compute_rank_to_storage_ranks,
+            {0: [0, 1], 1: [1, 2], 2: [2, 3], 3: [3, 0]},
+        )
+        self.assertEqual(
+            storage_rank_to_compute_ranks,
+            {0: [0, 3], 1: [0, 1], 2: [1, 2], 3: [2, 3]},
+        )
+        self.assertEqual(storage_rank_to_local_shard, {3: (1, 2), 0: (1, 2)})
+        self._assert_assignment_invariants(
+            compute_rank_to_storage_ranks,
+            storage_rank_to_compute_ranks,
+            num_assigned_storage_ranks=2,
+        )
+
+    def test_plan_storage_rank_shards_for_c5_s3_k1(self) -> None:
+        (
+            compute_rank_to_storage_ranks,
+            storage_rank_to_compute_ranks,
+            storage_rank_to_local_shard,
+        ) = _plan_storage_rank_shards_for_compute_rank(
+            rank=4,
+            world_size=5,
+            num_storage_nodes=3,
+            num_assigned_storage_ranks=1,
+        )
+
+        self.assertEqual(
+            compute_rank_to_storage_ranks,
+            {0: [0], 1: [0], 2: [1], 3: [1], 4: [2]},
+        )
+        self.assertEqual(
+            storage_rank_to_compute_ranks,
+            {0: [0, 1], 1: [2, 3], 2: [4]},
+        )
+        self.assertEqual(storage_rank_to_local_shard, {2: (0, 1)})
+        self._assert_assignment_invariants(
+            compute_rank_to_storage_ranks,
+            storage_rank_to_compute_ranks,
+            num_assigned_storage_ranks=1,
+        )
+
+    def test_plan_storage_rank_shards_for_c3_s5_k2(self) -> None:
+        (
+            compute_rank_to_storage_ranks,
+            storage_rank_to_compute_ranks,
+            storage_rank_to_local_shard,
+        ) = _plan_storage_rank_shards_for_compute_rank(
+            rank=1,
+            world_size=3,
+            num_storage_nodes=5,
+            num_assigned_storage_ranks=2,
+        )
+
+        self.assertEqual(
+            compute_rank_to_storage_ranks,
+            {0: [0, 1], 1: [1, 2], 2: [3, 4]},
+        )
+        self.assertEqual(
+            storage_rank_to_compute_ranks,
+            {0: [0], 1: [0, 1], 2: [1], 3: [2], 4: [2]},
+        )
+        self.assertEqual(storage_rank_to_local_shard, {1: (1, 2), 2: (0, 1)})
+        self._assert_assignment_invariants(
+            compute_rank_to_storage_ranks,
+            storage_rank_to_compute_ranks,
+            num_assigned_storage_ranks=2,
+        )
+
+    def test_plan_storage_rank_shards_rejects_invalid_inputs(self) -> None:
+        with self.assertRaises(ValueError):
+            _plan_storage_rank_shards_for_compute_rank(
+                rank=0,
+                world_size=0,
+                num_storage_nodes=4,
+                num_assigned_storage_ranks=1,
+            )
+
+        with self.assertRaises(ValueError):
+            _plan_storage_rank_shards_for_compute_rank(
+                rank=0,
+                world_size=4,
+                num_storage_nodes=4,
+                num_assigned_storage_ranks=0,
+            )
+
+        with self.assertRaises(ValueError):
+            _plan_storage_rank_shards_for_compute_rank(
+                rank=0,
+                world_size=2,
+                num_storage_nodes=5,
+                num_assigned_storage_ranks=2,
+            )
 
 
 @patch(
@@ -554,6 +741,139 @@ class TestRemoteDistDatasetWithSplits(RemoteDistDatasetTestBase):
             neg_labels_1,
             torch.tensor([[3], [4]]),
         )
+
+
+class TestRemoteDistDatasetAssignedStorageRanks(RemoteDistDatasetTestBase):
+    def _create_servers_by_rank(self) -> dict[int, DistServer]:
+        return {
+            0: _create_ablp_server_for_anchor_ids([0, 1, 2, 3]),
+            1: _create_ablp_server_for_anchor_ids([4, 5, 6, 7]),
+            2: _create_ablp_server_for_anchor_ids([8, 9, 10, 11]),
+            3: _create_ablp_server_for_anchor_ids([12, 13, 14, 15]),
+        }
+
+    def test_fetch_node_ids_with_num_assigned_storage_ranks(self) -> None:
+        servers_by_rank = self._create_servers_by_rank()
+        cluster_info = _create_mock_graph_store_info(num_storage_nodes=4)
+        remote_dataset = RemoteDistDataset(cluster_info=cluster_info, local_rank=0)
+
+        with _patch_remote_requests(
+            _make_async_request_server_side_effect(servers_by_rank),
+            _make_sync_request_server_side_effect(servers_by_rank),
+        ):
+            rank_zero_result = remote_dataset.fetch_node_ids(
+                rank=0,
+                world_size=4,
+                split="train",
+                node_type=USER,
+                num_assigned_storage_ranks=2,
+            )
+
+            self.assertEqual(list(rank_zero_result.keys()), [0, 1])
+            self.assert_tensor_equality(rank_zero_result[0], torch.tensor([0, 1]))
+            self.assert_tensor_equality(rank_zero_result[1], torch.tensor([4, 5]))
+
+            all_rank_results = [
+                remote_dataset.fetch_node_ids(
+                    rank=rank,
+                    world_size=4,
+                    split="train",
+                    node_type=USER,
+                    num_assigned_storage_ranks=2,
+                )
+                for rank in range(4)
+            ]
+
+        all_anchor_nodes = torch.cat(
+            [
+                node_ids
+                for rank_result in all_rank_results
+                for _, node_ids in sorted(rank_result.items())
+            ]
+        )
+        all_anchor_nodes, _ = torch.sort(all_anchor_nodes)
+        self.assert_tensor_equality(all_anchor_nodes, torch.arange(16))
+
+    def test_fetch_ablp_input_with_num_assigned_storage_ranks(self) -> None:
+        servers_by_rank = self._create_servers_by_rank()
+        cluster_info = _create_mock_graph_store_info(num_storage_nodes=4)
+        remote_dataset = RemoteDistDataset(cluster_info=cluster_info, local_rank=0)
+
+        with _patch_remote_requests(
+            _make_async_request_server_side_effect(servers_by_rank),
+            _make_sync_request_server_side_effect(servers_by_rank),
+        ):
+            rank_zero_result = remote_dataset.fetch_ablp_input(
+                split="train",
+                rank=0,
+                world_size=4,
+                anchor_node_type=USER,
+                supervision_edge_type=USER_TO_STORY,
+                num_assigned_storage_ranks=2,
+            )
+
+            self.assertEqual(list(rank_zero_result.keys()), [0, 1])
+            self.assert_tensor_equality(
+                rank_zero_result[0].anchor_nodes, torch.tensor([0, 1])
+            )
+            self.assert_tensor_equality(
+                rank_zero_result[1].anchor_nodes, torch.tensor([4, 5])
+            )
+
+            positive_labels_0, negative_labels_0 = rank_zero_result[0].labels[
+                USER_TO_STORY
+            ]
+            self.assert_tensor_equality(
+                positive_labels_0,
+                torch.tensor([[0, 1], [10, 11]]),
+            )
+            assert negative_labels_0 is not None
+            self.assert_tensor_equality(negative_labels_0, torch.tensor([[2], [12]]))
+
+            positive_labels_1, negative_labels_1 = rank_zero_result[1].labels[
+                USER_TO_STORY
+            ]
+            self.assert_tensor_equality(
+                positive_labels_1,
+                torch.tensor([[40, 41], [50, 51]]),
+            )
+            assert negative_labels_1 is not None
+            self.assert_tensor_equality(negative_labels_1, torch.tensor([[42], [52]]))
+
+            all_rank_results = [
+                remote_dataset.fetch_ablp_input(
+                    split="train",
+                    rank=rank,
+                    world_size=4,
+                    anchor_node_type=USER,
+                    supervision_edge_type=USER_TO_STORY,
+                    num_assigned_storage_ranks=2,
+                )
+                for rank in range(4)
+            ]
+
+        all_anchor_nodes = torch.cat(
+            [
+                ablp_input.anchor_nodes
+                for rank_result in all_rank_results
+                for _, ablp_input in sorted(rank_result.items())
+            ]
+        )
+        all_anchor_nodes, _ = torch.sort(all_anchor_nodes)
+        self.assert_tensor_equality(all_anchor_nodes, torch.arange(16))
+
+    def test_fetch_node_ids_requires_rank_and_world_size_for_num_assigned_storage_ranks(
+        self,
+    ) -> None:
+        cluster_info = _create_mock_graph_store_info(num_storage_nodes=4)
+        remote_dataset = RemoteDistDataset(cluster_info=cluster_info, local_rank=0)
+
+        with self.assertRaises(ValueError):
+            remote_dataset.fetch_node_ids(
+                split="train",
+                node_type=USER,
+                num_assigned_storage_ranks=1,
+            )
 
 
 class TestRemoteDistDatasetLabeledHomogeneous(RemoteDistDatasetTestBase):

--- a/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
+++ b/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
@@ -283,7 +283,7 @@ class TestPlanStorageRankShards(TestCase):
     @parameterized.expand(
         [
             param(
-                "c4_s4_k2",
+                "4_compute_4_storage_2_assigned",
                 rank=3,
                 world_size=4,
                 num_storage_nodes=4,
@@ -294,7 +294,7 @@ class TestPlanStorageRankShards(TestCase):
                 },
             ),
             param(
-                "c5_s3_k1",
+                "5_compute_3_storage_1_assigned",
                 rank=4,
                 world_size=5,
                 num_storage_nodes=3,
@@ -304,7 +304,7 @@ class TestPlanStorageRankShards(TestCase):
                 },
             ),
             param(
-                "c3_s5_k2",
+                "3_compute_5_storage_2_assigned",
                 rank=1,
                 world_size=3,
                 num_storage_nodes=5,

--- a/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
+++ b/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
@@ -503,13 +503,14 @@ class TestRemoteDistDatasetHeterogeneous(RemoteDistDatasetTestBase):
         result = remote_dataset.fetch_node_ids(node_type=STORY)
         self.assert_tensor_equality(result[0], torch.arange(5))
 
-        # With sharding: first half of user nodes (rank 0 of 2)
+        # With sharding: first partition of user nodes (rank 0 of 2)
+        # tensor_split gives first partition the extra: [3, 2]
         result = remote_dataset.fetch_node_ids(rank=0, world_size=2, node_type=USER)
-        self.assert_tensor_equality(result[0], torch.arange(2))
+        self.assert_tensor_equality(result[0], torch.arange(3))
 
-        # With sharding: second half of user nodes (rank 1 of 2)
+        # With sharding: second partition of user nodes (rank 1 of 2)
         result = remote_dataset.fetch_node_ids(rank=1, world_size=2, node_type=USER)
-        self.assert_tensor_equality(result[0], torch.arange(2, 5))
+        self.assert_tensor_equality(result[0], torch.arange(3, 5))
 
     def test_fetch_node_partition_book_heterogeneous(self, mock_request):
         """Test fetch_node_partition_book returns per-type partition books for heterogeneous graphs."""
@@ -602,17 +603,18 @@ class TestRemoteDistDatasetWithSplits(RemoteDistDatasetTestBase):
         )
 
         # With sharding: train split [0, 1, 2] across 2 ranks
+        # tensor_split gives first partition the extra: [2, 1]
         self.assert_tensor_equality(
             remote_dataset.fetch_node_ids(
                 rank=0, world_size=2, node_type=USER, split="train"
             )[0],
-            torch.tensor([0]),
+            torch.tensor([0, 1]),
         )
         self.assert_tensor_equality(
             remote_dataset.fetch_node_ids(
                 rank=1, world_size=2, node_type=USER, split="train"
             )[0],
-            torch.tensor([1, 2]),
+            torch.tensor([2]),
         )
 
     @patch(
@@ -706,17 +708,17 @@ class TestRemoteDistDatasetWithSplits(RemoteDistDatasetTestBase):
         self.assertIsInstance(ablp_0, ABLPInputNodes)
         self.assertEqual(ablp_0.anchor_node_type, USER)
 
-        # Rank 0 should get node 0
-        self.assert_tensor_equality(ablp_0.anchor_nodes, torch.tensor([0]))
+        # Rank 0 should get nodes 0, 1 (tensor_split gives first partition the extra)
+        self.assert_tensor_equality(ablp_0.anchor_nodes, torch.tensor([0, 1]))
         pos_labels_0, neg_labels_0 = ablp_0.labels[USER_TO_STORY]
         self.assert_tensor_equality(
             pos_labels_0,
-            torch.tensor([[0, 1]]),
+            torch.tensor([[0, 1], [1, 2]]),
         )
         assert neg_labels_0 is not None
         self.assert_tensor_equality(
             neg_labels_0,
-            torch.tensor([[2]]),
+            torch.tensor([[2], [3]]),
         )
 
         result_rank1 = remote_dataset.fetch_ablp_input(
@@ -729,17 +731,17 @@ class TestRemoteDistDatasetWithSplits(RemoteDistDatasetTestBase):
         ablp_1 = result_rank1[0]
         self.assertIsInstance(ablp_1, ABLPInputNodes)
 
-        # Rank 1 should get nodes 1, 2
-        self.assert_tensor_equality(ablp_1.anchor_nodes, torch.tensor([1, 2]))
+        # Rank 1 should get node 2
+        self.assert_tensor_equality(ablp_1.anchor_nodes, torch.tensor([2]))
         pos_labels_1, neg_labels_1 = ablp_1.labels[USER_TO_STORY]
         self.assert_tensor_equality(
             pos_labels_1,
-            torch.tensor([[1, 2], [2, 3]]),
+            torch.tensor([[2, 3]]),
         )
         assert neg_labels_1 is not None
         self.assert_tensor_equality(
             neg_labels_1,
-            torch.tensor([[3], [4]]),
+            torch.tensor([[4]]),
         )
 
 

--- a/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
+++ b/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
@@ -7,6 +7,7 @@ import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 from absl.testing import absltest
+from parameterized import param, parameterized
 
 import gigl.distributed.graph_store.dist_server as dist_server_module
 from gigl.common import LocalUri
@@ -279,86 +280,104 @@ class TestPlanStorageRankShards(TestCase):
         self.assertTrue(all(count > 0 for count in assignment_counts))
         self.assertLessEqual(max(assignment_counts) - min(assignment_counts), 1)
 
-    def test_plan_storage_rank_shards_for_c4_s4_k2(self) -> None:
+    @parameterized.expand(
+        [
+            param(
+                "c4_s4_k2",
+                rank=3,
+                world_size=4,
+                num_storage_nodes=4,
+                num_assigned_storage_ranks=2,
+                expected={
+                    3: StorageRankShardAssignment(rank=1, world_size=2),
+                    0: StorageRankShardAssignment(rank=1, world_size=2),
+                },
+            ),
+            param(
+                "c5_s3_k1",
+                rank=4,
+                world_size=5,
+                num_storage_nodes=3,
+                num_assigned_storage_ranks=1,
+                expected={
+                    2: StorageRankShardAssignment(rank=0, world_size=1),
+                },
+            ),
+            param(
+                "c3_s5_k2",
+                rank=1,
+                world_size=3,
+                num_storage_nodes=5,
+                num_assigned_storage_ranks=2,
+                expected={
+                    1: StorageRankShardAssignment(rank=1, world_size=2),
+                    2: StorageRankShardAssignment(rank=0, world_size=1),
+                },
+            ),
+        ]
+    )
+    def test_plan_storage_rank_shards(
+        self,
+        _: str,
+        rank: int,
+        world_size: int,
+        num_storage_nodes: int,
+        num_assigned_storage_ranks: int,
+        expected: dict[int, StorageRankShardAssignment],
+    ) -> None:
         result = _plan_storage_rank_shards_for_compute_rank(
-            rank=3,
-            world_size=4,
-            num_storage_nodes=4,
-            num_assigned_storage_ranks=2,
+            rank=rank,
+            world_size=world_size,
+            num_storage_nodes=num_storage_nodes,
+            num_assigned_storage_ranks=num_assigned_storage_ranks,
         )
 
-        self.assertEqual(list(result.keys()), [3, 0])
-        self.assertEqual(
-            result,
-            {
-                3: StorageRankShardAssignment(rank=1, world_size=2),
-                0: StorageRankShardAssignment(rank=1, world_size=2),
-            },
-        )
+        self.assertEqual(result, expected)
         self._assert_assignment_invariants(
-            world_size=4, num_storage_nodes=4, num_assigned_storage_ranks=2
+            world_size=world_size,
+            num_storage_nodes=num_storage_nodes,
+            num_assigned_storage_ranks=num_assigned_storage_ranks,
         )
 
-    def test_plan_storage_rank_shards_for_c5_s3_k1(self) -> None:
-        result = _plan_storage_rank_shards_for_compute_rank(
-            rank=4,
-            world_size=5,
-            num_storage_nodes=3,
-            num_assigned_storage_ranks=1,
-        )
-
-        self.assertEqual(list(result.keys()), [2])
-        self.assertEqual(
-            result,
-            {2: StorageRankShardAssignment(rank=0, world_size=1)},
-        )
-        self._assert_assignment_invariants(
-            world_size=5, num_storage_nodes=3, num_assigned_storage_ranks=1
-        )
-
-    def test_plan_storage_rank_shards_for_c3_s5_k2(self) -> None:
-        result = _plan_storage_rank_shards_for_compute_rank(
-            rank=1,
-            world_size=3,
-            num_storage_nodes=5,
-            num_assigned_storage_ranks=2,
-        )
-
-        self.assertEqual(list(result.keys()), [1, 2])
-        self.assertEqual(
-            result,
-            {
-                1: StorageRankShardAssignment(rank=1, world_size=2),
-                2: StorageRankShardAssignment(rank=0, world_size=1),
-            },
-        )
-        self._assert_assignment_invariants(
-            world_size=3, num_storage_nodes=5, num_assigned_storage_ranks=2
-        )
-
-    def test_plan_storage_rank_shards_rejects_invalid_inputs(self) -> None:
-        with self.assertRaises(ValueError):
-            _plan_storage_rank_shards_for_compute_rank(
+    @parameterized.expand(
+        [
+            param(
+                "world_size_zero",
                 rank=0,
                 world_size=0,
                 num_storage_nodes=4,
                 num_assigned_storage_ranks=1,
-            )
-
-        with self.assertRaises(ValueError):
-            _plan_storage_rank_shards_for_compute_rank(
+            ),
+            param(
+                "num_assigned_zero",
                 rank=0,
                 world_size=4,
                 num_storage_nodes=4,
                 num_assigned_storage_ranks=0,
-            )
-
-        with self.assertRaises(ValueError):
-            _plan_storage_rank_shards_for_compute_rank(
+            ),
+            param(
+                "insufficient_coverage",
                 rank=0,
                 world_size=2,
                 num_storage_nodes=5,
                 num_assigned_storage_ranks=2,
+            ),
+        ]
+    )
+    def test_plan_storage_rank_shards_rejects_invalid_inputs(
+        self,
+        _: str,
+        rank: int,
+        world_size: int,
+        num_storage_nodes: int,
+        num_assigned_storage_ranks: int,
+    ) -> None:
+        with self.assertRaises(ValueError):
+            _plan_storage_rank_shards_for_compute_rank(
+                rank=rank,
+                world_size=world_size,
+                num_storage_nodes=num_storage_nodes,
+                num_assigned_storage_ranks=num_assigned_storage_ranks,
             )
 
 

--- a/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
+++ b/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
@@ -13,6 +13,7 @@ from gigl.common import LocalUri
 from gigl.distributed.graph_store.dist_server import DistServer, _call_func_on_server
 from gigl.distributed.graph_store.remote_dist_dataset import (
     RemoteDistDataset,
+    StorageRankShardAssignment,
     _plan_storage_rank_shards_for_compute_rank,
 )
 from gigl.env.distributed import GraphStoreInfo
@@ -228,12 +229,45 @@ class RemoteDistDatasetTestBase(TestCase):
 
 
 class TestPlanStorageRankShards(TestCase):
+    @staticmethod
+    def _build_full_mappings(
+        world_size: int,
+        num_storage_nodes: int,
+        num_assigned_storage_ranks: int,
+    ) -> tuple[dict[int, list[int]], dict[int, list[int]]]:
+        """Build the full compute-to-storage and storage-to-compute mappings for invariant checks."""
+        compute_rank_to_storage_ranks: dict[int, list[int]] = {}
+        for compute_rank in range(world_size):
+            result = _plan_storage_rank_shards_for_compute_rank(
+                rank=compute_rank,
+                world_size=world_size,
+                num_storage_nodes=num_storage_nodes,
+                num_assigned_storage_ranks=num_assigned_storage_ranks,
+            )
+            compute_rank_to_storage_ranks[compute_rank] = list(result.keys())
+
+        storage_rank_to_compute_ranks: dict[int, list[int]] = {
+            s: [] for s in range(num_storage_nodes)
+        }
+        for cr, srs in compute_rank_to_storage_ranks.items():
+            for sr in srs:
+                storage_rank_to_compute_ranks[sr].append(cr)
+
+        return compute_rank_to_storage_ranks, storage_rank_to_compute_ranks
+
     def _assert_assignment_invariants(
         self,
-        compute_rank_to_storage_ranks: dict[int, list[int]],
-        storage_rank_to_compute_ranks: dict[int, list[int]],
+        world_size: int,
+        num_storage_nodes: int,
         num_assigned_storage_ranks: int,
     ) -> None:
+        (
+            compute_rank_to_storage_ranks,
+            storage_rank_to_compute_ranks,
+        ) = self._build_full_mappings(
+            world_size, num_storage_nodes, num_assigned_storage_ranks
+        )
+
         for storage_ranks in compute_rank_to_storage_ranks.values():
             self.assertLen(storage_ranks, num_assigned_storage_ranks)
             self.assertLen(storage_ranks, len(set(storage_ranks)))
@@ -246,84 +280,60 @@ class TestPlanStorageRankShards(TestCase):
         self.assertLessEqual(max(assignment_counts) - min(assignment_counts), 1)
 
     def test_plan_storage_rank_shards_for_c4_s4_k2(self) -> None:
-        (
-            compute_rank_to_storage_ranks,
-            storage_rank_to_compute_ranks,
-            storage_rank_to_local_shard,
-        ) = _plan_storage_rank_shards_for_compute_rank(
+        result = _plan_storage_rank_shards_for_compute_rank(
             rank=3,
             world_size=4,
             num_storage_nodes=4,
             num_assigned_storage_ranks=2,
         )
 
+        self.assertEqual(list(result.keys()), [3, 0])
         self.assertEqual(
-            compute_rank_to_storage_ranks,
-            {0: [0, 1], 1: [1, 2], 2: [2, 3], 3: [3, 0]},
+            result,
+            {
+                3: StorageRankShardAssignment(rank=1, world_size=2),
+                0: StorageRankShardAssignment(rank=1, world_size=2),
+            },
         )
-        self.assertEqual(
-            storage_rank_to_compute_ranks,
-            {0: [0, 3], 1: [0, 1], 2: [1, 2], 3: [2, 3]},
-        )
-        self.assertEqual(storage_rank_to_local_shard, {3: (1, 2), 0: (1, 2)})
         self._assert_assignment_invariants(
-            compute_rank_to_storage_ranks,
-            storage_rank_to_compute_ranks,
-            num_assigned_storage_ranks=2,
+            world_size=4, num_storage_nodes=4, num_assigned_storage_ranks=2
         )
 
     def test_plan_storage_rank_shards_for_c5_s3_k1(self) -> None:
-        (
-            compute_rank_to_storage_ranks,
-            storage_rank_to_compute_ranks,
-            storage_rank_to_local_shard,
-        ) = _plan_storage_rank_shards_for_compute_rank(
+        result = _plan_storage_rank_shards_for_compute_rank(
             rank=4,
             world_size=5,
             num_storage_nodes=3,
             num_assigned_storage_ranks=1,
         )
 
+        self.assertEqual(list(result.keys()), [2])
         self.assertEqual(
-            compute_rank_to_storage_ranks,
-            {0: [0], 1: [0], 2: [1], 3: [1], 4: [2]},
+            result,
+            {2: StorageRankShardAssignment(rank=0, world_size=1)},
         )
-        self.assertEqual(
-            storage_rank_to_compute_ranks,
-            {0: [0, 1], 1: [2, 3], 2: [4]},
-        )
-        self.assertEqual(storage_rank_to_local_shard, {2: (0, 1)})
         self._assert_assignment_invariants(
-            compute_rank_to_storage_ranks,
-            storage_rank_to_compute_ranks,
-            num_assigned_storage_ranks=1,
+            world_size=5, num_storage_nodes=3, num_assigned_storage_ranks=1
         )
 
     def test_plan_storage_rank_shards_for_c3_s5_k2(self) -> None:
-        (
-            compute_rank_to_storage_ranks,
-            storage_rank_to_compute_ranks,
-            storage_rank_to_local_shard,
-        ) = _plan_storage_rank_shards_for_compute_rank(
+        result = _plan_storage_rank_shards_for_compute_rank(
             rank=1,
             world_size=3,
             num_storage_nodes=5,
             num_assigned_storage_ranks=2,
         )
 
+        self.assertEqual(list(result.keys()), [1, 2])
         self.assertEqual(
-            compute_rank_to_storage_ranks,
-            {0: [0, 1], 1: [1, 2], 2: [3, 4]},
+            result,
+            {
+                1: StorageRankShardAssignment(rank=1, world_size=2),
+                2: StorageRankShardAssignment(rank=0, world_size=1),
+            },
         )
-        self.assertEqual(
-            storage_rank_to_compute_ranks,
-            {0: [0], 1: [0, 1], 2: [1], 3: [2], 4: [2]},
-        )
-        self.assertEqual(storage_rank_to_local_shard, {1: (1, 2), 2: (0, 1)})
         self._assert_assignment_invariants(
-            compute_rank_to_storage_ranks,
-            storage_rank_to_compute_ranks,
-            num_assigned_storage_ranks=2,
+            world_size=3, num_storage_nodes=5, num_assigned_storage_ranks=2
         )
 
     def test_plan_storage_rank_shards_rejects_invalid_inputs(self) -> None:


### PR DESCRIPTION
**Scope of work done**

We do this so that we can have graph store mode sample from select servers, as we don't want to full cross-cluster fanout which is quite noisy and causes problems. In practice this is probably going to be like, `< 4` but tbd on topology .

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
