### PR TITLE
Route sbt jar resolution through Google's Maven Central mirror

### DIFF
--- a/scala/.sbtopts
+++ b/scala/.sbtopts
@@ -1,0 +1,2 @@
+-Dsbt.override.build.repos=true
+-Dsbt.repository.config=repositories

--- a/scala/repositories
+++ b/scala/repositories
@@ -1,0 +1,6 @@
+[repositories]
+  local
+  gcs-maven-central: https://maven-central.storage-download.googleapis.com/maven2/
+  maven-central
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  sbt-plugin-releases: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]

--- a/scala_spark35/.sbtopts
+++ b/scala_spark35/.sbtopts
@@ -1,0 +1,2 @@
+-Dsbt.override.build.repos=true
+-Dsbt.repository.config=repositories

--- a/scala_spark35/repositories
+++ b/scala_spark35/repositories
@@ -1,0 +1,6 @@
+[repositories]
+  local
+  gcs-maven-central: https://maven-central.storage-download.googleapis.com/maven2/
+  maven-central
+  typesafe-ivy-releases: https://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  sbt-plugin-releases: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]


### PR DESCRIPTION
CI has been hitting HTTP 429 from repo1.maven.org during sbt dependency resolution. Add an sbt `repositories` file and `.sbtopts` to each scala project so coursier tries the GCS-backed mirror at maven-central.storage-download.googleapis.com first, with Maven Central as fallback. `sbt.override.build.repos=true` ensures project-level resolvers can't reintroduce direct Maven Central hits.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
