### PR TITLE
Add relation-aware graph transformer signals

### DIFF
--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -498,16 +498,6 @@ class GraphTransformerEncoderLayer(nn.Module):
         key_by_position = key.transpose(1, 2)
         relation_matrices = self._relation_attention_matrices.to(dtype=query.dtype)
 
-        if (
-            relation_indices.numel() > 1
-            and not torch.all(relation_indices[1:] >= relation_indices[:-1]).item()
-        ):
-            relation_sort_perm = torch.argsort(relation_indices)
-            relation_indices = relation_indices[relation_sort_perm]
-            batch_indices = batch_indices[relation_sort_perm]
-            query_indices = query_indices[relation_sort_perm]
-            key_indices = key_indices[relation_sort_perm]
-
         unique_relation_indices, relation_counts = torch.unique_consecutive(
             relation_indices,
             return_counts=True,

--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -239,6 +239,17 @@ class GraphTransformerEncoderLayer(nn.Module):
         activation: Activation function for the feed-forward network.
             Supported values: "gelu" (default), "relu", "silu", "tanh",
             "geglu", "swiglu", "reglu".
+        relation_attention_mode: Optional relation-aware augmentation strategy
+            for attention scores. ``"none"`` preserves the default shared
+            self-attention path. ``"edge_type_bilinear"`` adds a learned
+            per-edge-type bilinear term for sampled directed graph edges. This
+            changes attention weights, not value/message content.
+        relation_value_mode: Optional relation-aware value augmentation strategy.
+            ``"none"`` preserves the default shared value path.
+            ``"sparse_residual_gate"`` adds a zero-initialized sparse residual
+            message path from relation-indexed source values to target queries.
+        num_relations: Number of relation channels expected in
+            ``pairwise_relation_indices`` when a relation-aware mode is enabled.
 
     Raises:
         ValueError: If model_dim is not divisible by num_heads.
@@ -252,16 +263,41 @@ class GraphTransformerEncoderLayer(nn.Module):
         dropout_rate: float = 0.1,
         attention_dropout_rate: float = 0.0,
         activation: str = "gelu",
+        relation_attention_mode: Literal["none", "edge_type_bilinear"] = "none",
+        relation_value_mode: Literal["none", "sparse_residual_gate"] = "none",
+        num_relations: int = 0,
     ) -> None:
         super().__init__()
         if model_dim % num_heads != 0:
             raise ValueError(
                 f"model_dim ({model_dim}) must be divisible by num_heads ({num_heads})"
             )
+        if relation_attention_mode not in {"none", "edge_type_bilinear"}:
+            raise ValueError(
+                "relation_attention_mode must be one of "
+                "{'none', 'edge_type_bilinear'}, "
+                f"got '{relation_attention_mode}'"
+            )
+        if relation_value_mode not in {"none", "sparse_residual_gate"}:
+            raise ValueError(
+                "relation_value_mode must be one of "
+                "{'none', 'sparse_residual_gate'}, "
+                f"got '{relation_value_mode}'"
+            )
+        if (
+            relation_attention_mode == "edge_type_bilinear"
+            or relation_value_mode == "sparse_residual_gate"
+        ) and num_relations <= 0:
+            raise ValueError(
+                "Relation-aware attention/value modes require num_relations > 0."
+            )
 
         self._num_heads = num_heads
         self._head_dim = model_dim // num_heads
         self._attention_dropout_rate = attention_dropout_rate
+        self._relation_attention_mode = relation_attention_mode
+        self._relation_value_mode = relation_value_mode
+        self._num_relations = num_relations
 
         self._attention_norm = nn.LayerNorm(model_dim)
         self._query_projection = nn.Linear(model_dim, model_dim)
@@ -269,6 +305,19 @@ class GraphTransformerEncoderLayer(nn.Module):
         self._value_projection = nn.Linear(model_dim, model_dim)
         self._output_projection = nn.Linear(model_dim, model_dim)
         self._dropout = nn.Dropout(dropout_rate)
