### PR TITLE
Add anchor-only graph transformer readout

### DIFF
--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -3,8 +3,8 @@
 Adapted from RelGT's LocalModule (https://github.com/snap-stanford/relgt).
 Converts heterogeneous graph data into fixed-length sequences via
 ``heterodata_to_graph_transformer_input``, processes through a stack of pre-norm
-transformer encoder layers, then produces per-node embeddings via
-attention-weighted neighbor readout.
+transformer encoder layers, then produces per-node embeddings via configurable
+anchor or anchor-neighbor readout.
 
 Conforms to the same forward interface as ``HGT`` and ``SimpleHGN`` in
 ``gigl.src.common.models.pyg.heterogeneous``, making it a drop-in
@@ -366,8 +366,8 @@ class GraphTransformerEncoder(nn.Module):
 
     Converts heterogeneous graph data into fixed-length sequences via
     ``heterodata_to_graph_transformer_input``, processes through pre-norm
-    transformer encoder layers, and produces per-node embeddings via
-    attention-weighted neighbor readout (from RelGT's LocalModule).
+    transformer encoder layers, and produces per-node embeddings via configurable
+    anchor or anchor-neighbor readout.
 
     Conforms to the same forward interface as ``HGT`` and ``SimpleHGN``,
     making it a drop-in encoder for ``LinkPredictionGNN``.
@@ -398,6 +398,11 @@ class GraphTransformerEncoder(nn.Module):
             add learned absolute position embeddings here, while attention-level
             options like RoPE or ALiBi would require changes inside the
             attention block.
+        readout_mode: Strategy used to turn encoded sequence tokens into one
+            embedding per anchor. ``"anchor_neighbor_attention"`` preserves the
+            existing behavior by adding the encoded anchor token to an
+            attention-weighted neighbor aggregation. ``"anchor_only"`` returns
+            only the encoded anchor token.
         dropout_rate: Dropout probability for feed-forward layers.
         attention_dropout_rate: Dropout probability for attention weights.
         should_l2_normalize_embedding_layer_output: Whether to L2 normalize
@@ -487,6 +492,10 @@ class GraphTransformerEncoder(nn.Module):
         hop_distance: int = 2,
         sequence_construction_method: Literal["khop", "ppr"] = "khop",
         sequence_positional_encoding_type: Optional[str] = None,
+        readout_mode: Literal[
+            "anchor_neighbor_attention",
+            "anchor_only",
+        ] = "anchor_neighbor_attention",
         dropout_rate: float = 0.1,
         attention_dropout_rate: float = 0.0,
         should_l2_normalize_embedding_layer_output: bool = False,
@@ -509,11 +518,18 @@ class GraphTransformerEncoder(nn.Module):
                 "pe_integration_mode must be one of {'concat', 'add'}, "
                 f"got '{pe_integration_mode}'"
             )
+        if readout_mode not in {"anchor_neighbor_attention", "anchor_only"}:
+            raise ValueError(
+                "readout_mode must be one of "
+                "{'anchor_neighbor_attention', 'anchor_only'}, "
+                f"got '{readout_mode}'"
+            )
 
         self._hid_dim = hid_dim
         self._out_dim = out_dim
         self._max_seq_len = max_seq_len
         self._hop_distance = hop_distance
