### PR TITLE
Add incoming sampling direction for graph transformer input contruction & anchor based PE

### DIFF
--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -432,7 +432,7 @@ class GraphTransformerEncoder(nn.Module):
         pairwise_attention_bias_attr_names: List of pairwise feature names used
             as additive attention bias. These must correspond to sparse
             graph-level attributes on ``data``.
-        tokenization_direction: Direction used for sequence token construction.
+        sampling_direction: Direction used for sequence token construction.
             ``"outgoing"`` preserves the existing k-hop reachability expansion.
             ``"incoming"`` expands over reversed edges and is supported only
             when ``sequence_construction_method="khop"``. Directed relative
@@ -501,7 +501,7 @@ class GraphTransformerEncoder(nn.Module):
         anchor_based_input_attr_names: Optional[list[str]] = None,
         anchor_based_input_embedding_dict: Optional[nn.ModuleDict] = None,
         pairwise_attention_bias_attr_names: Optional[list[str]] = None,
-        tokenization_direction: Literal["outgoing", "incoming"] = "outgoing",
+        sampling_direction: Literal["outgoing", "incoming"] = "outgoing",
         feature_embedding_layer_dict: Optional[nn.ModuleDict] = None,
         pe_integration_mode: Literal["concat", "add"] = "concat",
         activation: str = "gelu",
@@ -526,17 +526,17 @@ class GraphTransformerEncoder(nn.Module):
                 "sequence_construction_method must be one of {'khop', 'ppr'}, "
                 f"got '{sequence_construction_method}'"
             )
-        if tokenization_direction not in {"outgoing", "incoming"}:
+        if sampling_direction not in {"outgoing", "incoming"}:
             raise ValueError(
-                "tokenization_direction must be one of {'outgoing', 'incoming'}, "
-                f"got '{tokenization_direction}'"
+                "sampling_direction must be one of {'outgoing', 'incoming'}, "
+                f"got '{sampling_direction}'"
             )
         if (
-            tokenization_direction == "incoming"
+            sampling_direction == "incoming"
             and sequence_construction_method != "khop"
         ):
             raise ValueError(
-                "tokenization_direction='incoming' is currently supported only "
+                "sampling_direction='incoming' is currently supported only "
                 "with sequence_construction_method='khop'."
             )
         if sequence_positional_encoding_type is not None:
@@ -577,7 +577,7 @@ class GraphTransformerEncoder(nn.Module):
                 "sequence_construction_method='ppr'."
             )
         self._sequence_construction_method = sequence_construction_method
-        self._tokenization_direction = tokenization_direction
+        self._sampling_direction = sampling_direction
         self._sequence_positional_encoding_type = sequence_positional_encoding_type
         self._should_l2_normalize_embedding_layer_output = (
             should_l2_normalize_embedding_layer_output
@@ -819,7 +819,7 @@ class GraphTransformerEncoder(nn.Module):
             anchor_node_ids=anchor_node_ids,
             hop_distance=self._hop_distance,
             sequence_construction_method=self._sequence_construction_method,
-            tokenization_direction=self._tokenization_direction,
+            sampling_direction=self._sampling_direction,
             anchor_based_attention_bias_attr_names=self._anchor_based_attention_bias_attr_names,
             anchor_based_input_attr_names=self._anchor_based_input_attr_names,
             pairwise_attention_bias_attr_names=self._pairwise_attention_bias_attr_names,

--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -433,8 +433,8 @@ class GraphTransformerEncoder(nn.Module):
             as additive attention bias. These must correspond to sparse
             graph-level attributes on ``data``.
         sampling_direction: Direction used for sequence token construction.
-            ``"outgoing"`` preserves the existing k-hop reachability expansion.
-            ``"incoming"`` expands over reversed edges and is supported only
+            ``"out"`` preserves the existing k-hop reachability expansion.
+            ``"in"`` expands over reversed edges and is supported only
             when ``sequence_construction_method="khop"``. Directed relative
             encodings such as ``"hop_distance"`` should be computed with the
             same direction.
@@ -501,7 +501,7 @@ class GraphTransformerEncoder(nn.Module):
         anchor_based_input_attr_names: Optional[list[str]] = None,
         anchor_based_input_embedding_dict: Optional[nn.ModuleDict] = None,
         pairwise_attention_bias_attr_names: Optional[list[str]] = None,
-        sampling_direction: Literal["outgoing", "incoming"] = "outgoing",
+        sampling_direction: Literal["in", "out"] = "out",
         feature_embedding_layer_dict: Optional[nn.ModuleDict] = None,
         pe_integration_mode: Literal["concat", "add"] = "concat",
         activation: str = "gelu",
@@ -526,18 +526,15 @@ class GraphTransformerEncoder(nn.Module):
                 "sequence_construction_method must be one of {'khop', 'ppr'}, "
                 f"got '{sequence_construction_method}'"
             )
-        if sampling_direction not in {"outgoing", "incoming"}:
+        if sampling_direction not in {"in", "out"}:
             raise ValueError(
-                "sampling_direction must be one of {'outgoing', 'incoming'}, "
+                "sampling_direction must be one of {'in', 'out'}, "
                 f"got '{sampling_direction}'"
             )
