### PR TITLE
Add @overload signatures to l2_normalize_embeddings and clear 4 caller-side ty: ignore comments

### DIFF
--- a/gigl/src/common/models/layers/normalization.py
+++ b/gigl/src/common/models/layers/normalization.py
@@ -1,9 +1,21 @@
-from typing import Union
+from typing import Union, overload
 
 import torch
 from torch.nn import functional as F
 
 from gigl.src.common.types.graph_data import NodeType
+
+
+@overload
+def l2_normalize_embeddings(
+    node_typed_embeddings: torch.Tensor,
+) -> torch.Tensor: ...
+
+
+@overload
+def l2_normalize_embeddings(
+    node_typed_embeddings: dict[NodeType, torch.Tensor],
+) -> dict[NodeType, torch.Tensor]: ...
 
 
 def l2_normalize_embeddings(

--- a/gigl/src/common/models/pyg/heterogeneous.py
+++ b/gigl/src/common/models/pyg/heterogeneous.py
@@ -129,7 +129,7 @@ class HGT(nn.Module):
         if self.should_l2_normalize_embedding_layer_output:
             node_typed_embeddings = l2_normalize_embeddings(
                 node_typed_embeddings=node_typed_embeddings
-            )  # ty: ignore[invalid-assignment] TODO(ty-torch-container-shapes): fix ty false positives for torch container and return shapes.
+            )
 
         return node_typed_embeddings
 
@@ -285,4 +285,4 @@ class SimpleHGN(nn.Module):
             node_typed_embeddings = l2_normalize_embeddings(
                 node_typed_embeddings=node_typed_embeddings
             )
-        return node_typed_embeddings  # ty: ignore[invalid-return-type] TODO(ty-torch-container-shapes): fix ty false positives for torch container and return shapes.
+        return node_typed_embeddings

--- a/gigl/src/common/models/pyg/homogeneous.py
+++ b/gigl/src/common/models/pyg/homogeneous.py
@@ -146,11 +146,11 @@ class BasicHomogeneousGNN(nn.Module, GnnModel):
         if self.should_l2_normalize_embedding_layer_output:
             x = l2_normalize_embeddings(node_typed_embeddings=x)
         if self.return_emb:
-            return x  # ty: ignore[invalid-return-type] TODO(ty-torch-container-shapes): fix ty false positives for torch container and return shapes.
+            return x
         if self.linear_layer:
             x = self.linear(x)
 
-        return x  # ty: ignore[invalid-return-type] TODO(ty-torch-container-shapes): fix ty false positives for torch container and return shapes.
+        return x
 
     def init_conv_layers(
         self,


### PR DESCRIPTION
Add `@overload` signatures to `l2_normalize_embeddings` in `normalization.py` so ty resolves the return type concretely at call sites: `Tensor → Tensor` and `dict[NodeType, Tensor] → dict[NodeType, Tensor]`.

This clears 4 now-unnecessary caller-side `# ty: ignore` comments:
- `homogeneous.py:149,153` — tagged `ty-torch-container-shapes`
- `heterogeneous.py:130-132` — tagged `ty-torch-container-shapes`
- `heterogeneous.py:288` — tagged `ty-torch-container-shapes` (bonus clear)

The two in-body ignores in `normalization.py` (ty#2374 `Top[]` intersection bug) are intentionally preserved and owned by PR G.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