+        self._readout_mode = readout_mode
         if sequence_construction_method not in {"khop", "ppr"}:
             raise ValueError(
                 "sequence_construction_method must be one of {'khop', 'ppr'}, "
@@ -672,7 +688,9 @@ class GraphTransformerEncoder(nn.Module):
         self._final_norm = nn.LayerNorm(hid_dim)
 
         # Readout attention: projects concatenated (anchor, neighbor) to score
-        self._readout_attention = nn.Linear(2 * hid_dim, 1)
+        self._readout_attention: Optional[nn.Linear] = None
+        if self._readout_mode == "anchor_neighbor_attention":
+            self._readout_attention = nn.Linear(2 * hid_dim, 1)
 
         # Output projection: hid_dim -> out_dim
         self._output_projection = nn.Linear(hid_dim, out_dim)
@@ -1058,6 +1076,9 @@ class GraphTransformerEncoder(nn.Module):
 
         # Readout: anchor (position 0) + attention-weighted neighbor aggregation
         anchor = x[:, 0, :].unsqueeze(1)  # (batch, 1, hid_dim)
+        if self._readout_mode == "anchor_only":
+            return anchor.squeeze(1)
+
         neighbors = x[:, 1:, :]  # (batch, seq-1, hid_dim)
         neighbor_valid_mask = valid_mask[:, 1:]
         seq_minus_one = neighbors.size(1)
@@ -1069,6 +1090,8 @@ class GraphTransformerEncoder(nn.Module):
         anchor_expanded = anchor.expand(-1, seq_minus_one, -1)
 
         # Compute attention scores over neighbors
+        if self._readout_attention is None:
+            raise ValueError("Readout attention layer is not initialized.")
         readout_scores = self._readout_attention(
             torch.cat([anchor_expanded, neighbors], dim=-1)
         )  # (batch, seq-1, 1)

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -238,6 +238,140 @@ class TestGraphTransformerEncoder(TestCase):
 
         self.assertTrue(torch.allclose(result_1, result_2))
 
+    def test_readout_mode_rejects_invalid_value(self) -> None:
+        """Test that unsupported readout modes fail fast."""
+        with self.assertRaisesRegex(ValueError, "readout_mode"):
+            self._create_encoder(readout_mode="neighbor_average")
+
+    def test_forward_with_anchor_only_readout(self) -> None:
+        """Test public forward with anchor-only readout."""
+        data = _create_simple_hetero_data()
+        encoder = self._create_encoder(readout_mode="anchor_only")
+        encoder.eval()
+
+        self.assertIsNone(encoder._readout_attention)
+
+        with torch.no_grad():
+            embeddings = encoder(
+                data=data,
+                anchor_node_type=self._user_node_type,
+                device=self._device,
+            )
+
+        self.assertEqual(embeddings.shape, (3, self._out_dim))
+        self.assertFalse(torch.isnan(embeddings).any())
+
+    def test_anchor_only_readout_returns_anchor_token(self) -> None:
+        """Test anchor-only readout returns the post-norm anchor token."""
+        encoder = self._create_encoder(
+            hid_dim=4,
+            out_dim=2,
+            num_layers=0,
+            num_heads=2,
+            readout_mode="anchor_only",
+        )
+        self.assertIsNone(encoder._readout_attention)
+
+        sequences = torch.tensor(
+            [
+                [
+                    [1.0, 2.0, 3.0, 4.0],
+                    [100.0, 100.0, 100.0, 100.0],
+                    [-100.0, -100.0, -100.0, -100.0],
+                ],
+                [
+                    [4.0, 3.0, 2.0, 1.0],
+                    [50.0, 60.0, 70.0, 80.0],
+                    [90.0, 100.0, 110.0, 120.0],
+                ],
+            ]
+        )
+        valid_mask = torch.tensor(
+            [
+                [True, True, True],
+                [True, True, False],
+            ]
+        )
+
+        expected = encoder._final_norm(sequences[:, :1, :]).squeeze(1)
+        actual = encoder._encode_and_readout(
+            sequences=sequences,
+            valid_mask=valid_mask,
+        )
+
+        self.assertTrue(torch.allclose(actual, expected, atol=1e-6))
+
+    def test_default_readout_matches_anchor_neighbor_attention(self) -> None:
+        """Test default readout adds attention-weighted neighbors to anchor."""
+        encoder = self._create_encoder(
+            hid_dim=4,
+            out_dim=2,
+            num_layers=0,
+            num_heads=2,
+            readout_mode="anchor_neighbor_attention",
+        )
+        readout_attention = encoder._readout_attention
+        assert isinstance(readout_attention, nn.Linear)
+        assert readout_attention.bias is not None
+        with torch.no_grad():
+            readout_attention.weight.copy_(
+                torch.tensor([[0.2, -0.1, 0.3, 0.4, 0.5, -0.2, 0.1, -0.3]])
+            )
+            readout_attention.bias.zero_()
+
+        sequences = torch.tensor(
+            [
+                [
+                    [1.0, 2.0, 3.0, 4.0],
+                    [4.0, 3.0, 2.0, 1.0],
+                    [0.0, 1.0, 0.0, 1.0],
+                    [9.0, 9.0, 9.0, 9.0],
+                ],
+                [
+                    [2.0, 0.0, 1.0, 3.0],
+                    [1.0, 1.0, 1.0, 1.0],
+                    [5.0, 5.0, 5.0, 5.0],
+                    [6.0, 6.0, 6.0, 6.0],
+                ],
+            ]
+        )
+        valid_mask = torch.tensor(
+            [
+                [True, True, True, False],
+                [True, True, False, False],
+            ]
+        )
+
+        x = sequences * valid_mask.unsqueeze(-1).to(sequences.dtype)
+        x = encoder._final_norm(x)
+        x = x * valid_mask.unsqueeze(-1).to(x.dtype)
+        anchor = x[:, 0, :].unsqueeze(1)
+        neighbors = x[:, 1:, :]
+        neighbor_valid_mask = valid_mask[:, 1:]
+        anchor_expanded = anchor.expand(-1, neighbors.size(1), -1)
+        readout_scores = readout_attention(
+            torch.cat([anchor_expanded, neighbors], dim=-1)
+        )
+        readout_scores = readout_scores.masked_fill(
+            ~neighbor_valid_mask.unsqueeze(-1),
+            torch.finfo(readout_scores.dtype).min,
+        )
+        readout_weights = torch.softmax(readout_scores, dim=1)
+        readout_weights = torch.nan_to_num(readout_weights, nan=0.0)
+        readout_weights = readout_weights * neighbor_valid_mask.unsqueeze(-1).to(
+            readout_weights.dtype
+        )
+        expected = (
+            anchor + (neighbors * readout_weights).sum(dim=1, keepdim=True)
+        ).squeeze(1)
+
+        actual = encoder._encode_and_readout(
+            sequences=sequences,
+            valid_mask=valid_mask,
+        )
+
+        self.assertTrue(torch.allclose(actual, expected, atol=1e-6))
+
 
 def _create_user_graph_with_pe() -> HeteroData:
     data = HeteroData()


### PR DESCRIPTION
**Scope of work done**

<!-- Description of PR goes here -->
Add anchor only graph transformer readout option to match baseline implementations

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