+        self._relation_attention_matrices: Optional[nn.Parameter] = None
+        if relation_attention_mode == "edge_type_bilinear":
+            # score(target, source, relation) += q_target^T W_relation k_source
+            # Zero init keeps startup behavior identical to shared attention.
+            self._relation_attention_matrices = nn.Parameter(
+                torch.zeros(num_relations, num_heads, self._head_dim, self._head_dim)
+            )
+        self._relation_value_gates: Optional[nn.Parameter] = None
+        if relation_value_mode == "sparse_residual_gate":
+            # Sparse residual on relation edges: message(target) += gate * value_source.
+            self._relation_value_gates = nn.Parameter(
+                torch.zeros(num_relations, num_heads, self._head_dim)
+            )
 
         self._ffn_norm = nn.LayerNorm(model_dim)
         self._ffn = FeedForwardNetwork(
@@ -287,6 +336,10 @@ class GraphTransformerEncoderLayer(nn.Module):
             nn.init.xavier_uniform_(projection.weight)
             if projection.bias is not None:
                 nn.init.zeros_(projection.bias)
+        if self._relation_attention_matrices is not None:
+            nn.init.zeros_(self._relation_attention_matrices)
+        if self._relation_value_gates is not None:
+            nn.init.zeros_(self._relation_value_gates)
         self._ffn_norm.reset_parameters()
         self._ffn.reset_parameters()
 
@@ -295,6 +348,7 @@ class GraphTransformerEncoderLayer(nn.Module):
         x: Tensor,
         attn_bias: Optional[Tensor] = None,
         valid_mask: Optional[Tensor] = None,
+        pairwise_relation_indices: Optional[Tensor] = None,
     ) -> Tensor:
         """Forward pass.
 
@@ -305,6 +359,9 @@ class GraphTransformerEncoderLayer(nn.Module):
                 Added as an additive mask to attention scores.
             valid_mask: Optional boolean tensor of shape ``(batch, seq)`` used
                 to zero out padded token states after each residual block.
+            pairwise_relation_indices: Optional long tensor of shape
+                ``(num_relation_edges, 4)`` with sparse
+                ``(batch_idx, query_pos, key_pos, relation_idx)`` coordinates.
 
         Returns:
             Output tensor of shape ``(batch, seq, model_dim)``.
@@ -330,14 +387,19 @@ class GraphTransformerEncoderLayer(nn.Module):
             batch_size, seq_len, self._num_heads, self._head_dim
         ).transpose(1, 2)
 
-        attention_output = F.scaled_dot_product_attention(
-            query,
-            key,
-            value,
-            attn_mask=attn_bias,
-            dropout_p=self._attention_dropout_rate if self.training else 0.0,
-            is_causal=False,
+        attention_output = self._run_attention(
+            query=query,
+            key=key,
+            value=value,
+            attn_bias=attn_bias,
+            pairwise_relation_indices=pairwise_relation_indices,
         )
+        if self._relation_value_mode == "sparse_residual_gate":
+            attention_output = self._add_relation_value_residual(
+                attention_output=attention_output,
+                value=value,
+                pairwise_relation_indices=pairwise_relation_indices,
+            )
 
         # Reshape back to (batch, seq, model_dim)
         attention_output = attention_output.transpose(1, 2).reshape(
@@ -359,6 +421,241 @@ class GraphTransformerEncoderLayer(nn.Module):
             x = x * valid_mask.unsqueeze(-1).to(x.dtype)
 
         return x
+
+    def _run_attention(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        attn_bias: Optional[Tensor],
+        pairwise_relation_indices: Optional[Tensor],
+    ) -> Tensor:
+        if self._relation_attention_mode == "edge_type_bilinear":
+            attn_bias = self._add_relation_attention_bias(
+                attn_bias=attn_bias,
+                query=query,
+                key=key,
+                pairwise_relation_indices=pairwise_relation_indices,
+            )
+
+        return F.scaled_dot_product_attention(
+            query,
+            key,
+            value,
+            attn_mask=attn_bias,
+            dropout_p=self._attention_dropout_rate if self.training else 0.0,
+            is_causal=False,
+        )
+
+    def _add_relation_value_residual(
+        self,
+        attention_output: Tensor,
+        value: Tensor,
+        pairwise_relation_indices: Optional[Tensor],
+    ) -> Tensor:
+        if pairwise_relation_indices is None:
+            raise ValueError(
+                "pairwise_relation_indices is required when "
+                "relation_value_mode='sparse_residual_gate'."
+            )
+        if self._relation_value_gates is None:
+            raise ValueError("Relation value gates are not initialized.")
+        if pairwise_relation_indices.numel() == 0:
+            return attention_output
+        if (
+            pairwise_relation_indices.dim() != 2
+            or pairwise_relation_indices.size(-1) != 4
+        ):
+            raise ValueError(
+                "pairwise_relation_indices must have shape (num_relation_edges, 4)."
+            )
+
+        pairwise_relation_indices = pairwise_relation_indices.to(
+            device=value.device,
+            dtype=torch.long,
+        )
+        batch_indices = pairwise_relation_indices[:, 0]
+        query_indices = pairwise_relation_indices[:, 1]
+        key_indices = pairwise_relation_indices[:, 2]
+        relation_indices = pairwise_relation_indices[:, 3]
+        if (
+            relation_indices.min().item() < 0
+            or relation_indices.max().item() >= self._num_relations
+        ):
+            raise ValueError(
+                "pairwise_relation_indices contains relation ids outside "
+                f"[0, {self._num_relations})."
+            )
+
+        batch_size, _, seq_len, _ = value.shape
+        value_by_position = value.transpose(1, 2)
+        selected_values = value_by_position[batch_indices, key_indices]
+        selected_gates = self._relation_value_gates.to(dtype=value.dtype)[
+            relation_indices
+        ]
+        messages = selected_values * selected_gates
+
+        residual_by_position = value.new_zeros(
+            (batch_size, seq_len, self._num_heads, self._head_dim)
+        )
+        residual_by_position.index_put_(
+            (batch_indices, query_indices),
+            messages,
+            accumulate=True,
+        )
+
+        counts = value.new_zeros((batch_size, seq_len))
+        counts.index_put_(
+            (batch_indices, query_indices),
+            torch.ones(
+                pairwise_relation_indices.size(0),
+                dtype=value.dtype,
+                device=value.device,
+            ),
+            accumulate=True,
+        )
+        residual_by_position = residual_by_position / counts.clamp_min(1).view(
+            batch_size,
+            seq_len,
+            1,
+            1,
+        )
+
+        return attention_output + residual_by_position.transpose(1, 2).to(
+            dtype=attention_output.dtype
+        )
+
+    def _build_relation_attention_bias(
+        self,
+        query: Tensor,
+        key: Tensor,
+        pairwise_relation_indices: Optional[Tensor],
+    ) -> Optional[Tensor]:
+        if (
+            pairwise_relation_indices is not None
+            and pairwise_relation_indices.numel() == 0
+        ):
+            return None
+
+        batch_size, _, seq_len, _ = query.shape
+        empty_bias = query.new_zeros((batch_size, self._num_heads, seq_len, seq_len))
+        return self._add_relation_attention_bias(
+            attn_bias=empty_bias,
+            query=query,
+            key=key,
+            pairwise_relation_indices=pairwise_relation_indices,
+        )
+
+    def _add_relation_attention_bias(
+        self,
+        attn_bias: Optional[Tensor],
+        query: Tensor,
+        key: Tensor,
+        pairwise_relation_indices: Optional[Tensor],
+    ) -> Optional[Tensor]:
+        if pairwise_relation_indices is None:
+            raise ValueError(
+                "pairwise_relation_indices is required when "
+                "relation_attention_mode='edge_type_bilinear'."
+            )
+        if self._relation_attention_matrices is None:
+            raise ValueError("Relation attention matrices are not initialized.")
+        if pairwise_relation_indices.numel() == 0:
+            return attn_bias
+        if (
+            pairwise_relation_indices.dim() != 2
+            or pairwise_relation_indices.size(-1) != 4
+        ):
+            raise ValueError(
+                "pairwise_relation_indices must have shape (num_relation_edges, 4)."
+            )
+
+        pairwise_relation_indices = pairwise_relation_indices.to(
+            device=query.device,
+            dtype=torch.long,
+        )
+        batch_indices = pairwise_relation_indices[:, 0]
+        query_indices = pairwise_relation_indices[:, 1]
+        key_indices = pairwise_relation_indices[:, 2]
+        relation_indices = pairwise_relation_indices[:, 3]
+        if (
+            relation_indices.min().item() < 0
+            or relation_indices.max().item() >= self._num_relations
+        ):
+            raise ValueError(
+                "pairwise_relation_indices contains relation ids outside "
+                f"[0, {self._num_relations})."
+            )
+
+        batch_size, _, seq_len, _ = query.shape
+        if attn_bias is None:
+            attn_bias = query.new_zeros((batch_size, self._num_heads, seq_len, seq_len))
+        elif attn_bias.shape[1:] != (self._num_heads, seq_len, seq_len):
+            attn_bias = attn_bias.expand(
+                batch_size,
+                self._num_heads,
+                seq_len,
+                seq_len,
+            ).clone()
+        else:
+            attn_bias = attn_bias.clone()
+
+        attn_bias_by_position = attn_bias.permute(0, 2, 3, 1)
+        query_by_position = query.transpose(1, 2)
+        key_by_position = key.transpose(1, 2)
+        relation_matrices = self._relation_attention_matrices.to(dtype=query.dtype)
+
+        if (
+            relation_indices.numel() > 1
+            and not torch.all(relation_indices[1:] >= relation_indices[:-1]).item()
+        ):
+            relation_sort_perm = torch.argsort(relation_indices)
+            relation_indices = relation_indices[relation_sort_perm]
+            batch_indices = batch_indices[relation_sort_perm]
+            query_indices = query_indices[relation_sort_perm]
+            key_indices = key_indices[relation_sort_perm]
+
+        unique_relation_indices, relation_counts = torch.unique_consecutive(
+            relation_indices,
+            return_counts=True,
+        )
+        relation_start = 0
+        for relation_idx_tensor, relation_count_tensor in zip(
+            unique_relation_indices,
+            relation_counts,
+        ):
+            relation_idx = int(relation_idx_tensor.item())
+            relation_end = relation_start + int(relation_count_tensor.item())
+            relation_batch_indices = batch_indices[relation_start:relation_end]
+            relation_query_indices = query_indices[relation_start:relation_end]
+            relation_key_indices = key_indices[relation_start:relation_end]
+
+            selected_query = query_by_position[
+                relation_batch_indices,
+                relation_query_indices,
+            ]
+            selected_key = key_by_position[
+                relation_batch_indices,
+                relation_key_indices,
+            ]
+            relation_scores = torch.einsum(
+                "ehd,hdf,ehf->eh",
+                selected_query,
+                relation_matrices[relation_idx],
+                selected_key,
+            ) / math.sqrt(self._head_dim)
+            attn_bias_by_position.index_put_(
+                (
+                    relation_batch_indices,
+                    relation_query_indices,
+                    relation_key_indices,
+                ),
+                relation_scores.to(dtype=attn_bias.dtype),
+                accumulate=True,
+            )
+            relation_start = relation_end
+
+        return attn_bias
 
 
 class GraphTransformerEncoder(nn.Module):
@@ -450,6 +747,14 @@ class GraphTransformerEncoder(nn.Module):
             uses 4.0 for standard activations and 8/3 (~2.67) for XGLU variants,
             following the convention that XGLU's gating doubles the effective
             parameters, so a smaller ratio maintains similar parameter count.
+        relation_attention_mode: Optional relation-aware augmentation for
+            attention scores. ``"none"`` preserves the current transformer path.
+            ``"edge_type_bilinear"`` adds a learned per-edge-type bilinear score
+            term for sampled directed edges.
+        relation_value_mode: Optional relation-aware value augmentation.
+            ``"none"`` preserves the current transformer path.
+            ``"sparse_residual_gate"`` adds a zero-initialized sparse residual
+            value path on sampled directed relation edges.
 
     Notes:
         This encoder uses ``nn.LazyLinear`` for node-level PE fusion. If you wrap
@@ -499,6 +804,8 @@ class GraphTransformerEncoder(nn.Module):
         pe_integration_mode: Literal["concat", "add"] = "concat",
         activation: str = "gelu",
         feedforward_ratio: Optional[float] = None,
+        relation_attention_mode: Literal["none", "edge_type_bilinear"] = "none",
+        relation_value_mode: Literal["none", "sparse_residual_gate"] = "none",
         **kwargs: object,
     ) -> None:
         super().__init__()
@@ -540,6 +847,18 @@ class GraphTransformerEncoder(nn.Module):
                 "sequence_construction_method='ppr' because khop sequences do not "
                 "enforce a stable token order."
             )
+        if relation_attention_mode not in {"none", "edge_type_bilinear"}:
+            raise ValueError(
+                "relation_attention_mode must be one of "
+                "{'none', 'edge_type_bilinear'}, "
+                f"got '{relation_attention_mode}'"
+            )
+        if relation_value_mode not in {"none", "sparse_residual_gate"}:
+            raise ValueError(
+                "relation_value_mode must be one of "
+                "{'none', 'sparse_residual_gate'}, "
+                f"got '{relation_value_mode}'"
+            )
         anchor_bias_attr_names = anchor_based_attention_bias_attr_names or []
         anchor_input_attr_names = anchor_based_input_attr_names or []
         pairwise_bias_attr_names = pairwise_attention_bias_attr_names or []
@@ -571,6 +890,18 @@ class GraphTransformerEncoder(nn.Module):
         self._feature_embedding_layer_dict = feature_embedding_layer_dict
         self._pe_integration_mode = pe_integration_mode
         self._num_heads = num_heads
+        self._relation_attention_mode = relation_attention_mode
+        self._relation_value_mode = relation_value_mode
+        self._edge_type_to_feat_dim_map = {
+            edge_type: edge_type_to_feat_dim_map[edge_type]
+            for edge_type in sorted(edge_type_to_feat_dim_map.keys())
+        }
+        self._relation_attention_edge_types = (
+            list(self._edge_type_to_feat_dim_map.keys())
+            if relation_attention_mode == "edge_type_bilinear"
+            or relation_value_mode == "sparse_residual_gate"
+            else []
+        )
         anchor_input_embedding_attr_names = (
             set(anchor_based_input_embedding_dict.keys())
             if anchor_based_input_embedding_dict is not None
@@ -664,6 +995,9 @@ class GraphTransformerEncoder(nn.Module):
                     dropout_rate=dropout_rate,
                     attention_dropout_rate=attention_dropout_rate,
                     activation=activation,
+                    relation_attention_mode=relation_attention_mode,
+                    relation_value_mode=relation_value_mode,
+                    num_relations=len(self._relation_attention_edge_types),
                 )
                 for _ in range(num_layers)
             ]
@@ -801,6 +1135,12 @@ class GraphTransformerEncoder(nn.Module):
             anchor_based_attention_bias_attr_names=self._anchor_based_attention_bias_attr_names,
             anchor_based_input_attr_names=self._anchor_based_input_attr_names,
             pairwise_attention_bias_attr_names=self._pairwise_attention_bias_attr_names,
+            relation_edge_types=(
+                self._relation_attention_edge_types
+                if self._relation_attention_mode == "edge_type_bilinear"
+                or self._relation_value_mode == "sparse_residual_gate"
+                else None
+            ),
         )
 
         # Free memory after sequences are built
@@ -837,6 +1177,9 @@ class GraphTransformerEncoder(nn.Module):
             sequences=sequences,
             valid_mask=valid_mask,
             attn_bias=attn_bias,
+            pairwise_relation_indices=sequence_auxiliary_data[
+                "pairwise_relation_indices"
+            ],
         )
         embeddings = self._output_projection(embeddings)
 
@@ -1036,6 +1379,7 @@ class GraphTransformerEncoder(nn.Module):
         sequences: Tensor,
         valid_mask: Tensor,
         attn_bias: Optional[Tensor] = None,
+        pairwise_relation_indices: Optional[Tensor] = None,
     ) -> Tensor:
         """Process sequences through transformer layers and attention readout.
 
@@ -1044,6 +1388,8 @@ class GraphTransformerEncoder(nn.Module):
             valid_mask: Boolean mask of shape ``(batch_size, max_seq_len)``.
             attn_bias: Optional additive attention bias broadcastable to
                 ``(batch_size, num_heads, seq, seq)``.
+            pairwise_relation_indices: Optional sparse relation coordinates shaped
+                ``(num_relation_edges, 4)``.
 
         Returns:
             Output embeddings of shape ``(batch_size, hid_dim)``.
@@ -1051,7 +1397,12 @@ class GraphTransformerEncoder(nn.Module):
         x = sequences * valid_mask.unsqueeze(-1).to(sequences.dtype)
 
         for encoder_layer in self._encoder_layers:
-            x = encoder_layer(x, attn_bias=attn_bias, valid_mask=valid_mask)
+            x = encoder_layer(
+                x,
+                attn_bias=attn_bias,
+                pairwise_relation_indices=pairwise_relation_indices,
+                valid_mask=valid_mask,
+            )
 
         x = self._final_norm(x)
         x = x * valid_mask.unsqueeze(-1).to(x.dtype)

--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -244,12 +244,8 @@ class GraphTransformerEncoderLayer(nn.Module):
             self-attention path. ``"edge_type_bilinear"`` adds a learned
             per-edge-type bilinear term for sampled directed graph edges. This
             changes attention weights, not value/message content.
-        relation_value_mode: Optional relation-aware value augmentation strategy.
-            ``"none"`` preserves the default shared value path.
-            ``"sparse_residual_gate"`` adds a zero-initialized sparse residual
-            message path from relation-indexed source values to target queries.
         num_relations: Number of relation channels expected in
-            ``pairwise_relation_indices`` when a relation-aware mode is enabled.
+            ``pairwise_relation_indices`` when relation-aware attention is enabled.
 
     Raises:
         ValueError: If model_dim is not divisible by num_heads.
