### PR TITLE
Expose public API under gigl.distributed.graph_store

### DIFF
--- a/examples/link_prediction/graph_store/heterogeneous_inference.py
+++ b/examples/link_prediction/graph_store/heterogeneous_inference.py
@@ -99,13 +99,13 @@ from gigl.common import GcsUri, Uri, UriFactory
 from gigl.common.data.export import EmbeddingExporter, load_embeddings_to_bigquery
 from gigl.common.logger import Logger
 from gigl.common.utils.gcs import GcsUtils
-from gigl.distributed.graph_store.compute import (
+from gigl.distributed.graph_store import (
+    GraphStoreInfo,
+    RemoteDistDataset,
+    get_graph_store_info,
     init_compute_process,
     shutdown_compute_process,
 )
-from gigl.distributed.graph_store.remote_dist_dataset import RemoteDistDataset
-from gigl.distributed.utils import get_graph_store_info
-from gigl.env.distributed import GraphStoreInfo
 from gigl.nn import LinkPredictionGNN
 from gigl.src.common.types import AppliedTaskIdentifier
 from gigl.src.common.types.graph_data import EdgeType, NodeType

--- a/examples/link_prediction/graph_store/heterogeneous_training.py
+++ b/examples/link_prediction/graph_store/heterogeneous_training.py
@@ -94,13 +94,14 @@ from gigl.common.logger import Logger
 from gigl.common.utils.torch_training import is_distributed_available_and_initialized
 from gigl.distributed import DistABLPLoader
 from gigl.distributed.distributed_neighborloader import DistNeighborLoader
-from gigl.distributed.graph_store.compute import (
+from gigl.distributed.graph_store import (
+    GraphStoreInfo,
+    RemoteDistDataset,
+    get_graph_store_info,
     init_compute_process,
     shutdown_compute_process,
 )
-from gigl.distributed.graph_store.remote_dist_dataset import RemoteDistDataset
-from gigl.distributed.utils import get_available_device, get_graph_store_info
-from gigl.env.distributed import GraphStoreInfo
+from gigl.distributed.utils import get_available_device
 from gigl.nn import LinkPredictionGNN, RetrievalLoss
 from gigl.src.common.translators.model_eval_metrics_translator import (
     write_eval_metrics_to_uri,

--- a/examples/link_prediction/graph_store/homogeneous_inference.py
+++ b/examples/link_prediction/graph_store/homogeneous_inference.py
@@ -99,10 +99,12 @@ from gigl.common import GcsUri, Uri, UriFactory
 from gigl.common.data.export import EmbeddingExporter, load_embeddings_to_bigquery
 from gigl.common.logger import Logger
 from gigl.common.utils.gcs import GcsUtils
-from gigl.distributed.graph_store.compute import init_compute_process
-from gigl.distributed.graph_store.remote_dist_dataset import RemoteDistDataset
-from gigl.distributed.utils import get_graph_store_info
-from gigl.env.distributed import GraphStoreInfo
+from gigl.distributed.graph_store import (
+    GraphStoreInfo,
+    RemoteDistDataset,
+    get_graph_store_info,
+    init_compute_process,
+)
 from gigl.nn import LinkPredictionGNN
 from gigl.src.common.types import AppliedTaskIdentifier
 from gigl.src.common.types.graph_data import EdgeType, NodeType

--- a/examples/link_prediction/graph_store/homogeneous_training.py
+++ b/examples/link_prediction/graph_store/homogeneous_training.py
@@ -138,13 +138,14 @@ from gigl.common.logger import Logger
 from gigl.common.utils.torch_training import is_distributed_available_and_initialized
 from gigl.distributed import DistABLPLoader
 from gigl.distributed.distributed_neighborloader import DistNeighborLoader
-from gigl.distributed.graph_store.compute import (
+from gigl.distributed.graph_store import (
+    GraphStoreInfo,
+    RemoteDistDataset,
+    get_graph_store_info,
     init_compute_process,
     shutdown_compute_process,
 )
-from gigl.distributed.graph_store.remote_dist_dataset import RemoteDistDataset
-from gigl.distributed.utils import get_available_device, get_graph_store_info
-from gigl.env.distributed import GraphStoreInfo
+from gigl.distributed.utils import get_available_device
 from gigl.nn import LinkPredictionGNN, RetrievalLoss
 from gigl.src.common.translators.model_eval_metrics_translator import (
     write_eval_metrics_to_uri,

--- a/examples/link_prediction/graph_store/storage_main.py
+++ b/examples/link_prediction/graph_store/storage_main.py
@@ -82,12 +82,12 @@ import torch
 from gigl.common import Uri, UriFactory
 from gigl.common.logger import Logger
 from gigl.common.utils.os_utils import import_obj
-from gigl.distributed.graph_store.storage_utils import (
+from gigl.distributed.graph_store import (
+    GraphStoreInfo,
     build_storage_dataset,
+    get_graph_store_info,
     run_storage_server,
 )
-from gigl.distributed.utils import get_graph_store_info
-from gigl.env.distributed import GraphStoreInfo
 from gigl.utils.data_splitters import DistNodeAnchorLinkSplitter, DistNodeSplitter
 
 logger = Logger()

--- a/gigl/distributed/__init__.py
+++ b/gigl/distributed/__init__.py
@@ -3,6 +3,7 @@ GLT Distributed Classes implemented in GiGL
 """
 
 __all__ = [
+    "DistABLPLoader",
     "DistNeighborLoader",
     "DistDataset",
     "DistributedContext",

--- a/gigl/distributed/graph_store/__init__.py
+++ b/gigl/distributed/graph_store/__init__.py
@@ -1,0 +1,25 @@
+"""
+Public API for GiGL's graph-store deployment mode.
+
+Graph-store mode separates storage and compute clusters: storage nodes build and serve
+a partitioned dataset, while compute nodes connect over RPC via a ``RemoteDistDataset``.
+
+This module is the stable import surface for that workflow; helpers, RPC utilities, and
+server lifecycle internals remain in private submodules.
+"""
+
+__all__ = [
+    "GraphStoreInfo",
+    "RemoteDistDataset",
+    "build_storage_dataset",
+    "get_graph_store_info",
+    "init_compute_process",
+    "run_storage_server",
+    "shutdown_compute_process",
+]
+
+from gigl.distributed.utils import GraphStoreInfo, get_graph_store_info
+
+from .compute import init_compute_process, shutdown_compute_process
+from .remote_dist_dataset import RemoteDistDataset
+from .storage_utils import build_storage_dataset, run_storage_server

--- a/gigl/distributed/graph_store/__init__.py
+++ b/gigl/distributed/graph_store/__init__.py
@@ -18,8 +18,13 @@ __all__ = [
     "shutdown_compute_process",
 ]
 
+from gigl.distributed.graph_store.compute import (
+    init_compute_process,
+    shutdown_compute_process,
+)
+from gigl.distributed.graph_store.remote_dist_dataset import RemoteDistDataset
+from gigl.distributed.graph_store.storage_utils import (
+    build_storage_dataset,
+    run_storage_server,
+)
 from gigl.distributed.utils import GraphStoreInfo, get_graph_store_info
-
-from .compute import init_compute_process, shutdown_compute_process
-from .remote_dist_dataset import RemoteDistDataset
-from .storage_utils import build_storage_dataset, run_storage_server


### PR DESCRIPTION
Populate the previously-empty graph_store package __init__ with a stable import surface: init_compute_process, shutdown_compute_process, RemoteDistDataset, build_storage_dataset, run_storage_server, plus convenience re-exports of GraphStoreInfo and get_graph_store_info. RPC and server-lifecycle internals (DistServer, request_server, init_server, etc.) stay private.

Migrate the graph_store examples to the new public path and fix a latent bug where DistABLPLoader was imported but missing from gigl.distributed.__all__.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
