### PR TITLE
Guard data preprocessor against empty preprocessing specs

### DIFF
--- a/gigl/src/data_preprocessor/data_preprocessor.py
+++ b/gigl/src/data_preprocessor/data_preprocessor.py
@@ -352,6 +352,13 @@ class DataPreprocessor:
             edge_ref_to_preprocessing_spec
         )
 
+        if num_dataflow_jobs == 0:
+            logger.info("No data references to preprocess; skipping Dataflow.")
+            return PreprocessedMetadataReferences(
+                node_data=node_refs_and_results,
+                edge_data=edge_refs_and_results,
+            )
+
         with concurrent.futures.ThreadPoolExecutor(
             max_workers=num_dataflow_jobs
         ) as executor:

--- a/gigl/src/data_preprocessor/lib/enumerate/utils.py
+++ b/gigl/src/data_preprocessor/lib/enumerate/utils.py
@@ -251,7 +251,7 @@ class Enumerator:
             f"Launch {len(node_data_references)} node enumeration jobs in parallel."
         )
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(node_data_references)
+            max_workers=max(1, len(node_data_references))
         ) as executor:
             futures: list[concurrent.futures.Future] = list()
             for node_data_ref in node_data_references:
@@ -278,7 +278,7 @@ class Enumerator:
             f"Launch {len(edge_data_references)} edge enumeration jobs in parallel."
         )
         with concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(edge_data_references)
+            max_workers=max(1, len(edge_data_references))
         ) as executor:
             futures: list[concurrent.futures.Future] = list()
             for edge_data_ref in edge_data_references:


### PR DESCRIPTION
Clamp ThreadPoolExecutor max_workers to >=1 in the enumerator and short-circuit __preprocess_all_data_references when both node and edge spec dicts are empty, so an empty DataPreprocessorConfig no longer crashes with `max_workers must be greater than 0`.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