@@ -264,7 +260,6 @@ class GraphTransformerEncoderLayer(nn.Module):
         attention_dropout_rate: float = 0.0,
         activation: str = "gelu",
         relation_attention_mode: Literal["none", "edge_type_bilinear"] = "none",
-        relation_value_mode: Literal["none", "sparse_residual_gate"] = "none",
         num_relations: int = 0,
     ) -> None:
         super().__init__()
@@ -278,25 +273,15 @@ class GraphTransformerEncoderLayer(nn.Module):
                 "{'none', 'edge_type_bilinear'}, "
                 f"got '{relation_attention_mode}'"
             )
-        if relation_value_mode not in {"none", "sparse_residual_gate"}:
+        if relation_attention_mode == "edge_type_bilinear" and num_relations <= 0:
             raise ValueError(
-                "relation_value_mode must be one of "
-                "{'none', 'sparse_residual_gate'}, "
-                f"got '{relation_value_mode}'"
-            )
-        if (
-            relation_attention_mode == "edge_type_bilinear"
-            or relation_value_mode == "sparse_residual_gate"
-        ) and num_relations <= 0:
-            raise ValueError(
-                "Relation-aware attention/value modes require num_relations > 0."
+                "Relation-aware attention mode requires num_relations > 0."
             )
 
         self._num_heads = num_heads
         self._head_dim = model_dim // num_heads
         self._attention_dropout_rate = attention_dropout_rate
         self._relation_attention_mode = relation_attention_mode
-        self._relation_value_mode = relation_value_mode
         self._num_relations = num_relations
 
         self._attention_norm = nn.LayerNorm(model_dim)
@@ -311,12 +296,6 @@ class GraphTransformerEncoderLayer(nn.Module):
             # Zero init keeps startup behavior identical to shared attention.
             self._relation_attention_matrices = nn.Parameter(
                 torch.zeros(num_relations, num_heads, self._head_dim, self._head_dim)
-            )
-        self._relation_value_gates: Optional[nn.Parameter] = None
-        if relation_value_mode == "sparse_residual_gate":
-            # Sparse residual on relation edges: message(target) += gate * value_source.
-            self._relation_value_gates = nn.Parameter(
-                torch.zeros(num_relations, num_heads, self._head_dim)
             )
 
         self._ffn_norm = nn.LayerNorm(model_dim)
@@ -338,8 +317,6 @@ class GraphTransformerEncoderLayer(nn.Module):
                 nn.init.zeros_(projection.bias)
         if self._relation_attention_matrices is not None:
             nn.init.zeros_(self._relation_attention_matrices)
-        if self._relation_value_gates is not None:
-            nn.init.zeros_(self._relation_value_gates)
         self._ffn_norm.reset_parameters()
         self._ffn.reset_parameters()
 
@@ -394,12 +371,6 @@ class GraphTransformerEncoderLayer(nn.Module):
             attn_bias=attn_bias,
             pairwise_relation_indices=pairwise_relation_indices,
         )
-        if self._relation_value_mode == "sparse_residual_gate":
-            attention_output = self._add_relation_value_residual(
-                attention_output=attention_output,
-                value=value,
-                pairwise_relation_indices=pairwise_relation_indices,
-            )
 
         # Reshape back to (batch, seq, model_dim)
         attention_output = attention_output.transpose(1, 2).reshape(
@@ -445,84 +416,6 @@ class GraphTransformerEncoderLayer(nn.Module):
             attn_mask=attn_bias,
             dropout_p=self._attention_dropout_rate if self.training else 0.0,
             is_causal=False,
-        )
-
-    def _add_relation_value_residual(
-        self,
-        attention_output: Tensor,
-        value: Tensor,
-        pairwise_relation_indices: Optional[Tensor],
-    ) -> Tensor:
-        if pairwise_relation_indices is None:
-            raise ValueError(
-                "pairwise_relation_indices is required when "
-                "relation_value_mode='sparse_residual_gate'."
-            )
-        if self._relation_value_gates is None:
-            raise ValueError("Relation value gates are not initialized.")
-        if pairwise_relation_indices.numel() == 0:
-            return attention_output
-        if (
-            pairwise_relation_indices.dim() != 2
-            or pairwise_relation_indices.size(-1) != 4
-        ):
-            raise ValueError(
-                "pairwise_relation_indices must have shape (num_relation_edges, 4)."
-            )
-
-        pairwise_relation_indices = pairwise_relation_indices.to(
-            device=value.device,
-            dtype=torch.long,
-        )
-        batch_indices = pairwise_relation_indices[:, 0]
-        query_indices = pairwise_relation_indices[:, 1]
-        key_indices = pairwise_relation_indices[:, 2]
-        relation_indices = pairwise_relation_indices[:, 3]
-        if (
-            relation_indices.min().item() < 0
-            or relation_indices.max().item() >= self._num_relations
-        ):
-            raise ValueError(
-                "pairwise_relation_indices contains relation ids outside "
-                f"[0, {self._num_relations})."
-            )
-
-        batch_size, _, seq_len, _ = value.shape
-        value_by_position = value.transpose(1, 2)
-        selected_values = value_by_position[batch_indices, key_indices]
-        selected_gates = self._relation_value_gates.to(dtype=value.dtype)[
-            relation_indices
-        ]
-        messages = selected_values * selected_gates
-
-        residual_by_position = value.new_zeros(
-            (batch_size, seq_len, self._num_heads, self._head_dim)
-        )
-        residual_by_position.index_put_(
-            (batch_indices, query_indices),
-            messages,
-            accumulate=True,
-        )
-
-        counts = value.new_zeros((batch_size, seq_len))
-        counts.index_put_(
-            (batch_indices, query_indices),
-            torch.ones(
-                pairwise_relation_indices.size(0),
-                dtype=value.dtype,
-                device=value.device,
-            ),
-            accumulate=True,
-        )
-        residual_by_position = residual_by_position / counts.clamp_min(1).view(
-            batch_size,
-            seq_len,
-            1,
-            1,
-        )
-
-        return attention_output + residual_by_position.transpose(1, 2).to(
-            dtype=attention_output.dtype
         )
 
     def _build_relation_attention_bias(
@@ -751,10 +644,6 @@ class GraphTransformerEncoder(nn.Module):
             attention scores. ``"none"`` preserves the current transformer path.
             ``"edge_type_bilinear"`` adds a learned per-edge-type bilinear score
             term for sampled directed edges.
-        relation_value_mode: Optional relation-aware value augmentation.
-            ``"none"`` preserves the current transformer path.
-            ``"sparse_residual_gate"`` adds a zero-initialized sparse residual
-            value path on sampled directed relation edges.
 
     Notes:
         This encoder uses ``nn.LazyLinear`` for node-level PE fusion. If you wrap
@@ -805,7 +694,6 @@ class GraphTransformerEncoder(nn.Module):
         activation: str = "gelu",
         feedforward_ratio: Optional[float] = None,
         relation_attention_mode: Literal["none", "edge_type_bilinear"] = "none",
-        relation_value_mode: Literal["none", "sparse_residual_gate"] = "none",
         **kwargs: object,
     ) -> None:
         super().__init__()
@@ -853,12 +741,6 @@ class GraphTransformerEncoder(nn.Module):
                 "{'none', 'edge_type_bilinear'}, "
                 f"got '{relation_attention_mode}'"
             )
-        if relation_value_mode not in {"none", "sparse_residual_gate"}:
-            raise ValueError(
-                "relation_value_mode must be one of "
-                "{'none', 'sparse_residual_gate'}, "
-                f"got '{relation_value_mode}'"
-            )
         anchor_bias_attr_names = anchor_based_attention_bias_attr_names or []
         anchor_input_attr_names = anchor_based_input_attr_names or []
         pairwise_bias_attr_names = pairwise_attention_bias_attr_names or []
@@ -891,7 +773,6 @@ class GraphTransformerEncoder(nn.Module):
         self._pe_integration_mode = pe_integration_mode
         self._num_heads = num_heads
         self._relation_attention_mode = relation_attention_mode
-        self._relation_value_mode = relation_value_mode
         self._edge_type_to_feat_dim_map = {
             edge_type: edge_type_to_feat_dim_map[edge_type]
             for edge_type in sorted(edge_type_to_feat_dim_map.keys())
@@ -899,7 +780,6 @@ class GraphTransformerEncoder(nn.Module):
         self._relation_attention_edge_types = (
             list(self._edge_type_to_feat_dim_map.keys())
             if relation_attention_mode == "edge_type_bilinear"
-            or relation_value_mode == "sparse_residual_gate"
             else []
         )
         anchor_input_embedding_attr_names = (
@@ -996,7 +876,6 @@ class GraphTransformerEncoder(nn.Module):
                     attention_dropout_rate=attention_dropout_rate,
                     activation=activation,
                     relation_attention_mode=relation_attention_mode,
-                    relation_value_mode=relation_value_mode,
                     num_relations=len(self._relation_attention_edge_types),
                 )
                 for _ in range(num_layers)
@@ -1138,7 +1017,6 @@ class GraphTransformerEncoder(nn.Module):
             relation_edge_types=(
                 self._relation_attention_edge_types
                 if self._relation_attention_mode == "edge_type_bilinear"
-                or self._relation_value_mode == "sparse_residual_gate"
                 else None
             ),
         )

--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -244,6 +244,8 @@ class GraphTransformerEncoderLayer(nn.Module):
             self-attention path. ``"edge_type_bilinear"`` adds a learned
             per-edge-type bilinear term for sampled directed graph edges. This
             changes attention weights, not value/message content.
+            ``"edge_type_hgt"`` replaces the base query/key score on relation
+            edges with an HGT-style relation transform and relation prior.
         num_relations: Number of relation channels expected in
             ``pairwise_relation_indices`` when relation-aware attention is enabled.
 
@@ -259,7 +261,11 @@ class GraphTransformerEncoderLayer(nn.Module):
         dropout_rate: float = 0.1,
         attention_dropout_rate: float = 0.0,
         activation: str = "gelu",
-        relation_attention_mode: Literal["none", "edge_type_bilinear"] = "none",
+        relation_attention_mode: Literal[
+            "none",
+            "edge_type_bilinear",
+            "edge_type_hgt",
+        ] = "none",
         num_relations: int = 0,
     ) -> None:
         super().__init__()
@@ -267,13 +273,17 @@ class GraphTransformerEncoderLayer(nn.Module):
             raise ValueError(
                 f"model_dim ({model_dim}) must be divisible by num_heads ({num_heads})"
             )
-        if relation_attention_mode not in {"none", "edge_type_bilinear"}:
+        if relation_attention_mode not in {
+            "none",
+            "edge_type_bilinear",
+            "edge_type_hgt",
+        }:
             raise ValueError(
                 "relation_attention_mode must be one of "
-                "{'none', 'edge_type_bilinear'}, "
+                "{'none', 'edge_type_bilinear', 'edge_type_hgt'}, "
                 f"got '{relation_attention_mode}'"
             )