-        if (
-            sampling_direction == "incoming"
-            and sequence_construction_method != "khop"
-        ):
+        if sequence_construction_method == "ppr" and sampling_direction != "out":
             raise ValueError(
-                "sampling_direction='incoming' is currently supported only "
-                "with sequence_construction_method='khop'."
+                "sequence_construction_method='ppr' supports only "
+                "sampling_direction='out'."
             )
         if sequence_positional_encoding_type is not None:
             sequence_positional_encoding_type = (

--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -435,7 +435,9 @@ class GraphTransformerEncoder(nn.Module):
         tokenization_direction: Direction used for sequence token construction.
             ``"outgoing"`` preserves the existing k-hop reachability expansion.
             ``"incoming"`` expands over reversed edges and is supported only
-            when ``sequence_construction_method="khop"``.
+            when ``sequence_construction_method="khop"``. Directed relative
+            encodings such as ``"hop_distance"`` should be computed with the
+            same direction.
         feature_embedding_layer_dict: Optional ModuleDict mapping node types to
             feature embedding layers. If provided, these are applied to node
             features before node projection. (default: None)

--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -432,6 +432,10 @@ class GraphTransformerEncoder(nn.Module):
         pairwise_attention_bias_attr_names: List of pairwise feature names used
             as additive attention bias. These must correspond to sparse
             graph-level attributes on ``data``.
+        tokenization_direction: Direction used for sequence token construction.
+            ``"outgoing"`` preserves the existing k-hop reachability expansion.
+            ``"incoming"`` expands over reversed edges and is supported only
+            when ``sequence_construction_method="khop"``.
         feature_embedding_layer_dict: Optional ModuleDict mapping node types to
             feature embedding layers. If provided, these are applied to node
             features before node projection. (default: None)
@@ -495,6 +499,7 @@ class GraphTransformerEncoder(nn.Module):
         anchor_based_input_attr_names: Optional[list[str]] = None,
         anchor_based_input_embedding_dict: Optional[nn.ModuleDict] = None,
         pairwise_attention_bias_attr_names: Optional[list[str]] = None,
+        tokenization_direction: Literal["outgoing", "incoming"] = "outgoing",
         feature_embedding_layer_dict: Optional[nn.ModuleDict] = None,
         pe_integration_mode: Literal["concat", "add"] = "concat",
         activation: str = "gelu",
@@ -518,6 +523,19 @@ class GraphTransformerEncoder(nn.Module):
             raise ValueError(
                 "sequence_construction_method must be one of {'khop', 'ppr'}, "
                 f"got '{sequence_construction_method}'"
+            )
+        if tokenization_direction not in {"outgoing", "incoming"}:
+            raise ValueError(
+                "tokenization_direction must be one of {'outgoing', 'incoming'}, "
+                f"got '{tokenization_direction}'"
+            )
+        if (
+            tokenization_direction == "incoming"
+            and sequence_construction_method != "khop"
+        ):
+            raise ValueError(
+                "tokenization_direction='incoming' is currently supported only "
+                "with sequence_construction_method='khop'."
             )
         if sequence_positional_encoding_type is not None:
             sequence_positional_encoding_type = (
@@ -557,6 +575,7 @@ class GraphTransformerEncoder(nn.Module):
                 "sequence_construction_method='ppr'."
             )
         self._sequence_construction_method = sequence_construction_method
+        self._tokenization_direction = tokenization_direction
         self._sequence_positional_encoding_type = sequence_positional_encoding_type
         self._should_l2_normalize_embedding_layer_output = (
             should_l2_normalize_embedding_layer_output
@@ -798,6 +817,7 @@ class GraphTransformerEncoder(nn.Module):
             anchor_node_ids=anchor_node_ids,
             hop_distance=self._hop_distance,
             sequence_construction_method=self._sequence_construction_method,
+            tokenization_direction=self._tokenization_direction,
             anchor_based_attention_bias_attr_names=self._anchor_based_attention_bias_attr_names,
             anchor_based_input_attr_names=self._anchor_based_input_attr_names,
             pairwise_attention_bias_attr_names=self._pairwise_attention_bias_attr_names,

--- a/gigl/transforms/add_positional_encodings.py
+++ b/gigl/transforms/add_positional_encodings.py
@@ -254,11 +254,11 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
             assumed to be undirected for distance computation.
             (default: :obj:`False`)
         sampling_direction (str, optional): Direction used for directed
-            distance computation. ``"outgoing"`` preserves existing shortest
-            paths over graph edges, while ``"incoming"`` computes shortest paths
-            over reversed graph edges. Use ``"incoming"`` to align hop-distance
-            relative encodings with incoming Graph Transformer sampling.
-            (default: :obj:`"outgoing"`)
+            distance computation. ``"out"`` preserves existing shortest paths
+            over graph edges, while ``"in"`` computes shortest paths over
+            reversed graph edges. Use ``"in"`` to align hop-distance relative
+            encodings with incoming Graph Transformer sampling.
+            (default: :obj:`"out"`)
     """
 
     def __init__(
@@ -266,11 +266,11 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         h_max: int,
         attr_name: Optional[str] = "hop_distance",
         is_undirected: bool = False,
-        sampling_direction: Literal["outgoing", "incoming"] = "outgoing",
+        sampling_direction: Literal["in", "out"] = "out",
     ) -> None:
-        if sampling_direction not in {"outgoing", "incoming"}:
+        if sampling_direction not in {"in", "out"}:
             raise ValueError(
-                "sampling_direction must be one of {'outgoing', 'incoming'}, "
+                "sampling_direction must be one of {'in', 'out'}, "
                 f"got '{sampling_direction}'."
             )
         self.h_max = h_max
@@ -287,7 +287,7 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         # Convert to homogeneous to compute shortest paths
         homo_data = data.to_homogeneous()
         edge_index = homo_data.edge_index
-        if self.sampling_direction == "incoming":
+        if self.sampling_direction == "in":
             edge_index = edge_index.flip(0)
         num_nodes = homo_data.num_nodes
         num_edges = edge_index.size(1)
@@ -457,7 +457,8 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         return data
 
     def __repr__(self) -> str:
-        repr_args = f"h_max={self.h_max}"
-        if self.sampling_direction != "outgoing":
-            repr_args += f", sampling_direction='{self.sampling_direction}'"
-        return f"{self.__class__.__name__}({repr_args})"
+        return (
+            f"{self.__class__.__name__}("
+            f"h_max={self.h_max}, sampling_direction='{self.sampling_direction}'"
+            ")"
+        )

--- a/gigl/transforms/add_positional_encodings.py
+++ b/gigl/transforms/add_positional_encodings.py
@@ -253,11 +253,11 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         is_undirected (bool, optional): If set to :obj:`True`, the graph is
             assumed to be undirected for distance computation.
             (default: :obj:`False`)
-        tokenization_direction (str, optional): Direction used for directed
+        sampling_direction (str, optional): Direction used for directed
             distance computation. ``"outgoing"`` preserves existing shortest
             paths over graph edges, while ``"incoming"`` computes shortest paths
             over reversed graph edges. Use ``"incoming"`` to align hop-distance
-            relative encodings with incoming Graph Transformer tokenization.
+            relative encodings with incoming Graph Transformer sampling.
             (default: :obj:`"outgoing"`)
     """
 
@@ -266,17 +266,17 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         h_max: int,
         attr_name: Optional[str] = "hop_distance",
         is_undirected: bool = False,
-        tokenization_direction: Literal["outgoing", "incoming"] = "outgoing",
+        sampling_direction: Literal["outgoing", "incoming"] = "outgoing",
     ) -> None:
-        if tokenization_direction not in {"outgoing", "incoming"}:
+        if sampling_direction not in {"outgoing", "incoming"}:
             raise ValueError(
-                "tokenization_direction must be one of {'outgoing', 'incoming'}, "
-                f"got '{tokenization_direction}'."
+                "sampling_direction must be one of {'outgoing', 'incoming'}, "
+                f"got '{sampling_direction}'."
             )
         self.h_max = h_max
         self.attr_name = attr_name
         self.is_undirected = is_undirected
-        self.tokenization_direction = tokenization_direction
+        self.sampling_direction = sampling_direction
 
     def forward(self, data: HeteroData) -> HeteroData:
         assert isinstance(data, HeteroData), (
@@ -287,7 +287,7 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         # Convert to homogeneous to compute shortest paths
         homo_data = data.to_homogeneous()
         edge_index = homo_data.edge_index
-        if self.tokenization_direction == "incoming":
+        if self.sampling_direction == "incoming":
             edge_index = edge_index.flip(0)
         num_nodes = homo_data.num_nodes
         num_edges = edge_index.size(1)
@@ -458,6 +458,6 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
 
     def __repr__(self) -> str:
         repr_args = f"h_max={self.h_max}"
-        if self.tokenization_direction != "outgoing":
-            repr_args += f", tokenization_direction='{self.tokenization_direction}'"
+        if self.sampling_direction != "outgoing":
+            repr_args += f", sampling_direction='{self.sampling_direction}'"
         return f"{self.__class__.__name__}({repr_args})"

--- a/gigl/transforms/add_positional_encodings.py
+++ b/gigl/transforms/add_positional_encodings.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 
 import torch
 from torch_geometric.data import HeteroData
@@ -253,6 +253,12 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         is_undirected (bool, optional): If set to :obj:`True`, the graph is
             assumed to be undirected for distance computation.
             (default: :obj:`False`)
+        tokenization_direction (str, optional): Direction used for directed
+            distance computation. ``"outgoing"`` preserves existing shortest
+            paths over graph edges, while ``"incoming"`` computes shortest paths
+            over reversed graph edges. Use ``"incoming"`` to align hop-distance
+            relative encodings with incoming Graph Transformer tokenization.
+            (default: :obj:`"outgoing"`)
     """
 
     def __init__(
@@ -260,10 +266,17 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         h_max: int,
         attr_name: Optional[str] = "hop_distance",
         is_undirected: bool = False,
+        tokenization_direction: Literal["outgoing", "incoming"] = "outgoing",
     ) -> None:
+        if tokenization_direction not in {"outgoing", "incoming"}:
+            raise ValueError(
+                "tokenization_direction must be one of {'outgoing', 'incoming'}, "
+                f"got '{tokenization_direction}'."
+            )
         self.h_max = h_max
         self.attr_name = attr_name
         self.is_undirected = is_undirected
+        self.tokenization_direction = tokenization_direction
 
     def forward(self, data: HeteroData) -> HeteroData:
         assert isinstance(data, HeteroData), (
@@ -274,6 +287,8 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         # Convert to homogeneous to compute shortest paths
         homo_data = data.to_homogeneous()
         edge_index = homo_data.edge_index
+        if self.tokenization_direction == "incoming":
+            edge_index = edge_index.flip(0)
         num_nodes = homo_data.num_nodes
         num_edges = edge_index.size(1)
 
@@ -442,4 +457,7 @@ class AddHeteroHopDistanceEncoding(BaseTransform):
         return data
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(h_max={self.h_max})"
+        repr_args = f"h_max={self.h_max}"
+        if self.tokenization_direction != "outgoing":
+            repr_args += f", tokenization_direction='{self.tokenization_direction}'"
+        return f"{self.__class__.__name__}({repr_args})"

--- a/gigl/transforms/graph_transformer.py
+++ b/gigl/transforms/graph_transformer.py
@@ -90,7 +90,7 @@ def heterodata_to_graph_transformer_input(
     anchor_based_attention_bias_attr_names: Optional[list[str]] = None,
     anchor_based_input_attr_names: Optional[list[str]] = None,
     pairwise_attention_bias_attr_names: Optional[list[str]] = None,
-    sampling_direction: Literal["outgoing", "incoming"] = "outgoing",
+    sampling_direction: Literal["in", "out"] = "out",
 ) -> tuple[Tensor, Tensor, SequenceAuxiliaryData]:
     """
     Transform a HeteroData object to Graph Transformer sequence input.
@@ -133,8 +133,8 @@ def heterodata_to_graph_transformer_input(
             as attention bias. These must correspond to sparse graph-level
             attributes on ``data``. Example: ['pairwise_distance'].
         sampling_direction: Direction used for token construction.
-            ``"outgoing"`` preserves the existing k-hop reachability expansion.
-            ``"incoming"`` expands over reversed edges and is supported only
+            ``"out"`` preserves the existing k-hop reachability expansion.
+            ``"in"`` expands over reversed edges and is supported only
             with ``sequence_construction_method="khop"``. Directed relative
             encodings such as ``"hop_distance"`` should be computed with the
             same direction.
@@ -197,19 +197,15 @@ def heterodata_to_graph_transformer_input(
             "be used as pairwise attention bias."
         )
 
-    if sampling_direction not in {"outgoing", "incoming"}:
+    if sampling_direction not in {"in", "out"}:
         raise ValueError(
-            "sampling_direction must be one of {'outgoing', 'incoming'}, "
+            "sampling_direction must be one of {'in', 'out'}, "
             f"got '{sampling_direction}'."
         )
 
-    if (
-        sampling_direction == "incoming"
-        and sequence_construction_method != "khop"
-    ):
+    if sequence_construction_method == "ppr" and sampling_direction != "out":
         raise ValueError(
-            "sampling_direction='incoming' is currently supported only with "
-            "sequence_construction_method='khop'."
+            "sequence_construction_method='ppr' supports only sampling_direction='out'."
         )
 
     if (
@@ -255,7 +251,7 @@ def heterodata_to_graph_transformer_input(
     ppr_weight_sequences: Optional[Tensor] = None
     if sequence_construction_method == "khop":
         homo_edge_index = homo_data.edge_index  # (2, num_edges)
-        if sampling_direction == "incoming":
+        if sampling_direction == "in":
             homo_edge_index = homo_edge_index.flip(0)
         # Use sparse matrix operations for efficient k-hop neighbor extraction
         # Returns: (batch_size, num_nodes) sparse matrix where non-zero entries are reachable

--- a/gigl/transforms/graph_transformer.py
+++ b/gigl/transforms/graph_transformer.py
@@ -90,7 +90,7 @@ def heterodata_to_graph_transformer_input(
     anchor_based_attention_bias_attr_names: Optional[list[str]] = None,
     anchor_based_input_attr_names: Optional[list[str]] = None,
     pairwise_attention_bias_attr_names: Optional[list[str]] = None,
-    tokenization_direction: Literal["outgoing", "incoming"] = "outgoing",
+    sampling_direction: Literal["outgoing", "incoming"] = "outgoing",
 ) -> tuple[Tensor, Tensor, SequenceAuxiliaryData]:
     """
     Transform a HeteroData object to Graph Transformer sequence input.
@@ -132,7 +132,7 @@ def heterodata_to_graph_transformer_input(
         pairwise_attention_bias_attr_names: List of pairwise feature names used
             as attention bias. These must correspond to sparse graph-level
             attributes on ``data``. Example: ['pairwise_distance'].
-        tokenization_direction: Direction used for token construction.
+        sampling_direction: Direction used for token construction.
             ``"outgoing"`` preserves the existing k-hop reachability expansion.
             ``"incoming"`` expands over reversed edges and is supported only
             with ``sequence_construction_method="khop"``. Directed relative
@@ -197,18 +197,18 @@ def heterodata_to_graph_transformer_input(
             "be used as pairwise attention bias."
         )
 
-    if tokenization_direction not in {"outgoing", "incoming"}:
+    if sampling_direction not in {"outgoing", "incoming"}:
         raise ValueError(
-            "tokenization_direction must be one of {'outgoing', 'incoming'}, "
-            f"got '{tokenization_direction}'."
+            "sampling_direction must be one of {'outgoing', 'incoming'}, "
+            f"got '{sampling_direction}'."
         )
 
     if (
-        tokenization_direction == "incoming"
+        sampling_direction == "incoming"
         and sequence_construction_method != "khop"
     ):
         raise ValueError(
-            "tokenization_direction='incoming' is currently supported only with "
+            "sampling_direction='incoming' is currently supported only with "
             "sequence_construction_method='khop'."
         )
 
@@ -255,7 +255,7 @@ def heterodata_to_graph_transformer_input(
     ppr_weight_sequences: Optional[Tensor] = None
     if sequence_construction_method == "khop":
         homo_edge_index = homo_data.edge_index  # (2, num_edges)
-        if tokenization_direction == "incoming":
+        if sampling_direction == "incoming":
             homo_edge_index = homo_edge_index.flip(0)
         # Use sparse matrix operations for efficient k-hop neighbor extraction
         # Returns: (batch_size, num_nodes) sparse matrix where non-zero entries are reachable

--- a/gigl/transforms/graph_transformer.py
+++ b/gigl/transforms/graph_transformer.py
@@ -90,6 +90,7 @@ def heterodata_to_graph_transformer_input(
     anchor_based_attention_bias_attr_names: Optional[list[str]] = None,
     anchor_based_input_attr_names: Optional[list[str]] = None,
     pairwise_attention_bias_attr_names: Optional[list[str]] = None,
+    tokenization_direction: Literal["outgoing", "incoming"] = "outgoing",
 ) -> tuple[Tensor, Tensor, SequenceAuxiliaryData]:
     """
     Transform a HeteroData object to Graph Transformer sequence input.
@@ -131,6 +132,10 @@ def heterodata_to_graph_transformer_input(
         pairwise_attention_bias_attr_names: List of pairwise feature names used
             as attention bias. These must correspond to sparse graph-level
             attributes on ``data``. Example: ['pairwise_distance'].
+        tokenization_direction: Direction used for token construction.
+            ``"outgoing"`` preserves the existing k-hop reachability expansion.
+            ``"incoming"`` expands over reversed edges and is supported only
+            with ``sequence_construction_method="khop"``.
 
     Returns:
         (sequences, valid_mask, attention_bias_data), where:
@@ -190,6 +195,21 @@ def heterodata_to_graph_transformer_input(
             "be used as pairwise attention bias."
         )
 
+    if tokenization_direction not in {"outgoing", "incoming"}:
+        raise ValueError(
+            "tokenization_direction must be one of {'outgoing', 'incoming'}, "
+            f"got '{tokenization_direction}'."
+        )
+
+    if (
+        tokenization_direction == "incoming"
+        and sequence_construction_method != "khop"
+    ):
+        raise ValueError(
+            "tokenization_direction='incoming' is currently supported only with "
+            "sequence_construction_method='khop'."
+        )
+
     if (
         PPR_WEIGHT_FEATURE_NAME in anchor_bias_attr_names + anchor_input_attr_names
         and sequence_construction_method != "ppr"
@@ -233,6 +253,8 @@ def heterodata_to_graph_transformer_input(
     ppr_weight_sequences: Optional[Tensor] = None
     if sequence_construction_method == "khop":
         homo_edge_index = homo_data.edge_index  # (2, num_edges)
+        if tokenization_direction == "incoming":
+            homo_edge_index = homo_edge_index.flip(0)
         # Use sparse matrix operations for efficient k-hop neighbor extraction
         # Returns: (batch_size, num_nodes) sparse matrix where non-zero entries are reachable
         reachable = _get_k_hop_neighbors_sparse(

--- a/gigl/transforms/graph_transformer.py
+++ b/gigl/transforms/graph_transformer.py
@@ -135,7 +135,9 @@ def heterodata_to_graph_transformer_input(
         tokenization_direction: Direction used for token construction.
             ``"outgoing"`` preserves the existing k-hop reachability expansion.
             ``"incoming"`` expands over reversed edges and is supported only
-            with ``sequence_construction_method="khop"``.
+            with ``sequence_construction_method="khop"``. Directed relative
+            encodings such as ``"hop_distance"`` should be computed with the
+            same direction.
 
     Returns:
         (sequences, valid_mask, attention_bias_data), where:

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -238,6 +238,33 @@ class TestGraphTransformerEncoder(TestCase):
 
         self.assertTrue(torch.allclose(result_1, result_2))
 
+    def test_forward_with_incoming_tokenization_direction(self) -> None:
+        """Test forward pass with incoming k-hop tokenization."""
+        data = _create_simple_hetero_data()
+        encoder = self._create_encoder(tokenization_direction="incoming")
+        encoder.eval()
+
+        with torch.no_grad():
+            embeddings = encoder(
+                data=data,
+                anchor_node_type=self._user_node_type,
+                device=self._device,
+            )
+
+        self.assertEqual(embeddings.shape, (3, self._out_dim))
+        self.assertFalse(torch.isnan(embeddings).any())
+
+    def test_tokenization_direction_rejects_invalid_value(self) -> None:
+        with self.assertRaisesRegex(ValueError, "tokenization_direction"):
+            self._create_encoder(tokenization_direction="sideways")
+
+    def test_incoming_tokenization_direction_requires_khop(self) -> None:
+        with self.assertRaisesRegex(ValueError, "currently supported only"):
+            self._create_encoder(
+                sequence_construction_method="ppr",
+                tokenization_direction="incoming",
+            )
+
 
 def _create_user_graph_with_pe() -> HeteroData:
     data = HeteroData()

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -238,10 +238,10 @@ class TestGraphTransformerEncoder(TestCase):
 
         self.assertTrue(torch.allclose(result_1, result_2))
 
-    def test_forward_with_incoming_sampling_direction(self) -> None:
+    def test_forward_with_in_sampling_direction(self) -> None:
         """Test forward pass with incoming k-hop sampling."""
         data = _create_simple_hetero_data()
-        encoder = self._create_encoder(sampling_direction="incoming")
+        encoder = self._create_encoder(sampling_direction="in")
         encoder.eval()
 
         with torch.no_grad():
@@ -258,11 +258,11 @@ class TestGraphTransformerEncoder(TestCase):
         with self.assertRaisesRegex(ValueError, "sampling_direction"):
             self._create_encoder(sampling_direction="sideways")
 
-    def test_incoming_sampling_direction_requires_khop(self) -> None:
-        with self.assertRaisesRegex(ValueError, "currently supported only"):
+    def test_in_sampling_direction_requires_khop(self) -> None:
+        with self.assertRaisesRegex(ValueError, "supports only"):
             self._create_encoder(
                 sequence_construction_method="ppr",
-                sampling_direction="incoming",
+                sampling_direction="in",
             )
 
 

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -238,10 +238,10 @@ class TestGraphTransformerEncoder(TestCase):
 
         self.assertTrue(torch.allclose(result_1, result_2))
 
-    def test_forward_with_incoming_tokenization_direction(self) -> None:
-        """Test forward pass with incoming k-hop tokenization."""
+    def test_forward_with_incoming_sampling_direction(self) -> None:
+        """Test forward pass with incoming k-hop sampling."""
         data = _create_simple_hetero_data()
-        encoder = self._create_encoder(tokenization_direction="incoming")
+        encoder = self._create_encoder(sampling_direction="incoming")
         encoder.eval()
 
         with torch.no_grad():
@@ -254,15 +254,15 @@ class TestGraphTransformerEncoder(TestCase):
         self.assertEqual(embeddings.shape, (3, self._out_dim))
         self.assertFalse(torch.isnan(embeddings).any())
 
-    def test_tokenization_direction_rejects_invalid_value(self) -> None:
-        with self.assertRaisesRegex(ValueError, "tokenization_direction"):
-            self._create_encoder(tokenization_direction="sideways")
+    def test_sampling_direction_rejects_invalid_value(self) -> None:
+        with self.assertRaisesRegex(ValueError, "sampling_direction"):
+            self._create_encoder(sampling_direction="sideways")
 
-    def test_incoming_tokenization_direction_requires_khop(self) -> None:
+    def test_incoming_sampling_direction_requires_khop(self) -> None:
         with self.assertRaisesRegex(ValueError, "currently supported only"):
             self._create_encoder(
                 sequence_construction_method="ppr",
-                tokenization_direction="incoming",
+                sampling_direction="incoming",
             )
 
 

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -1,6 +1,6 @@
 """Tests for GraphTransformerEncoder."""
 
-from typing import cast
+from typing import Literal, cast
 
 import torch
 import torch.nn as nn
@@ -247,7 +247,15 @@ class TestGraphTransformerEncoder(TestCase):
     def test_readout_mode_rejects_invalid_value(self) -> None:
         """Test that unsupported readout modes fail fast."""
         with self.assertRaisesRegex(ValueError, "readout_mode"):
-            self._create_encoder(readout_mode="anchor_neighbor_attention")
+            self._create_encoder(
+                readout_mode=cast(
+                    Literal[
+                        "anchor_neighbor_attention",
+                        "anchor_only",
+                    ],
+                    "mean_pool",
+                )
+            )
 
     def test_forward_with_anchor_only_readout(self) -> None:
         """Test public forward with anchor-only readout."""

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -277,6 +277,7 @@ class TestGraphTransformerEncoder(TestCase):
                 sequence_construction_method="ppr",
                 sampling_direction="in",
             )
+
     def test_anchor_only_readout_returns_anchor_token(self) -> None:
         """Test anchor-only readout returns the post-norm anchor token."""
         encoder = self._create_encoder(

--- a/tests/unit/transforms/add_positional_encodings_test.py
+++ b/tests/unit/transforms/add_positional_encodings_test.py
@@ -1,3 +1,5 @@
+from typing import Literal, cast
+
 import torch
 from absl.testing import absltest
 from torch_geometric.data import HeteroData
@@ -47,6 +49,19 @@ def create_empty_hetero_data() -> HeteroData:
     data = HeteroData()
     data["user"].x = torch.zeros(0, 4)
     data["item"].x = torch.zeros(0, 4)
+    return data
+
+
+def create_directed_chain_data() -> HeteroData:
+    """Create a directed chain 0 -> 1 -> 2 for direction tests."""
+    data = HeteroData()
+    data["user"].x = torch.randn(3, 4)
+    data["user", "to", "user"].edge_index = torch.tensor(
+        [
+            [0, 1],
+            [1, 2],
+        ]
+    )
     return data
 
 
@@ -267,6 +282,45 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
         self.assertTrue(result.hop_distance.is_sparse_csr)
         self.assertEqual(result.hop_distance.shape, (5, 5))
 
+    def test_forward_tokenization_direction_defaults_to_outgoing(self):
+        """Outgoing hop distances preserve existing directed reachability."""
+        data = create_directed_chain_data()
+        transform = AddHeteroHopDistanceEncoding(h_max=2)
+
+        result = transform(data)
+        dense = result.hop_distance.to_dense()
+
+        self.assertEqual(dense[0, 1].item(), 1.0)
+        self.assertEqual(dense[0, 2].item(), 2.0)
+        self.assertEqual(dense[2, 1].item(), 0.0)
+        self.assertEqual(dense[2, 0].item(), 0.0)
+
+    def test_forward_tokenization_direction_incoming_reverses_reachability(self):
+        """Incoming hop distances are computed over reversed graph edges."""
+        data = create_directed_chain_data()
+        transform = AddHeteroHopDistanceEncoding(
+            h_max=2,
+            tokenization_direction="incoming",
+        )
+
+        result = transform(data)
+        dense = result.hop_distance.to_dense()
+
+        self.assertEqual(dense[2, 1].item(), 1.0)
+        self.assertEqual(dense[2, 0].item(), 2.0)
+        self.assertEqual(dense[0, 1].item(), 0.0)
+        self.assertEqual(dense[0, 2].item(), 0.0)
+
+    def test_tokenization_direction_rejects_invalid_value(self):
+        with self.assertRaisesRegex(ValueError, "tokenization_direction"):
+            AddHeteroHopDistanceEncoding(
+                h_max=2,
+                tokenization_direction=cast(
+                    Literal["outgoing", "incoming"],
+                    "sideways",
+                ),
+            )
+
     def test_forward_empty_graph(self):
         """Test forward pass with empty graph."""
         data = create_empty_hetero_data()
@@ -284,6 +338,17 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
         """Test string representation."""
         transform = AddHeteroHopDistanceEncoding(h_max=5)
         self.assertEqual(repr(transform), "AddHeteroHopDistanceEncoding(h_max=5)")
+
+    def test_repr_incoming_tokenization_direction(self):
+        """Test string representation with non-default direction."""
+        transform = AddHeteroHopDistanceEncoding(
+            h_max=5,
+            tokenization_direction="incoming",
+        )
+        self.assertEqual(
+            repr(transform),
+            "AddHeteroHopDistanceEncoding(h_max=5, tokenization_direction='incoming')",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/transforms/add_positional_encodings_test.py
+++ b/tests/unit/transforms/add_positional_encodings_test.py
@@ -282,8 +282,8 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
         self.assertTrue(result.hop_distance.is_sparse_csr)
         self.assertEqual(result.hop_distance.shape, (5, 5))
 
-    def test_forward_sampling_direction_defaults_to_outgoing(self):
-        """Outgoing hop distances preserve existing directed reachability."""
+    def test_forward_sampling_direction_defaults_to_out(self):
+        """Out hop distances preserve existing directed reachability."""
         data = create_directed_chain_data()
         transform = AddHeteroHopDistanceEncoding(h_max=2)
 
@@ -295,12 +295,12 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
         self.assertEqual(dense[2, 1].item(), 0.0)
         self.assertEqual(dense[2, 0].item(), 0.0)
 
-    def test_forward_sampling_direction_incoming_reverses_reachability(self):
-        """Incoming hop distances are computed over reversed graph edges."""
+    def test_forward_sampling_direction_in_reverses_reachability(self):
+        """In hop distances are computed over reversed graph edges."""
         data = create_directed_chain_data()
         transform = AddHeteroHopDistanceEncoding(
             h_max=2,
-            sampling_direction="incoming",
+            sampling_direction="in",
         )
 
         result = transform(data)
@@ -316,7 +316,7 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
             AddHeteroHopDistanceEncoding(
                 h_max=2,
                 sampling_direction=cast(
-                    Literal["outgoing", "incoming"],
+                    Literal["in", "out"],
                     "sideways",
                 ),
             )
@@ -337,17 +337,20 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
     def test_repr(self):
         """Test string representation."""
         transform = AddHeteroHopDistanceEncoding(h_max=5)
-        self.assertEqual(repr(transform), "AddHeteroHopDistanceEncoding(h_max=5)")
+        self.assertEqual(
+            repr(transform),
+            "AddHeteroHopDistanceEncoding(h_max=5, sampling_direction='out')",
+        )
 
-    def test_repr_incoming_sampling_direction(self):
+    def test_repr_in_sampling_direction(self):
         """Test string representation with non-default direction."""
         transform = AddHeteroHopDistanceEncoding(
             h_max=5,
-            sampling_direction="incoming",
+            sampling_direction="in",
         )
         self.assertEqual(
             repr(transform),
-            "AddHeteroHopDistanceEncoding(h_max=5, sampling_direction='incoming')",
+            "AddHeteroHopDistanceEncoding(h_max=5, sampling_direction='in')",
         )
 
 

--- a/tests/unit/transforms/add_positional_encodings_test.py
+++ b/tests/unit/transforms/add_positional_encodings_test.py
@@ -282,7 +282,7 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
         self.assertTrue(result.hop_distance.is_sparse_csr)
         self.assertEqual(result.hop_distance.shape, (5, 5))
 
-    def test_forward_tokenization_direction_defaults_to_outgoing(self):
+    def test_forward_sampling_direction_defaults_to_outgoing(self):
         """Outgoing hop distances preserve existing directed reachability."""
         data = create_directed_chain_data()
         transform = AddHeteroHopDistanceEncoding(h_max=2)
@@ -295,12 +295,12 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
         self.assertEqual(dense[2, 1].item(), 0.0)
         self.assertEqual(dense[2, 0].item(), 0.0)
 
-    def test_forward_tokenization_direction_incoming_reverses_reachability(self):
+    def test_forward_sampling_direction_incoming_reverses_reachability(self):
         """Incoming hop distances are computed over reversed graph edges."""
         data = create_directed_chain_data()
         transform = AddHeteroHopDistanceEncoding(
             h_max=2,
-            tokenization_direction="incoming",
+            sampling_direction="incoming",
         )
 
         result = transform(data)
@@ -311,11 +311,11 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
         self.assertEqual(dense[0, 1].item(), 0.0)
         self.assertEqual(dense[0, 2].item(), 0.0)
 
-    def test_tokenization_direction_rejects_invalid_value(self):
-        with self.assertRaisesRegex(ValueError, "tokenization_direction"):
+    def test_sampling_direction_rejects_invalid_value(self):
+        with self.assertRaisesRegex(ValueError, "sampling_direction"):
             AddHeteroHopDistanceEncoding(
                 h_max=2,
-                tokenization_direction=cast(
+                sampling_direction=cast(
                     Literal["outgoing", "incoming"],
                     "sideways",
                 ),
@@ -339,15 +339,15 @@ class TestAddHeteroHopDistanceEncoding(TestCase):
         transform = AddHeteroHopDistanceEncoding(h_max=5)
         self.assertEqual(repr(transform), "AddHeteroHopDistanceEncoding(h_max=5)")
 
-    def test_repr_incoming_tokenization_direction(self):
+    def test_repr_incoming_sampling_direction(self):
         """Test string representation with non-default direction."""
         transform = AddHeteroHopDistanceEncoding(
             h_max=5,
-            tokenization_direction="incoming",
+            sampling_direction="incoming",
         )
         self.assertEqual(
             repr(transform),
-            "AddHeteroHopDistanceEncoding(h_max=5, tokenization_direction='incoming')",
+            "AddHeteroHopDistanceEncoding(h_max=5, sampling_direction='incoming')",
         )
 
 

--- a/tests/unit/transforms/graph_transformer_test.py
+++ b/tests/unit/transforms/graph_transformer_test.py
@@ -125,7 +125,7 @@ def create_ppr_sequence_hetero_data() -> HeteroData:
 
 
 def create_directed_chain_data() -> HeteroData:
-    """Create a directed chain 0 -> 1 -> 2 for tokenization direction tests."""
+    """Create a directed chain 0 -> 1 -> 2 for sampling direction tests."""
     data = HeteroData()
     data["user"].x = torch.tensor([[10.0], [11.0], [12.0]])
     data["user", "to", "user"].edge_index = torch.tensor(
@@ -320,8 +320,8 @@ class TestHeteroToGraphTransformerInput(TestCase):
         # First position should be anchor node
         self.assertTrue(torch.allclose(sequences[0, 0], anchor_feature))
 
-    def test_tokenization_direction_defaults_to_outgoing(self):
-        """Outgoing tokenization preserves existing k-hop reachability."""
+    def test_sampling_direction_defaults_to_outgoing(self):
+        """Outgoing sampling preserves existing k-hop reachability."""
         data = create_directed_chain_data()
 
         sequences, valid_mask, _ = heterodata_to_graph_transformer_input(
@@ -336,8 +336,8 @@ class TestHeteroToGraphTransformerInput(TestCase):
         self.assertEqual(valid_mask[0].tolist(), [True, False, False])
         self.assertEqual(sequences[0, :, 0].tolist(), [12.0, 0.0, 0.0])
 
-    def test_tokenization_direction_incoming_uses_reverse_reachability(self):
-        """Incoming tokenization includes upstream message-source nodes."""
+    def test_sampling_direction_incoming_uses_reverse_reachability(self):
+        """Incoming sampling includes upstream message-source nodes."""
         data = create_directed_chain_data()
 
         sequences, valid_mask, _ = heterodata_to_graph_transformer_input(
@@ -347,28 +347,28 @@ class TestHeteroToGraphTransformerInput(TestCase):
             anchor_node_type="user",
             anchor_node_ids=torch.tensor([2]),
             hop_distance=2,
-            tokenization_direction="incoming",
+            sampling_direction="incoming",
         )
 
         self.assertEqual(valid_mask[0].tolist(), [True, True, True])
         self.assertEqual(sequences[0, :, 0].tolist(), [12.0, 10.0, 11.0])
 
-    def test_tokenization_direction_rejects_invalid_value(self):
+    def test_sampling_direction_rejects_invalid_value(self):
         data = create_directed_chain_data()
 
-        with self.assertRaisesRegex(ValueError, "tokenization_direction"):
+        with self.assertRaisesRegex(ValueError, "sampling_direction"):
             heterodata_to_graph_transformer_input(
                 data=data,
                 batch_size=1,
                 max_seq_len=3,
                 anchor_node_type="user",
-                tokenization_direction=cast(
+                sampling_direction=cast(
                     Literal["outgoing", "incoming"],
                     "sideways",
                 ),
             )
 
-    def test_tokenization_direction_incoming_requires_khop(self):
+    def test_sampling_direction_incoming_requires_khop(self):
         data = create_ppr_sequence_hetero_data()
 
         with self.assertRaisesRegex(ValueError, "currently supported only"):
@@ -378,7 +378,7 @@ class TestHeteroToGraphTransformerInput(TestCase):
                 max_seq_len=3,
                 anchor_node_type="user",
                 sequence_construction_method="ppr",
-                tokenization_direction="incoming",
+                sampling_direction="incoming",
             )
 
     def test_different_anchor_types(self):

--- a/tests/unit/transforms/graph_transformer_test.py
+++ b/tests/unit/transforms/graph_transformer_test.py
@@ -2,6 +2,8 @@
 Tests for heterodata_to_graph_transformer_input transform.
 """
 
+from typing import Literal, cast
+
 import torch
 import torch.nn as nn
 from absl.testing import absltest
@@ -119,6 +121,19 @@ def create_ppr_sequence_hetero_data() -> HeteroData:
 
     data.hop_distance = hop_distance.to_sparse_csr()
 
+    return data
+
+
+def create_directed_chain_data() -> HeteroData:
+    """Create a directed chain 0 -> 1 -> 2 for tokenization direction tests."""
+    data = HeteroData()
+    data["user"].x = torch.tensor([[10.0], [11.0], [12.0]])
+    data["user", "to", "user"].edge_index = torch.tensor(
+        [
+            [0, 1],
+            [1, 2],
+        ]
+    )
     return data
 
 
@@ -304,6 +319,67 @@ class TestHeteroToGraphTransformerInput(TestCase):
 
         # First position should be anchor node
         self.assertTrue(torch.allclose(sequences[0, 0], anchor_feature))
+
+    def test_tokenization_direction_defaults_to_outgoing(self):
+        """Outgoing tokenization preserves existing k-hop reachability."""
+        data = create_directed_chain_data()
+
+        sequences, valid_mask, _ = heterodata_to_graph_transformer_input(
+            data=data,
+            batch_size=1,
+            max_seq_len=3,
+            anchor_node_type="user",
+            anchor_node_ids=torch.tensor([2]),
+            hop_distance=2,
+        )
+
+        self.assertEqual(valid_mask[0].tolist(), [True, False, False])
+        self.assertEqual(sequences[0, :, 0].tolist(), [12.0, 0.0, 0.0])
+
+    def test_tokenization_direction_incoming_uses_reverse_reachability(self):
+        """Incoming tokenization includes upstream message-source nodes."""
+        data = create_directed_chain_data()
+
+        sequences, valid_mask, _ = heterodata_to_graph_transformer_input(
+            data=data,
+            batch_size=1,
+            max_seq_len=3,
+            anchor_node_type="user",
+            anchor_node_ids=torch.tensor([2]),
+            hop_distance=2,
+            tokenization_direction="incoming",
+        )
+
+        self.assertEqual(valid_mask[0].tolist(), [True, True, True])
+        self.assertEqual(sequences[0, :, 0].tolist(), [12.0, 10.0, 11.0])
+
+    def test_tokenization_direction_rejects_invalid_value(self):
+        data = create_directed_chain_data()
+
+        with self.assertRaisesRegex(ValueError, "tokenization_direction"):
+            heterodata_to_graph_transformer_input(
+                data=data,
+                batch_size=1,
+                max_seq_len=3,
+                anchor_node_type="user",
+                tokenization_direction=cast(
+                    Literal["outgoing", "incoming"],
+                    "sideways",
+                ),
+            )
+
+    def test_tokenization_direction_incoming_requires_khop(self):
+        data = create_ppr_sequence_hetero_data()
+
+        with self.assertRaisesRegex(ValueError, "currently supported only"):
+            heterodata_to_graph_transformer_input(
+                data=data,
+                batch_size=1,
+                max_seq_len=3,
+                anchor_node_type="user",
+                sequence_construction_method="ppr",
+                tokenization_direction="incoming",
+            )
 
     def test_different_anchor_types(self):
         """Test with different anchor node types."""

--- a/tests/unit/transforms/graph_transformer_test.py
+++ b/tests/unit/transforms/graph_transformer_test.py
@@ -320,8 +320,8 @@ class TestHeteroToGraphTransformerInput(TestCase):
         # First position should be anchor node
         self.assertTrue(torch.allclose(sequences[0, 0], anchor_feature))
 
-    def test_sampling_direction_defaults_to_outgoing(self):
-        """Outgoing sampling preserves existing k-hop reachability."""
+    def test_sampling_direction_defaults_to_out(self):
+        """Out sampling preserves existing k-hop reachability."""
         data = create_directed_chain_data()
 
         sequences, valid_mask, _ = heterodata_to_graph_transformer_input(
@@ -336,8 +336,8 @@ class TestHeteroToGraphTransformerInput(TestCase):
         self.assertEqual(valid_mask[0].tolist(), [True, False, False])
         self.assertEqual(sequences[0, :, 0].tolist(), [12.0, 0.0, 0.0])
 
-    def test_sampling_direction_incoming_uses_reverse_reachability(self):
-        """Incoming sampling includes upstream message-source nodes."""
+    def test_sampling_direction_in_uses_reverse_reachability(self):
+        """In sampling includes upstream message-source nodes."""
         data = create_directed_chain_data()
 
         sequences, valid_mask, _ = heterodata_to_graph_transformer_input(
@@ -347,7 +347,7 @@ class TestHeteroToGraphTransformerInput(TestCase):
             anchor_node_type="user",
             anchor_node_ids=torch.tensor([2]),
             hop_distance=2,
-            sampling_direction="incoming",
+            sampling_direction="in",
         )
 
         self.assertEqual(valid_mask[0].tolist(), [True, True, True])
@@ -363,22 +363,22 @@ class TestHeteroToGraphTransformerInput(TestCase):
                 max_seq_len=3,
                 anchor_node_type="user",
                 sampling_direction=cast(
-                    Literal["outgoing", "incoming"],
+                    Literal["in", "out"],
                     "sideways",
                 ),
             )
 
-    def test_sampling_direction_incoming_requires_khop(self):
+    def test_sampling_direction_in_requires_khop(self):
         data = create_ppr_sequence_hetero_data()
 
-        with self.assertRaisesRegex(ValueError, "currently supported only"):
+        with self.assertRaisesRegex(ValueError, "supports only"):
             heterodata_to_graph_transformer_input(
                 data=data,
                 batch_size=1,
                 max_seq_len=3,
                 anchor_node_type="user",
                 sequence_construction_method="ppr",
-                sampling_direction="incoming",
+                sampling_direction="in",
             )
 
     def test_different_anchor_types(self):


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
- update khop sequence construction to be able to use incoming edges, as our khop sampling does incoming edge sampling
- update the anchor based hop distance PE compute as well to enable incoming 
<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
