### PR TITLE
launcher: fix inverted use_cuda flag and force CPU image on graph-store storage pool

### DIFF
--- a/gigl/src/common/vertex_ai_launcher.py
+++ b/gigl/src/common/vertex_ai_launcher.py
@@ -85,7 +85,7 @@ def launch_single_pool_job(
         resource_config_uri=resource_config_uri,
         command_str=process_command,
         args=process_runtime_args,
-        use_cuda=is_cpu_execution,
+        use_cuda=not is_cpu_execution,
         container_uri=container_uri,
         vertex_ai_resource_config=vertex_ai_resource_config,
         env_vars=[env_var.EnvVar(name="TF_CPP_MIN_LOG_LEVEL", value="3")],
@@ -139,13 +139,15 @@ def launch_graph_store_enabled_job(
     storage_pool_config = vertex_ai_graph_store_config.graph_store_pool
     compute_pool_config = vertex_ai_graph_store_config.compute_pool
 
-    # Determine if CPU or GPU based on compute pool
-    is_cpu_execution = _determine_if_cpu_execution(
+    # Compute workers may use GPUs, but storage workers always run the CPU graph-store entrypoint.
+    is_compute_cpu_execution = _determine_if_cpu_execution(
         vertex_ai_resource_config=compute_pool_config
     )
     cpu_docker_uri = cpu_docker_uri or DEFAULT_GIGL_RELEASE_SRC_IMAGE_CPU
     cuda_docker_uri = cuda_docker_uri or DEFAULT_GIGL_RELEASE_SRC_IMAGE_CUDA
-    container_uri = cpu_docker_uri if is_cpu_execution else cuda_docker_uri
+    compute_container_uri = (
+        cpu_docker_uri if is_compute_cpu_execution else cuda_docker_uri
+    )
 
     logger.info(f"Running {component.value} with command: {compute_commmand}")
 
@@ -153,7 +155,7 @@ def launch_graph_store_enabled_job(
         vertex_ai_graph_store_config.compute_cluster_local_world_size
     )
     if not num_compute_processes:
-        if is_cpu_execution:
+        if is_compute_cpu_execution:
             num_compute_processes = 1
         else:
             num_compute_processes = vertex_ai_graph_store_config.compute_pool.gpu_limit
@@ -176,8 +178,8 @@ def launch_graph_store_enabled_job(
         resource_config_uri=resource_config_uri,
         command_str=compute_commmand,
         args=compute_runtime_args,
-        use_cuda=is_cpu_execution,
-        container_uri=container_uri,
+        use_cuda=not is_compute_cpu_execution,
+        container_uri=compute_container_uri,
         vertex_ai_resource_config=compute_pool_config,
         env_vars=environment_variables,
         labels=labels,
@@ -190,8 +192,8 @@ def launch_graph_store_enabled_job(
         resource_config_uri=resource_config_uri,
         command_str=storage_command,
         args=storage_args,
-        use_cuda=is_cpu_execution,
-        container_uri=container_uri,
+        use_cuda=False,
+        container_uri=cpu_docker_uri,
         vertex_ai_resource_config=storage_pool_config,
         env_vars=environment_variables,
         labels=labels,

--- a/tests/unit/src/common/vertex_ai_launcher_test.py
+++ b/tests/unit/src/common/vertex_ai_launcher_test.py
@@ -192,13 +192,18 @@ class TestVertexAILauncher(TestCase):
         self.assertIn(
             f"--epochs={process_runtime_args['epochs']}", compute_job_config.args
         )
+        self.assertIn("--use_cuda", compute_job_config.args)
 
         # Verify storage pool config
         self.assertEqual(storage_job_config.machine_type, storage_pool.machine_type)
+        self.assertEqual(storage_job_config.container_uri, cpu_docker_uri)
         self.assertIn(
             "gigl.distributed.graph_store.storage_main",
             " ".join(storage_job_config.command),
         )
+        self.assertIsNotNone(storage_job_config.args)
+        assert storage_job_config.args is not None  # Type narrowing for mypy
+        self.assertNotIn("--use_cuda", storage_job_config.args)
 
         # Verify environment variables
         compute_env_vars = {
@@ -304,6 +309,7 @@ class TestVertexAILauncher(TestCase):
         self.assertIn(
             f"--output_path={process_runtime_args['output_path']}", job_config.args
         )
+        self.assertNotIn("--use_cuda", job_config.args)
 
         # Verify resource labels
         expected_labels = {


### PR DESCRIPTION
      ## Summary

      Fixes two related bugs in `gigl/src/common/vertex_ai_launcher.py` that caused GPU/CPU misconfiguration on Vertex AI training jobs.

      ### Bug 1: Inverted `use_cuda` flag
      `_determine_if_cpu_execution(...)` returns `True` when the resource config asks for CPU, but its result was passed directly as `use_cuda`.
      The launcher now negates it in both `launch_single_pool_job` and the graph-store compute pool, so `use_cuda` correctly reflects GPU
      configuration.

      Effect of the bug: CPU-configured jobs ran with `--use_cuda` (then crashed/fell back), and GPU-configured jobs ran without `--use_cuda`
      (then ran on CPU at GPU cost).

      ### Bug 2: Storage pool tracking compute pool's CUDA-ness
      In `launch_graph_store_enabled_job`, the storage pool was being built with the same `use_cuda` and `container_uri` as the compute pool. The
       storage pool runs `gigl.distributed.graph_store.storage_main`, which is a CPU entrypoint that should never consume GPU resources. Storage
      now hardcodes `use_cuda=False` and `container_uri=cpu_docker_uri`.

      ### Clarity refactor
      Inside `launch_graph_store_enabled_job`: renamed `is_cpu_execution` → `is_compute_cpu_execution` and `container_uri` →
      `compute_container_uri` to make explicit that these describe only the compute pool. Updated the comment accordingly.

      ### Tests
      Re-added unit-test assertions (originally bundled with an unrelated TensorBoard PR that was reverted):
      - `test_launch_training_graph_store_cuda`: compute pool passes `--use_cuda`; storage pool uses the CPU image and omits `--use_cuda`.
      - `test_launch_inference_single_pool_cpu`: CPU job does not pass `--use_cuda`.

      ## Test plan

      - [x] `make unit_test_py PY_TEST_FILES="vertex_ai_launcher_test.py"` — both tests pass
      - [x] `make type_check` — no mypy issues
      - [x] `make format` — no formatting changes required for the touched files

      🤖 Generated with [Claude Code](https://claude.com/claude-code)