-        if relation_attention_mode == "edge_type_bilinear" and num_relations <= 0:
+        if relation_attention_mode != "none" and num_relations <= 0:
             raise ValueError(
                 "Relation-aware attention mode requires num_relations > 0."
             )
@@ -297,6 +307,19 @@ class GraphTransformerEncoderLayer(nn.Module):
             self._relation_attention_matrices = nn.Parameter(
                 torch.zeros(num_relations, num_heads, self._head_dim, self._head_dim)
             )
+        self._relation_hgt_attention_matrices: Optional[nn.Parameter] = None
+        self._relation_hgt_attention_priors: Optional[nn.Parameter] = None
+        if relation_attention_mode == "edge_type_hgt":
+            # Replaces the base score on relation edges with
+            # mu_relation * q_target^T W_relation k_source. Identity/one init
+            # preserves the base query/key score at startup.
+            self._relation_hgt_attention_matrices = nn.Parameter(
+                torch.empty(num_relations, self._head_dim, self._head_dim)
+            )
+            self._relation_hgt_attention_priors = nn.Parameter(
+                torch.empty(num_relations)
+            )
+            self._reset_hgt_relation_attention_parameters()
 
         self._ffn_norm = nn.LayerNorm(model_dim)
         self._ffn = FeedForwardNetwork(
@@ -317,8 +340,26 @@ class GraphTransformerEncoderLayer(nn.Module):
                 nn.init.zeros_(projection.bias)
         if self._relation_attention_matrices is not None:
             nn.init.zeros_(self._relation_attention_matrices)
+        self._reset_hgt_relation_attention_parameters()
         self._ffn_norm.reset_parameters()
         self._ffn.reset_parameters()
+
+    def _reset_hgt_relation_attention_parameters(self) -> None:
+        if self._relation_hgt_attention_matrices is None:
+            return
+        if self._relation_hgt_attention_priors is None:
+            raise ValueError("Relation HGT attention priors are not initialized.")
+
+        with torch.no_grad():
+            relation_identity = torch.eye(
+                self._head_dim,
+                dtype=self._relation_hgt_attention_matrices.dtype,
+                device=self._relation_hgt_attention_matrices.device,
+            )
+            self._relation_hgt_attention_matrices.copy_(
+                relation_identity.expand(self._num_relations, -1, -1)
+            )
+            self._relation_hgt_attention_priors.fill_(1.0)
 
     def forward(
         self,
@@ -401,7 +442,7 @@ class GraphTransformerEncoderLayer(nn.Module):
         attn_bias: Optional[Tensor],
         pairwise_relation_indices: Optional[Tensor],
     ) -> Tensor:
-        if self._relation_attention_mode == "edge_type_bilinear":
+        if self._relation_attention_mode in {"edge_type_bilinear", "edge_type_hgt"}:
             attn_bias = self._add_relation_attention_bias(
                 attn_bias=attn_bias,
                 query=query,
@@ -449,10 +490,8 @@ class GraphTransformerEncoderLayer(nn.Module):
         if pairwise_relation_indices is None:
             raise ValueError(
                 "pairwise_relation_indices is required when "
-                "relation_attention_mode='edge_type_bilinear'."
+                "relation_attention_mode is relation-aware."
             )
-        if self._relation_attention_matrices is None:
-            raise ValueError("Relation attention matrices are not initialized.")
         if pairwise_relation_indices.numel() == 0:
             return attn_bias
         if (
@@ -496,7 +535,6 @@ class GraphTransformerEncoderLayer(nn.Module):
         attn_bias_by_position = attn_bias.permute(0, 2, 3, 1)
         query_by_position = query.transpose(1, 2)
         key_by_position = key.transpose(1, 2)
-        relation_matrices = self._relation_attention_matrices.to(dtype=query.dtype)
 
         unique_relation_indices, relation_counts = torch.unique_consecutive(
             relation_indices,
@@ -521,12 +559,11 @@ class GraphTransformerEncoderLayer(nn.Module):
                 relation_batch_indices,
                 relation_key_indices,
             ]
-            relation_scores = torch.einsum(
-                "ehd,hdf,ehf->eh",
-                selected_query,
-                relation_matrices[relation_idx],
-                selected_key,
-            ) / math.sqrt(self._head_dim)
+            relation_scores = self._compute_relation_attention_scores(
+                selected_query=selected_query,
+                selected_key=selected_key,
+                relation_idx=relation_idx,
+            )
             attn_bias_by_position.index_put_(
                 (
                     relation_batch_indices,
@@ -539,6 +576,50 @@ class GraphTransformerEncoderLayer(nn.Module):
             relation_start = relation_end
 
         return attn_bias
+
+    def _compute_relation_attention_scores(
+        self,
+        selected_query: Tensor,
+        selected_key: Tensor,
+        relation_idx: int,
+    ) -> Tensor:
+        if self._relation_attention_mode == "edge_type_bilinear":
+            if self._relation_attention_matrices is None:
+                raise ValueError("Relation attention matrices are not initialized.")
+            relation_matrices = self._relation_attention_matrices.to(
+                dtype=selected_query.dtype
+            )
+            relation_scores = torch.einsum(
+                "ehd,hdf,ehf->eh",
+                selected_query,
+                relation_matrices[relation_idx],
+                selected_key,
+            )
+        elif self._relation_attention_mode == "edge_type_hgt":
+            if self._relation_hgt_attention_matrices is None:
+                raise ValueError("Relation HGT attention matrices are not initialized.")
+            if self._relation_hgt_attention_priors is None:
+                raise ValueError("Relation HGT attention priors are not initialized.")
+            relation_matrices = self._relation_hgt_attention_matrices.to(
+                dtype=selected_query.dtype
+            )
+            relation_priors = self._relation_hgt_attention_priors.to(
+                dtype=selected_query.dtype
+            )
+            hgt_scores = torch.einsum(
+                "ehd,df,ehf->eh",
+                selected_query,
+                relation_matrices[relation_idx],
+                selected_key,
+            )
+            base_scores = (selected_query * selected_key).sum(dim=-1)
+            relation_scores = relation_priors[relation_idx] * hgt_scores - base_scores
+        else:
+            raise ValueError(
+                "Relation attention scores requested when relation_attention_mode "
+                f"is '{self._relation_attention_mode}'."
+            )
+        return relation_scores / math.sqrt(self._head_dim)
 
 
 class GraphTransformerEncoder(nn.Module):
@@ -644,7 +725,9 @@ class GraphTransformerEncoder(nn.Module):
         relation_attention_mode: Optional relation-aware augmentation for
             attention scores. ``"none"`` preserves the current transformer path.
             ``"edge_type_bilinear"`` adds a learned per-edge-type bilinear score
-            term for sampled directed edges.
+            term for sampled directed edges. ``"edge_type_hgt"`` replaces base
+            query/key scores on relation edges with an HGT-style relation
+            transform and relation prior.
 
     Notes:
         This encoder uses ``nn.LazyLinear`` for node-level PE fusion. If you wrap
@@ -699,7 +782,11 @@ class GraphTransformerEncoder(nn.Module):
         pe_integration_mode: Literal["concat", "add"] = "concat",
         activation: str = "gelu",
         feedforward_ratio: Optional[float] = None,
-        relation_attention_mode: Literal["none", "edge_type_bilinear"] = "none",
+        relation_attention_mode: Literal[
+            "none",
+            "edge_type_bilinear",
+            "edge_type_hgt",
+        ] = "none",
         **kwargs: object,
     ) -> None:
         super().__init__()
@@ -758,10 +845,14 @@ class GraphTransformerEncoder(nn.Module):
                 "sequence_construction_method='ppr' because khop sequences do not "
                 "enforce a stable token order."
             )
-        if relation_attention_mode not in {"none", "edge_type_bilinear"}:
+        if relation_attention_mode not in {
+            "none",
+            "edge_type_bilinear",
+            "edge_type_hgt",
+        }:
             raise ValueError(
                 "relation_attention_mode must be one of "
-                "{'none', 'edge_type_bilinear'}, "
+                "{'none', 'edge_type_bilinear', 'edge_type_hgt'}, "
                 f"got '{relation_attention_mode}'"
             )
         anchor_bias_attr_names = anchor_based_attention_bias_attr_names or []
@@ -803,7 +894,7 @@ class GraphTransformerEncoder(nn.Module):
         }
         self._relation_attention_edge_types = (
             list(self._edge_type_to_feat_dim_map.keys())
-            if relation_attention_mode == "edge_type_bilinear"
+            if relation_attention_mode in {"edge_type_bilinear", "edge_type_hgt"}
             else []
         )
         anchor_input_embedding_attr_names = (
@@ -1047,7 +1138,8 @@ class GraphTransformerEncoder(nn.Module):
             pairwise_attention_bias_attr_names=self._pairwise_attention_bias_attr_names,
             relation_edge_types=(
                 self._relation_attention_edge_types
-                if self._relation_attention_mode == "edge_type_bilinear"
+                if self._relation_attention_mode
+                in {"edge_type_bilinear", "edge_type_hgt"}
                 else None
             ),
         )

--- a/gigl/transforms/graph_transformer.py
+++ b/gigl/transforms/graph_transformer.py
@@ -57,7 +57,7 @@ Example Usage:
     >>> # attention_bias_data['anchor_bias']: (batch_size, max_seq_len, 1)
 """
 
-from typing import Literal, Optional, TypedDict
+from typing import Literal, NamedTuple, Optional, TypedDict
 
 import torch
 from torch import Tensor
@@ -65,16 +65,29 @@ from torch_geometric.data import Data, HeteroData
 from torch_geometric.typing import NodeType
 from torch_geometric.utils import to_torch_sparse_tensor
 
+from gigl.src.common.types.graph_data import EdgeType as GiGLEdgeType
+
 TokenInputData = dict[str, Tensor]
 
 
 class SequenceAuxiliaryData(TypedDict):
     anchor_bias: Optional[Tensor]
     pairwise_bias: Optional[Tensor]
+    pairwise_relation_indices: Optional[Tensor]
     token_input: Optional[TokenInputData]
 
 
 PPR_WEIGHT_FEATURE_NAME = "ppr_weight"
+
+
+class _TokenOccurrenceIndex(NamedTuple):
+    batch_indices: Tensor
+    positions: Tensor
+    node_indices: Tensor
+    sorted_node_indices: Tensor
+    node_sort_perm: Tensor
+    sorted_batch_node_keys: Tensor
+    batch_node_sort_perm: Tensor
 
 
 def heterodata_to_graph_transformer_input(
@@ -90,6 +103,7 @@ def heterodata_to_graph_transformer_input(
     anchor_based_attention_bias_attr_names: Optional[list[str]] = None,
     anchor_based_input_attr_names: Optional[list[str]] = None,
     pairwise_attention_bias_attr_names: Optional[list[str]] = None,
+    relation_edge_types: Optional[list[GiGLEdgeType]] = None,
 ) -> tuple[Tensor, Tensor, SequenceAuxiliaryData]:
     """
     Transform a HeteroData object to Graph Transformer sequence input.
@@ -131,6 +145,10 @@ def heterodata_to_graph_transformer_input(
         pairwise_attention_bias_attr_names: List of pairwise feature names used
             as attention bias. These must correspond to sparse graph-level
             attributes on ``data``. Example: ['pairwise_distance'].
+        relation_edge_types: Optional ordered edge types used to materialize sparse
+            relation coordinates. Each output relation index corresponds to one
+            edge type in this list. Directed edges are stored as
+            ``(batch_idx, query_pos=dst_token, key_pos=src_token, relation_idx)``.
 
     Returns:
         (sequences, valid_mask, attention_bias_data), where:
@@ -143,6 +161,9 @@ def heterodata_to_graph_transformer_input(
                 ``"anchor_bias"`` shaped ``(batch, seq, num_anchor_attrs)`` or None
                 ``"pairwise_bias"`` shaped
                 ``(batch, seq, seq, num_pairwise_attrs)`` or None
+                ``"pairwise_relation_indices"`` shaped
+                ``(num_relation_edges, 4)`` or None, storing
+                ``(batch_idx, query_pos, key_pos, relation_idx)`` coordinates
                 ``"token_input"`` as a dict mapping attribute name to a
                 ``(batch, seq, 1)`` tensor, or None
 
@@ -312,6 +333,15 @@ def heterodata_to_graph_transformer_input(
         csr_matrices=pairwise_pe_matrices if pairwise_pe_matrices else None,
         device=device,
     )
+    pairwise_relation_indices = _lookup_pairwise_relation_indices(
+        data=data,
+        node_index_sequences=node_index_sequences,
+        valid_mask=valid_mask,
+        relation_edge_types=relation_edge_types,
+        node_type_offsets=node_type_offsets,
+        num_nodes=num_nodes,
+        device=device,
+    )
 
     anchor_bias_features = _compose_anchor_feature_tensor(
         anchor_relative_feature_sequences=anchor_relative_feature_sequences,
@@ -332,6 +362,7 @@ def heterodata_to_graph_transformer_input(
         {
             "anchor_bias": anchor_bias_features,
             "pairwise_bias": pairwise_feature_sequences,
+            "pairwise_relation_indices": pairwise_relation_indices,
             "token_input": token_input_features,
         },
     )
@@ -873,6 +904,220 @@ def _lookup_pairwise_relative_features(
         features[..., attr_idx][pair_valid_mask] = pe_values
 
     return features
+
+
+def _lookup_pairwise_relation_indices(
+    data: HeteroData,
+    node_index_sequences: Tensor,
+    valid_mask: Tensor,
+    relation_edge_types: Optional[list[GiGLEdgeType]],
+    node_type_offsets: dict[NodeType, int],
+    num_nodes: int,
+    device: torch.device,
+) -> Optional[Tensor]:
+    """Build sparse relation coordinates for valid token pairs.
+
+    For a directed edge ``source -> target``, attention uses ``query=target`` and
+    ``key=source`` so relation-aware attention follows message-passing
+    orientation.
+    """
+    if not relation_edge_types:
+        return None
+
+    token_occurrences = _build_token_occurrence_index(
+        node_index_sequences=node_index_sequences,
+        valid_mask=valid_mask,
+        num_nodes=num_nodes,
+        device=device,
+    )
+    if token_occurrences.batch_indices.numel() == 0:
+        return torch.zeros((0, 4), dtype=torch.long, device=device)
+
+    relation_index_parts: list[Tensor] = []
+    for relation_idx, edge_type in enumerate(relation_edge_types):
+        edge_type_tuple = edge_type.tuple_repr()
+        if edge_type_tuple not in data.edge_types:
+            continue
+
+        edge_index = data[edge_type_tuple].edge_index.to(
+            device=device,
+            dtype=torch.long,
+        )
+        if edge_index.numel() == 0:
+            continue
+
+        src_offset = int(node_type_offsets[edge_type.src_node_type])
+        dst_offset = int(node_type_offsets[edge_type.dst_node_type])
+        source_indices = edge_index[0] + src_offset
+        target_indices = edge_index[1] + dst_offset
+        (
+            relation_batch_indices,
+            relation_query_positions,
+            relation_key_positions,
+        ) = _match_directed_edges_to_token_pairs(
+            source_indices=source_indices,
+            target_indices=target_indices,
+            token_occurrences=token_occurrences,
+            num_nodes=num_nodes,
+            device=device,
+        )
+        if relation_batch_indices.numel() == 0:
+            continue
+
+        relation_indices = torch.stack(
+            [
+                relation_batch_indices,
+                relation_query_positions,
+                relation_key_positions,
+                torch.full(
+                    (relation_batch_indices.size(0),),
+                    relation_idx,
+                    dtype=torch.long,
+                    device=device,
+                ),
+            ],
+            dim=1,
+        )
+        relation_index_parts.append(torch.unique(relation_indices, dim=0))
+
+    if not relation_index_parts:
+        return torch.zeros((0, 4), dtype=torch.long, device=device)
+    return torch.cat(relation_index_parts, dim=0)
+
+
+def _build_token_occurrence_index(
+    node_index_sequences: Tensor,
+    valid_mask: Tensor,
+    num_nodes: int,
+    device: torch.device,
+) -> _TokenOccurrenceIndex:
+    """Index valid sequence tokens for sparse directed-edge to token matching."""
+    token_batch_indices, token_positions = torch.nonzero(valid_mask, as_tuple=True)
+    token_batch_indices = token_batch_indices.to(device=device, dtype=torch.long)
+    token_positions = token_positions.to(device=device, dtype=torch.long)
+    token_node_indices = node_index_sequences[token_batch_indices, token_positions].to(
+        device=device,
+        dtype=torch.long,
+    )
+
+    sorted_token_node_indices, node_sort_perm = torch.sort(token_node_indices)
+    token_batch_node_keys = token_batch_indices * num_nodes + token_node_indices
+    sorted_token_batch_node_keys, batch_node_sort_perm = torch.sort(
+        token_batch_node_keys
+    )
+
+    return _TokenOccurrenceIndex(
+        batch_indices=token_batch_indices,
+        positions=token_positions,
+        node_indices=token_node_indices,
+        sorted_node_indices=sorted_token_node_indices,
+        node_sort_perm=node_sort_perm,
+        sorted_batch_node_keys=sorted_token_batch_node_keys,
+        batch_node_sort_perm=batch_node_sort_perm,
+    )
+
+
+def _match_directed_edges_to_token_pairs(
+    source_indices: Tensor,
+    target_indices: Tensor,
+    token_occurrences: _TokenOccurrenceIndex,
+    num_nodes: int,
+    device: torch.device,
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Map ``source -> target`` graph edges onto valid sequence coordinates."""
+    empty = torch.zeros((0,), dtype=torch.long, device=device)
+    if source_indices.numel() == 0 or token_occurrences.batch_indices.numel() == 0:
+        return empty, empty, empty
+
+    source_indices = source_indices.to(device=device, dtype=torch.long)
+    target_indices = target_indices.to(device=device, dtype=torch.long)
+
+    target_lower_bounds = torch.searchsorted(
+        token_occurrences.sorted_node_indices,
+        target_indices,
+        right=False,
+    )
+    target_upper_bounds = torch.searchsorted(
+        token_occurrences.sorted_node_indices,
+        target_indices,
+        right=True,
+    )
+    target_match_counts = target_upper_bounds - target_lower_bounds
+    matched_edge_mask = target_match_counts > 0
+    if not matched_edge_mask.any():
+        return empty, empty, empty
+
+    matched_edge_indices = torch.nonzero(matched_edge_mask, as_tuple=True)[0]
+    matched_target_counts = target_match_counts[matched_edge_indices]
+    total_target_matches = int(matched_target_counts.sum().item())
+    repeated_target_edge_indices = torch.repeat_interleave(
+        matched_edge_indices,
+        matched_target_counts,
+    )
+    repeated_target_lower_bounds = torch.repeat_interleave(
+        target_lower_bounds[matched_edge_indices],
+        matched_target_counts,
+    )
+    target_group_start_offsets = torch.repeat_interleave(
+        torch.cumsum(matched_target_counts, dim=0) - matched_target_counts,
+        matched_target_counts,
+    )
+    target_sorted_positions = (
+        repeated_target_lower_bounds
+        + torch.arange(total_target_matches, device=device, dtype=torch.long)
+        - target_group_start_offsets
+    )
+    target_token_indices = token_occurrences.node_sort_perm[target_sorted_positions]
+    target_batch_indices = token_occurrences.batch_indices[target_token_indices]
+    target_query_positions = token_occurrences.positions[target_token_indices]
+
+    source_query_keys = (
+        target_batch_indices * num_nodes + source_indices[repeated_target_edge_indices]
+    )
+    source_lower_bounds = torch.searchsorted(
+        token_occurrences.sorted_batch_node_keys,
+        source_query_keys,
+        right=False,
+    )
+    source_upper_bounds = torch.searchsorted(
+        token_occurrences.sorted_batch_node_keys,
+        source_query_keys,
+        right=True,
+    )
+    source_match_counts = source_upper_bounds - source_lower_bounds
+    matched_target_mask = source_match_counts > 0
+    if not matched_target_mask.any():
+        return empty, empty, empty
+
+    matched_target_indices = torch.nonzero(matched_target_mask, as_tuple=True)[0]
+    matched_source_counts = source_match_counts[matched_target_indices]
+    total_source_matches = int(matched_source_counts.sum().item())
+    repeated_target_indices = torch.repeat_interleave(
+        matched_target_indices,
+        matched_source_counts,
+    )
+    repeated_source_lower_bounds = torch.repeat_interleave(
+        source_lower_bounds[matched_target_indices],
+        matched_source_counts,
+    )
+    source_group_start_offsets = torch.repeat_interleave(
+        torch.cumsum(matched_source_counts, dim=0) - matched_source_counts,
+        matched_source_counts,
+    )
+    source_sorted_positions = (
+        repeated_source_lower_bounds
+        + torch.arange(total_source_matches, device=device, dtype=torch.long)
+        - source_group_start_offsets
+    )
+    source_token_indices = token_occurrences.batch_node_sort_perm[
+        source_sorted_positions
+    ]
+
+    return (
+        target_batch_indices[repeated_target_indices],
+        target_query_positions[repeated_target_indices],
+        token_occurrences.positions[source_token_indices],
+    )
 
 
 def _get_k_hop_neighbors_sparse(

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -274,6 +274,10 @@ def _create_user_graph_with_ppr_edges() -> HeteroData:
     return data
 
 
+def _pairwise_relation_indices(coords: list[tuple[int, int, int, int]]) -> Tensor:
+    return torch.tensor(coords, dtype=torch.long)
+
+
 class TestGraphTransformerEncoderPEModes(TestCase):
     def setUp(self) -> None:
         self._node_type = NodeType("user")
@@ -411,6 +415,7 @@ class TestGraphTransformerEncoderPEModes(TestCase):
                             ]
                         ]
                     ),
+                    "pairwise_relation_indices": None,
                     "token_input": None,
                 },
             )
@@ -447,6 +452,7 @@ class TestGraphTransformerEncoderPEModes(TestCase):
                         [[[1.0, 0.5], [2.0, 0.25], [3.0, 0.125]]]
                     ),
                     "pairwise_bias": None,
+                    "pairwise_relation_indices": None,
                     "token_input": None,
                 },
             )
@@ -616,6 +622,270 @@ class TestGraphTransformerEncoderPEModes(TestCase):
         self.assertTrue(
             torch.allclose(base_embeddings, augmented_embeddings, atol=1e-6)
         )
+
+    def test_relation_attention_zero_init_matches_plain_layer(self) -> None:
+        torch.manual_seed(0)
+        base_layer = GraphTransformerEncoderLayer(
+            model_dim=8,
+            num_heads=2,
+            feedforward_dim=16,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+        )
+        relation_layer = GraphTransformerEncoderLayer(
+            model_dim=8,
+            num_heads=2,
+            feedforward_dim=16,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_bilinear",
+            num_relations=2,
+        )
+        relation_layer.load_state_dict(base_layer.state_dict(), strict=False)
+        base_layer.eval()
+        relation_layer.eval()
+
+        x = torch.randn(2, 4, 8)
+        valid_mask = torch.ones((2, 4), dtype=torch.bool)
+
+        with torch.no_grad():
+            assert relation_layer._relation_attention_matrices is not None
+            self.assertTrue(
+                torch.equal(
+                    relation_layer._relation_attention_matrices,
+                    torch.zeros_like(relation_layer._relation_attention_matrices),
+                )
+            )
+            base_output = base_layer(x, valid_mask=valid_mask)
+            relation_output = relation_layer(
+                x,
+                pairwise_relation_indices=_pairwise_relation_indices(
+                    [(0, 1, 0, 0), (1, 2, 1, 1)]
+                ),
+                valid_mask=valid_mask,
+            )
+
+        self.assertTrue(torch.allclose(base_output, relation_output, atol=1e-6))
+
+    def test_relation_value_mode_none_ignores_relation_indices(self) -> None:
+        torch.manual_seed(0)
+        layer = GraphTransformerEncoderLayer(
+            model_dim=8,
+            num_heads=2,
+            feedforward_dim=16,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+        )
+        layer.eval()
+        x = torch.randn(1, 3, 8)
+
+        with torch.no_grad():
+            base_output = layer(x, valid_mask=torch.ones((1, 3), dtype=torch.bool))
+            relation_index_output = layer(
+                x,
+                pairwise_relation_indices=_pairwise_relation_indices(
+                    [(0, 1, 0, 0), (0, 2, 1, 0)]
+                ),
+                valid_mask=torch.ones((1, 3), dtype=torch.bool),
+            )
+
+        self.assertTrue(torch.allclose(base_output, relation_index_output, atol=1e-6))
+
+    def test_relation_value_zero_init_matches_plain_layer(self) -> None:
+        torch.manual_seed(0)
+        base_layer = GraphTransformerEncoderLayer(
+            model_dim=8,
+            num_heads=2,
+            feedforward_dim=16,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+        )
+        relation_value_layer = GraphTransformerEncoderLayer(
+            model_dim=8,
+            num_heads=2,
+            feedforward_dim=16,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_value_mode="sparse_residual_gate",
+            num_relations=2,
+        )
+        relation_value_layer.load_state_dict(base_layer.state_dict(), strict=False)
+        base_layer.eval()
+        relation_value_layer.eval()
+
+        x = torch.randn(2, 4, 8)
+        valid_mask = torch.ones((2, 4), dtype=torch.bool)
+
+        with torch.no_grad():
+            assert relation_value_layer._relation_value_gates is not None
+            self.assertTrue(
+                torch.equal(
+                    relation_value_layer._relation_value_gates,
+                    torch.zeros_like(relation_value_layer._relation_value_gates),
+                )
+            )
+            base_output = base_layer(x, valid_mask=valid_mask)
+            relation_value_output = relation_value_layer(
+                x,
+                pairwise_relation_indices=_pairwise_relation_indices(
+                    [(0, 1, 0, 0), (1, 2, 1, 1)]
+                ),
+                valid_mask=valid_mask,
+            )
+
+        self.assertTrue(torch.allclose(base_output, relation_value_output, atol=1e-6))
+
+    def test_relation_value_residual_affects_indexed_queries_and_normalizes(
+        self,
+    ) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=4,
+            num_heads=2,
+            feedforward_dim=8,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_value_mode="sparse_residual_gate",
+            num_relations=2,
+        )
+        attention_output = torch.zeros((1, 2, 3, 2))
+        value = torch.tensor(
+            [
+                [
+                    [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]],
+                    [[4.0, 40.0], [5.0, 50.0], [6.0, 60.0]],
+                ]
+            ]
+        )
+
+        with torch.no_grad():
+            assert layer._relation_value_gates is not None
+            layer._relation_value_gates[0] = torch.tensor([[1.0, 0.5], [0.25, 0.0]])
+            layer._relation_value_gates[1] = torch.tensor([[2.0, 0.0], [0.0, 3.0]])
+            actual = layer._add_relation_value_residual(
+                attention_output=attention_output,
+                value=value,
+                pairwise_relation_indices=_pairwise_relation_indices(
+                    [
+                        (0, 1, 0, 0),
+                        (0, 1, 0, 0),
+                        (0, 1, 2, 1),
+                        (0, 2, 1, 0),
+                    ]
+                ),
+            )
+
+        expected = torch.zeros_like(attention_output)
+        expected[0, 0, 1] = torch.tensor([8.0 / 3.0, 10.0 / 3.0])
+        expected[0, 1, 1] = torch.tensor([2.0 / 3.0, 60.0])
+        expected[0, 0, 2] = torch.tensor([2.0, 10.0])
+        expected[0, 1, 2] = torch.tensor([1.25, 0.0])
+        self.assertTrue(torch.allclose(actual, expected, atol=1e-6))
+
+    def test_relation_value_residual_rejects_invalid_relation_ids(self) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=4,
+            num_heads=2,
+            feedforward_dim=8,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_value_mode="sparse_residual_gate",
+            num_relations=1,
+        )
+
+        with self.assertRaisesRegex(ValueError, "relation ids outside"):
+            layer._add_relation_value_residual(
+                attention_output=torch.zeros((1, 2, 2, 2)),
+                value=torch.zeros((1, 2, 2, 2)),
+                pairwise_relation_indices=_pairwise_relation_indices([(0, 1, 0, 1)]),
+            )
+
+    def test_relation_attention_nonzero_bias_only_indexed_pairs(self) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=2,
+            num_heads=1,
+            feedforward_dim=4,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_bilinear",
+            num_relations=1,
+        )
+        query = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]]])
+        key = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]]])
+
+        with torch.no_grad():
+            assert layer._relation_attention_matrices is not None
+            layer._relation_attention_matrices[0, 0] = torch.eye(2)
+            relation_bias = layer._build_relation_attention_bias(
+                query=query,
+                key=key,
+                pairwise_relation_indices=_pairwise_relation_indices([(0, 2, 1, 0)]),
+            )
+
+        assert relation_bias is not None
+        expected = torch.zeros((1, 1, 3, 3))
+        expected[0, 0, 2, 1] = 1.0 / torch.sqrt(torch.tensor(2.0)).item()
+        self.assertTrue(torch.allclose(relation_bias, expected, atol=1e-6))
+
+    def test_relation_attention_respects_existing_negative_bias(self) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=2,
+            num_heads=1,
+            feedforward_dim=4,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_bilinear",
+            num_relations=1,
+        )
+        query = torch.tensor([[[[1.0, 0.0], [0.0, 1.0]]]])
+        key = torch.tensor([[[[1.0, 0.0], [0.0, 1.0]]]])
+        negative_inf = torch.finfo(torch.float).min
+        attn_bias = torch.zeros((1, 1, 2, 2), dtype=torch.float)
+        attn_bias[0, 0, 0, 0] = negative_inf
+
+        with torch.no_grad():
+            assert layer._relation_attention_matrices is not None
+            layer._relation_attention_matrices[0, 0] = torch.eye(2)
+            relation_bias = layer._add_relation_attention_bias(
+                attn_bias=attn_bias,
+                query=query,
+                key=key,
+                pairwise_relation_indices=_pairwise_relation_indices([(0, 0, 0, 0)]),
+            )
+
+        assert relation_bias is not None
+        self.assertEqual(relation_bias[0, 0, 0, 0].item(), negative_inf)
+
+    def test_relation_attention_supports_ppr_sequence_construction(self) -> None:
+        data = _create_user_graph_with_ppr_edges()
+        ppr_edge_type = EdgeType(self._node_type, Relation("ppr"), self._node_type)
+
+        base_encoder = self._create_encoder(
+            edge_type_to_feat_dim_map={ppr_edge_type: 0},
+            sequence_construction_method="ppr",
+        )
+        relation_encoder = self._create_encoder(
+            edge_type_to_feat_dim_map={ppr_edge_type: 0},
+            sequence_construction_method="ppr",
+            relation_attention_mode="edge_type_bilinear",
+        )
+        relation_encoder.load_state_dict(base_encoder.state_dict(), strict=False)
+        base_encoder.eval()
+        relation_encoder.eval()
+
+        with torch.no_grad():
+            base_embeddings = base_encoder(
+                data=data,
+                anchor_node_type=self._node_type,
+                device=self._device,
+            )
+            relation_embeddings = relation_encoder(
+                data=data,
+                anchor_node_type=self._node_type,
+                device=self._device,
+            )
+
+        self.assertEqual(relation_embeddings.shape, (3, 6))
+        self.assertTrue(torch.allclose(base_embeddings, relation_embeddings, atol=1e-6))
 
     def test_forward_supports_mixed_embedded_and_continuous_token_input_features(
         self,

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -918,6 +918,42 @@ class TestGraphTransformerEncoderPEModes(TestCase):
         expected[0, 0, 2, 1] = 1.0 / torch.sqrt(torch.tensor(2.0)).item()
         self.assertTrue(torch.allclose(relation_bias, expected, atol=1e-6))
 
+    def test_relation_attention_handles_unsorted_relation_indices(self) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=2,
+            num_heads=1,
+            feedforward_dim=4,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_bilinear",
+            num_relations=2,
+        )
+        query = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]]])
+        key = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]]])
+
+        with torch.no_grad():
+            assert layer._relation_attention_matrices is not None
+            layer._relation_attention_matrices[0, 0] = torch.eye(2)
+            layer._relation_attention_matrices[1, 0] = 2.0 * torch.eye(2)
+            relation_bias = layer._build_relation_attention_bias(
+                query=query,
+                key=key,
+                pairwise_relation_indices=_pairwise_relation_indices(
+                    [
+                        (0, 2, 1, 1),
+                        (0, 1, 1, 0),
+                        (0, 2, 0, 1),
+                    ]
+                ),
+            )
+
+        assert relation_bias is not None
+        expected = torch.zeros((1, 1, 3, 3))
+        expected[0, 0, 2, 1] = 2.0 / torch.sqrt(torch.tensor(2.0)).item()
+        expected[0, 0, 1, 1] = 1.0 / torch.sqrt(torch.tensor(2.0)).item()
+        expected[0, 0, 2, 0] = 2.0 / torch.sqrt(torch.tensor(2.0)).item()
+        self.assertTrue(torch.allclose(relation_bias, expected, atol=1e-6))
+
     def test_relation_attention_rejects_invalid_relation_ids(self) -> None:
         layer = GraphTransformerEncoderLayer(
             model_dim=2,

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -643,6 +643,7 @@ class TestGraphTransformerEncoderPEModes(TestCase):
                 attention_bias_data={
                     "anchor_bias": None,
                     "pairwise_bias": torch.zeros((1, 3, 3, 1), dtype=torch.float),
+                    "pairwise_relation_indices": None,
                     "pairwise_nonmissing_indices": torch.tensor(
                         [
                             [0, 0, 0],

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -667,7 +667,7 @@ class TestGraphTransformerEncoderPEModes(TestCase):
 
         self.assertTrue(torch.allclose(base_output, relation_output, atol=1e-6))
 
-    def test_relation_value_mode_none_ignores_relation_indices(self) -> None:
+    def test_relation_indices_ignored_when_attention_mode_disabled(self) -> None:
         torch.manual_seed(0)
         layer = GraphTransformerEncoderLayer(
             model_dim=8,
@@ -690,114 +690,6 @@ class TestGraphTransformerEncoderPEModes(TestCase):
             )
 
         self.assertTrue(torch.allclose(base_output, relation_index_output, atol=1e-6))
-
-    def test_relation_value_zero_init_matches_plain_layer(self) -> None:
-        torch.manual_seed(0)
-        base_layer = GraphTransformerEncoderLayer(
-            model_dim=8,
-            num_heads=2,
-            feedforward_dim=16,
-            dropout_rate=0.0,
-            attention_dropout_rate=0.0,
-        )
-        relation_value_layer = GraphTransformerEncoderLayer(
-            model_dim=8,
-            num_heads=2,
-            feedforward_dim=16,
-            dropout_rate=0.0,
-            attention_dropout_rate=0.0,
-            relation_value_mode="sparse_residual_gate",
-            num_relations=2,
-        )
-        relation_value_layer.load_state_dict(base_layer.state_dict(), strict=False)
-        base_layer.eval()
-        relation_value_layer.eval()
-
-        x = torch.randn(2, 4, 8)
-        valid_mask = torch.ones((2, 4), dtype=torch.bool)
-
-        with torch.no_grad():
-            assert relation_value_layer._relation_value_gates is not None
-            self.assertTrue(
-                torch.equal(
-                    relation_value_layer._relation_value_gates,
-                    torch.zeros_like(relation_value_layer._relation_value_gates),
-                )
-            )
-            base_output = base_layer(x, valid_mask=valid_mask)
-            relation_value_output = relation_value_layer(
-                x,
-                pairwise_relation_indices=_pairwise_relation_indices(
-                    [(0, 1, 0, 0), (1, 2, 1, 1)]
-                ),
-                valid_mask=valid_mask,
-            )
-
-        self.assertTrue(torch.allclose(base_output, relation_value_output, atol=1e-6))
-
-    def test_relation_value_residual_affects_indexed_queries_and_normalizes(
-        self,
-    ) -> None:
-        layer = GraphTransformerEncoderLayer(
-            model_dim=4,
-            num_heads=2,
-            feedforward_dim=8,
-            dropout_rate=0.0,
-            attention_dropout_rate=0.0,
-            relation_value_mode="sparse_residual_gate",
-            num_relations=2,
-        )
-        attention_output = torch.zeros((1, 2, 3, 2))
-        value = torch.tensor(
-            [
-                [
-                    [[1.0, 10.0], [2.0, 20.0], [3.0, 30.0]],
-                    [[4.0, 40.0], [5.0, 50.0], [6.0, 60.0]],
-                ]
-            ]
-        )
-
-        with torch.no_grad():
-            assert layer._relation_value_gates is not None
-            layer._relation_value_gates[0] = torch.tensor([[1.0, 0.5], [0.25, 0.0]])
-            layer._relation_value_gates[1] = torch.tensor([[2.0, 0.0], [0.0, 3.0]])
-            actual = layer._add_relation_value_residual(
-                attention_output=attention_output,
-                value=value,
-                pairwise_relation_indices=_pairwise_relation_indices(
-                    [
-                        (0, 1, 0, 0),
-                        (0, 1, 0, 0),
-                        (0, 1, 2, 1),
-                        (0, 2, 1, 0),
-                    ]
-                ),
-            )
-
-        expected = torch.zeros_like(attention_output)
-        expected[0, 0, 1] = torch.tensor([8.0 / 3.0, 10.0 / 3.0])
-        expected[0, 1, 1] = torch.tensor([2.0 / 3.0, 60.0])
-        expected[0, 0, 2] = torch.tensor([2.0, 10.0])
-        expected[0, 1, 2] = torch.tensor([1.25, 0.0])
-        self.assertTrue(torch.allclose(actual, expected, atol=1e-6))
-
-    def test_relation_value_residual_rejects_invalid_relation_ids(self) -> None:
-        layer = GraphTransformerEncoderLayer(
-            model_dim=4,
-            num_heads=2,
-            feedforward_dim=8,
-            dropout_rate=0.0,
-            attention_dropout_rate=0.0,
-            relation_value_mode="sparse_residual_gate",
-            num_relations=1,
-        )
-
-        with self.assertRaisesRegex(ValueError, "relation ids outside"):
-            layer._add_relation_value_residual(
-                attention_output=torch.zeros((1, 2, 2, 2)),
-                value=torch.zeros((1, 2, 2, 2)),
-                pairwise_relation_indices=_pairwise_relation_indices([(0, 1, 0, 1)]),
-            )
 
     def test_relation_attention_nonzero_bias_only_indexed_pairs(self) -> None:
         layer = GraphTransformerEncoderLayer(
@@ -825,6 +717,24 @@ class TestGraphTransformerEncoderPEModes(TestCase):
         expected = torch.zeros((1, 1, 3, 3))
         expected[0, 0, 2, 1] = 1.0 / torch.sqrt(torch.tensor(2.0)).item()
         self.assertTrue(torch.allclose(relation_bias, expected, atol=1e-6))
+
+    def test_relation_attention_rejects_invalid_relation_ids(self) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=2,
+            num_heads=1,
+            feedforward_dim=4,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_bilinear",
+            num_relations=1,
+        )
+
+        with self.assertRaisesRegex(ValueError, "relation ids outside"):
+            layer._build_relation_attention_bias(
+                query=torch.zeros((1, 1, 2, 2)),
+                key=torch.zeros((1, 1, 2, 2)),
+                pairwise_relation_indices=_pairwise_relation_indices([(0, 1, 0, 1)]),
+            )
 
     def test_relation_attention_respects_existing_negative_bias(self) -> None:
         layer = GraphTransformerEncoderLayer(

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -868,6 +868,67 @@ class TestGraphTransformerEncoderPEModes(TestCase):
 
         self.assertTrue(torch.allclose(base_output, relation_output, atol=1e-6))
 
+    def test_relation_attention_hgt_init_matches_plain_layer(self) -> None:
+        torch.manual_seed(0)
+        base_layer = GraphTransformerEncoderLayer(
+            model_dim=8,
+            num_heads=2,
+            feedforward_dim=16,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+        )
+        relation_layer = GraphTransformerEncoderLayer(
+            model_dim=8,
+            num_heads=2,
+            feedforward_dim=16,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_hgt",
+            num_relations=2,
+        )
+        relation_layer.load_state_dict(base_layer.state_dict(), strict=False)
+        base_layer.eval()
+        relation_layer.eval()
+
+        x = torch.randn(2, 4, 8)
+        valid_mask = torch.ones((2, 4), dtype=torch.bool)
+
+        with torch.no_grad():
+            assert relation_layer._relation_hgt_attention_matrices is not None
+            assert relation_layer._relation_hgt_attention_priors is not None
+            self.assertEqual(
+                tuple(relation_layer._relation_hgt_attention_matrices.shape),
+                (2, 4, 4),
+            )
+            self.assertEqual(
+                tuple(relation_layer._relation_hgt_attention_priors.shape),
+                (2,),
+            )
+            expected_matrices = torch.eye(4).expand(2, -1, -1)
+            self.assertTrue(
+                torch.equal(
+                    relation_layer._relation_hgt_attention_matrices,
+                    expected_matrices,
+                )
+            )
+            self.assertTrue(
+                torch.equal(
+                    relation_layer._relation_hgt_attention_priors,
+                    torch.ones(2),
+                )
+            )
+
+            base_output = base_layer(x, valid_mask=valid_mask)
+            relation_output = relation_layer(
+                x,
+                pairwise_relation_indices=_pairwise_relation_indices(
+                    [(0, 1, 0, 0), (1, 2, 1, 1)]
+                ),
+                valid_mask=valid_mask,
+            )
+
+        self.assertTrue(torch.allclose(base_output, relation_output, atol=1e-6))
+
     def test_relation_indices_ignored_when_attention_mode_disabled(self) -> None:
         torch.manual_seed(0)
         layer = GraphTransformerEncoderLayer(
@@ -955,6 +1016,62 @@ class TestGraphTransformerEncoderPEModes(TestCase):
         expected[0, 0, 2, 0] = 2.0 / torch.sqrt(torch.tensor(2.0)).item()
         self.assertTrue(torch.allclose(relation_bias, expected, atol=1e-6))
 
+    def test_relation_attention_hgt_non_identity_bias_only_indexed_pairs(
+        self,
+    ) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=2,
+            num_heads=1,
+            feedforward_dim=4,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_hgt",
+            num_relations=1,
+        )
+        query = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]]])
+        key = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]]])
+
+        with torch.no_grad():
+            assert layer._relation_hgt_attention_matrices is not None
+            layer._relation_hgt_attention_matrices[0] = 2.0 * torch.eye(2)
+            relation_bias = layer._build_relation_attention_bias(
+                query=query,
+                key=key,
+                pairwise_relation_indices=_pairwise_relation_indices([(0, 2, 1, 0)]),
+            )
+
+        assert relation_bias is not None
+        expected = torch.zeros((1, 1, 3, 3))
+        expected[0, 0, 2, 1] = 1.0 / torch.sqrt(torch.tensor(2.0)).item()
+        self.assertTrue(torch.allclose(relation_bias, expected, atol=1e-6))
+
+    def test_relation_attention_hgt_mu_scales_indexed_pairs(self) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=2,
+            num_heads=1,
+            feedforward_dim=4,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_hgt",
+            num_relations=1,
+        )
+        query = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]]])
+        key = torch.tensor([[[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]]]])
+
+        with torch.no_grad():
+            assert layer._relation_hgt_attention_priors is not None
+            layer._relation_hgt_attention_priors[0] = 3.0
+            relation_bias = layer._build_relation_attention_bias(
+                query=query,
+                key=key,
+                pairwise_relation_indices=_pairwise_relation_indices([(0, 2, 1, 0)]),
+            )
+
+        assert relation_bias is not None
+        expected = torch.zeros((1, 1, 3, 3))
+        expected[0, 0, 2, 1] = 2.0 / torch.sqrt(torch.tensor(2.0)).item()
+        self.assertTrue(torch.allclose(relation_bias, expected, atol=1e-6))
+
     def test_relation_attention_rejects_invalid_relation_ids(self) -> None:
         layer = GraphTransformerEncoderLayer(
             model_dim=2,
@@ -963,6 +1080,24 @@ class TestGraphTransformerEncoderPEModes(TestCase):
             dropout_rate=0.0,
             attention_dropout_rate=0.0,
             relation_attention_mode="edge_type_bilinear",
+            num_relations=1,
+        )
+
+        with self.assertRaisesRegex(ValueError, "relation ids outside"):
+            layer._build_relation_attention_bias(
+                query=torch.zeros((1, 1, 2, 2)),
+                key=torch.zeros((1, 1, 2, 2)),
+                pairwise_relation_indices=_pairwise_relation_indices([(0, 1, 0, 1)]),
+            )
+
+    def test_relation_attention_hgt_rejects_invalid_relation_ids(self) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=2,
+            num_heads=1,
+            feedforward_dim=4,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_hgt",
             num_relations=1,
         )
 
@@ -1002,6 +1137,35 @@ class TestGraphTransformerEncoderPEModes(TestCase):
         assert relation_bias is not None
         self.assertEqual(relation_bias[0, 0, 0, 0].item(), negative_inf)
 
+    def test_relation_attention_hgt_respects_existing_negative_bias(self) -> None:
+        layer = GraphTransformerEncoderLayer(
+            model_dim=2,
+            num_heads=1,
+            feedforward_dim=4,
+            dropout_rate=0.0,
+            attention_dropout_rate=0.0,
+            relation_attention_mode="edge_type_hgt",
+            num_relations=1,
+        )
+        query = torch.tensor([[[[1.0, 0.0], [0.0, 1.0]]]])
+        key = torch.tensor([[[[1.0, 0.0], [0.0, 1.0]]]])
+        negative_inf = torch.finfo(torch.float).min
+        attn_bias = torch.zeros((1, 1, 2, 2), dtype=torch.float)
+        attn_bias[0, 0, 0, 0] = negative_inf
+
+        with torch.no_grad():
+            assert layer._relation_hgt_attention_matrices is not None
+            layer._relation_hgt_attention_matrices[0] = 2.0 * torch.eye(2)
+            relation_bias = layer._add_relation_attention_bias(
+                attn_bias=attn_bias,
+                query=query,
+                key=key,
+                pairwise_relation_indices=_pairwise_relation_indices([(0, 0, 0, 0)]),
+            )
+
+        assert relation_bias is not None
+        self.assertEqual(relation_bias[0, 0, 0, 0].item(), negative_inf)
+
     def test_relation_attention_supports_ppr_sequence_construction(self) -> None:
         data = _create_user_graph_with_ppr_edges()
         ppr_edge_type = EdgeType(self._node_type, Relation("ppr"), self._node_type)
@@ -1014,6 +1178,38 @@ class TestGraphTransformerEncoderPEModes(TestCase):
             edge_type_to_feat_dim_map={ppr_edge_type: 0},
             sequence_construction_method="ppr",
             relation_attention_mode="edge_type_bilinear",
+        )
+        relation_encoder.load_state_dict(base_encoder.state_dict(), strict=False)
+        base_encoder.eval()
+        relation_encoder.eval()
+
+        with torch.no_grad():
+            base_embeddings = base_encoder(
+                data=data,
+                anchor_node_type=self._node_type,
+                device=self._device,
+            )
+            relation_embeddings = relation_encoder(
+                data=data,
+                anchor_node_type=self._node_type,
+                device=self._device,
+            )
+
+        self.assertEqual(relation_embeddings.shape, (3, 6))
+        self.assertTrue(torch.allclose(base_embeddings, relation_embeddings, atol=1e-6))
+
+    def test_relation_attention_hgt_supports_ppr_sequence_construction(self) -> None:
+        data = _create_user_graph_with_ppr_edges()
+        ppr_edge_type = EdgeType(self._node_type, Relation("ppr"), self._node_type)
+
+        base_encoder = self._create_encoder(
+            edge_type_to_feat_dim_map={ppr_edge_type: 0},
+            sequence_construction_method="ppr",
+        )
+        relation_encoder = self._create_encoder(
+            edge_type_to_feat_dim_map={ppr_edge_type: 0},
+            sequence_construction_method="ppr",
+            relation_attention_mode="edge_type_hgt",
         )
         relation_encoder.load_state_dict(base_encoder.state_dict(), strict=False)
         base_encoder.eval()

--- a/tests/unit/transforms/graph_transformer_test.py
+++ b/tests/unit/transforms/graph_transformer_test.py
@@ -7,6 +7,7 @@ import torch.nn as nn
 from absl.testing import absltest
 from torch_geometric.data import HeteroData
 
+from gigl.src.common.types.graph_data import EdgeType, NodeType, Relation
 from gigl.transforms.graph_transformer import (
     _get_k_hop_neighbors_sparse,
     heterodata_to_graph_transformer_input,
@@ -252,6 +253,7 @@ class TestHeteroToGraphTransformerInput(TestCase):
         self.assertIsInstance(attention_bias_data, dict)
         self.assertIn("anchor_bias", attention_bias_data)
         self.assertIn("pairwise_bias", attention_bias_data)
+        self.assertIn("pairwise_relation_indices", attention_bias_data)
 
     def test_attention_mask_validity(self):
         """Test that attention mask correctly identifies valid positions."""
@@ -304,6 +306,52 @@ class TestHeteroToGraphTransformerInput(TestCase):
 
         # First position should be anchor node
         self.assertTrue(torch.allclose(sequences[0, 0], anchor_feature))
+
+    def test_pairwise_relation_indices_follow_order_direction_and_padding(self):
+        """Sparse relation indices preserve edge-type labels before homogenization."""
+        user = NodeType("user")
+        likes = EdgeType(user, Relation("likes"), user)
+        follows = EdgeType(user, Relation("follows"), user)
+        missing = EdgeType(user, Relation("missing"), user)
+
+        data = HeteroData()
+        data["user"].x = torch.tensor(
+            [
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 1.0],
+            ]
+        )
+        data["user"].batch_size = 1
+        data[likes.tuple_repr()].edge_index = torch.tensor([[0], [1]])
+        data[follows.tuple_repr()].edge_index = torch.tensor([[0, 1], [1, 2]])
+
+        _, valid_mask, auxiliary_data = heterodata_to_graph_transformer_input(
+            data=data,
+            batch_size=1,
+            max_seq_len=4,
+            anchor_node_type="user",
+            hop_distance=2,
+            relation_edge_types=[likes, follows, missing],
+        )
+
+        self.assertTrue(
+            torch.equal(valid_mask[0], torch.tensor([True, True, True, False]))
+        )
+        pairwise_relation_indices = auxiliary_data["pairwise_relation_indices"]
+        self.assertIsNotNone(pairwise_relation_indices)
+        assert pairwise_relation_indices is not None
+        self.assertEqual(pairwise_relation_indices.shape[1], 4)
+        self.assertEqual(
+            {tuple(coord) for coord in pairwise_relation_indices.tolist()},
+            {
+                (0, 1, 0, 0),  # likes: source 0 -> target 1
+                (0, 1, 0, 1),  # follows: source 0 -> target 1
+                (0, 2, 1, 1),  # follows: source 1 -> target 2
+            },
+        )
+        self.assertFalse((pairwise_relation_indices[:, 1:3] == 3).any().item())
+        self.assertFalse((pairwise_relation_indices[:, 3] == 2).any().item())
 
     def test_different_anchor_types(self):
         """Test with different anchor node types."""

--- a/tests/unit/transforms/graph_transformer_test.py
+++ b/tests/unit/transforms/graph_transformer_test.py
@@ -388,6 +388,7 @@ class TestHeteroToGraphTransformerInput(TestCase):
         )
         self.assertFalse((pairwise_relation_indices[:, 1:3] == 3).any().item())
         self.assertFalse((pairwise_relation_indices[:, 3] == 2).any().item())
+
     def test_sampling_direction_defaults_to_out(self):
         """Out sampling preserves existing k-hop reachability."""
         data = create_directed_chain_data()


### PR DESCRIPTION
## Scope of work done

This PR adds opt-in relation-aware attention logits to the GiGL Graph Transformer without enabling the graph-edge hard attention mask path.

- Adds `relation_attention_mode="edge_type_bilinear"` to `GraphTransformerEncoderLayer`.
- Adds zero-initialized per-relation bilinear attention matrices shaped `(num_relations, num_heads, head_dim, head_dim)`.
- Represents relation edges as sparse `(batch_idx, query_pos, key_pos, relation_idx)` coordinates.
- Maps directed graph edges `source -> target` into attention coordinates as `query=target`, `key=source`.
- Wires relation coordinate construction through `heterodata_to_graph_transformer_input`.
- Derives relation order in `GraphTransformerEncoder` from sorted `edge_type_to_feat_dim_map`.
- Adds transform and encoder unit coverage for relation ordering/direction, zero-init equivalence, invalid relation IDs, indexed-pair logit updates, padding exclusion, and existing negative attention masks.

Explicitly out of scope:

- Graph-edge hard attention masking.
- Relation value residual gates.
- Sparse edge-attribute attention bias.
- Sparse pairwise nonmissing structural-bias indices.

## Implementation notes

Default behavior remains unchanged unless `relation_attention_mode="edge_type_bilinear"` is configured.

Relation-aware logits initialize to zero, preserving baseline outputs at initialization.

Sparse relation coordinates are built before relation identity is lost in `to_homogeneous()`.

The main attention path still uses PyTorch SDPA. This PR only adds sparse relation logit bias before SDPA.

Where is the documentation for this feature?: N/A for this draft. I can add docs/changelog notes once we settle the final public interface names.

## Did you add automated tests or write a test plan?

Added unit coverage in:

- `tests/unit/nn/graph_transformer_test.py`
- `tests/unit/transforms/graph_transformer_test.py`

Local checks run:

- `python3 -m py_compile gigl/nn/graph_transformer.py gigl/transforms/graph_transformer.py tests/unit/nn/graph_transformer_test.py tests/unit/transforms/graph_transformer_test.py`
- `.venv/bin/ruff check --fix --config pyproject.toml gigl/nn/graph_transformer.py gigl/transforms/graph_transformer.py tests/unit/nn/graph_transformer_test.py tests/unit/transforms/graph_transformer_test.py`
- `.venv/bin/ruff format --config pyproject.toml gigl/nn/graph_transformer.py gigl/transforms/graph_transformer.py tests/unit/nn/graph_transformer_test.py tests/unit/transforms/graph_transformer_test.py`
- `git diff --check`
- Focused smoke script covering bilinear sparse bias, invalid relation IDs, transform relation indices, and encoder zero-init parity.