### PR TITLE
Fix CPP Installation

### DIFF
--- a/requirements/install_py_deps.sh
+++ b/requirements/install_py_deps.sh
@@ -140,7 +140,7 @@ install_gigl_lib_deps() {
 
     # gigl-core's CMake build requires torch to be present during the build, but
     # torch is a runtime dep of gigl, not a declared build dep of gigl-core.
-    # uv sync ignores no-build-isolation-package for workspace members and always
+    # uv sync may ignore no-build-isolation-package for workspace members and always
     # builds them in an isolated environment where torch is absent.
     # Workaround: phase 1 installs everything except gigl-core (so torch lands in
     # the venv); phase 2 uses `uv pip install --no-build-isolation` which explicitly

--- a/requirements/install_py_deps.sh
+++ b/requirements/install_py_deps.sh
@@ -138,21 +138,21 @@ install_gigl_lib_deps() {
         flag_use_inexact_match="--inexact"
     fi
 
-    # gigl-core's CMake build requires torch to be present in the ambient venv
-    # (no-build-isolation-package = ["gigl-core"] in pyproject.toml), but torch is
-    # a runtime dep of gigl, not a declared build dep of gigl-core. On a fresh
-    # install uv has no signal to install torch before starting the gigl-core build.
-    # Phase 1 installs all packages except gigl-core (so torch lands in the venv);
-    # phase 2 builds gigl-core with torch already available.
+    # gigl-core's CMake build requires torch to be present during the build, but
+    # torch is a runtime dep of gigl, not a declared build dep of gigl-core.
+    # uv sync ignores no-build-isolation-package for workspace members and always
+    # builds them in an isolated environment where torch is absent.
+    # Workaround: phase 1 installs everything except gigl-core (so torch lands in
+    # the venv); phase 2 uses `uv pip install --no-build-isolation` which explicitly
+    # skips isolation and lets CMake find torch from the ambient venv.
     if [[ $DEV -eq 1 ]]
     then
         # https://docs.astral.sh/uv/reference/cli/#uv-sync
         uv sync ${extra_deps_clause[@]} --group dev --locked ${flag_use_inexact_match} --no-install-package gigl-core
-        uv sync ${extra_deps_clause[@]} --group dev --locked ${flag_use_inexact_match}
     else
         uv sync ${extra_deps_clause[@]} --group gigl-core-build-backend --locked ${flag_use_inexact_match} --no-install-package gigl-core
-        uv sync ${extra_deps_clause[@]} --group gigl-core-build-backend --locked ${flag_use_inexact_match}
     fi
+    uv pip install --no-build-isolation ./gigl-core/
 
     # Taken from https://stackoverflow.com/questions/59895/how-do-i-get-the-directory-where-a-bash-script-is-located-from-within-the-script
     # We do this so if `install_py_deps.sh` is run from a different directory, the script can still find the post_install.py file.

--- a/requirements/install_py_deps.sh
+++ b/requirements/install_py_deps.sh
@@ -138,11 +138,19 @@ install_gigl_lib_deps() {
         flag_use_inexact_match="--inexact"
     fi
 
+    # gigl-core's CMake build requires torch to be present in the ambient venv
+    # (no-build-isolation-package = ["gigl-core"] in pyproject.toml), but torch is
+    # a runtime dep of gigl, not a declared build dep of gigl-core. On a fresh
+    # install uv has no signal to install torch before starting the gigl-core build.
+    # Phase 1 installs all packages except gigl-core (so torch lands in the venv);
+    # phase 2 builds gigl-core with torch already available.
     if [[ $DEV -eq 1 ]]
     then
         # https://docs.astral.sh/uv/reference/cli/#uv-sync
+        uv sync ${extra_deps_clause[@]} --group dev --locked ${flag_use_inexact_match} --no-install-package gigl-core
         uv sync ${extra_deps_clause[@]} --group dev --locked ${flag_use_inexact_match}
     else
+        uv sync ${extra_deps_clause[@]} --group gigl-core-build-backend --locked ${flag_use_inexact_match} --no-install-package gigl-core
         uv sync ${extra_deps_clause[@]} --group gigl-core-build-backend --locked ${flag_use_inexact_match}
     fi
 


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
`make install_dev_deps` failed on some VMs with:
 
```
CMake Error at CMakeLists.txt:76: Cannot find torch cmake config in CMAKE_PREFIX_PATH
```
 
`gigl-core` is a C++/CUDA extension that must be compiled against PyTorch (CMake needs to locate torch's cmake config). The `pyproject.toml` has `no-build-isolation-package = ["gigl-core"]` to let CMake find torch from the ambient venv, but this setting seems to be transiently ignored by `uv sync` for workspace members — it then builds them in an isolated temporary environment (`.cache/uv/builds-v0/.tmpXXXX`) where torch is absent.
 
**The root bootstrapping problem:** torch is a runtime dependency of `gigl`, not a declared build dependency of `gigl-core`, so `uv` has no signal to install torch before starting the `gigl-core` build.

## Fix
 
Two-phase install in `install_py_deps.sh`:
 
1. `uv sync --no-install-package gigl-core` — installs all packages (including torch) into the venv, skipping `gigl-core`
2. `uv pip install --no-build-isolation ./gigl-core/` — builds `gigl-core` explicitly without isolation, so CMake finds torch in the now-populated venv
`uv pip install --no-build-isolation` bypasses the workspace-member isolation behavior that makes `no-build-isolation-package` transiently ineffective in `uv sync`.

`uv cache clean` also has been identified as a potential fix here, allowing `make_install_dev_deps` to work, but still seemed to be leading to failures when running `build_cpp_extensions`
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
