### PR TITLE
Fail node id enumeration fast on NULL node ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fail node id enumeration fast when the source node table contains NULL node ids, instead of silently enumerating NULL
+  as its own node (https://github.com/Snapchat/GiGL/issues/288)
+
 ## [0.3.1] - Jun 4, 2026
 
 ### Fixed

--- a/gigl/src/data_preprocessor/lib/enumerate/queries.py
+++ b/gigl/src/data_preprocessor/lib/enumerate/queries.py
@@ -3,8 +3,20 @@ DEFAULT_ENUMERATED_NODE_ID_FIELD = "int_id"
 
 UNIQUE_NODE_ENUMERATION_QUERY = """
 WITH
+  source_node_ids AS (
+    -- Fail fast if any node id is NULL. Otherwise, NULL would survive SELECT DISTINCT and be
+    -- silently enumerated as its own node, and edges referencing it would fail to map to any
+    -- enumerated node id downstream. See https://github.com/Snapchat/GiGL/issues/288.
+    SELECT
+      IF(
+        {bq_source_table_node_id_col_name} IS NULL,
+        ERROR("Found NULL node id in column `{bq_source_table_node_id_col_name}` of table `{bq_source_table_name}`; node ids must be non-NULL."),
+        {bq_source_table_node_id_col_name}
+      ) AS {original_node_id_field}
+    FROM `{bq_source_table_name}`
+  ),
   unique_nodes AS (
-    SELECT DISTINCT {bq_source_table_node_id_col_name} as {original_node_id_field} FROM `{bq_source_table_name}`
+    SELECT DISTINCT {original_node_id_field} FROM source_node_ids
   )
 SELECT
   {original_node_id_field},

--- a/tests/integration/pipeline/data_preprocessor/enumerator_test.py
+++ b/tests/integration/pipeline/data_preprocessor/enumerator_test.py
@@ -16,6 +16,7 @@ from gigl.src.data_preprocessor.lib.enumerate.utils import (
     Enumerator,
     EnumeratorEdgeTypeMetadata,
     EnumeratorNodeTypeMetadata,
+    get_enumerated_node_id_map_bq_table_name,
 )
 from gigl.src.data_preprocessor.lib.ingest.bigquery import (
     BigqueryEdgeDataReference,
@@ -598,6 +599,66 @@ class EnumeratorTest(TestCase):
             node_data_references=sharded_node_references,
             edge_data_references=sharded_edge_references,
         )
+
+    def test_enumeration_fails_on_null_node_ids(self) -> None:
+        """Enumeration should fail loudly if the source node table contains NULL node ids.
+
+        See https://github.com/Snapchat/GiGL/issues/288: previously, a NULL node id would
+        survive SELECT DISTINCT, be silently assigned an enumerated int id, and edges
+        referencing it would not map to any enumerated node id downstream.
+        """
+        null_node_data_reference = BigqueryNodeDataReference(
+            reference_uri=BqUtils.join_path(
+                get_resource_config().project,
+                get_resource_config().temp_assets_bq_dataset_name,
+                f"null_node_features_{self.__applied_task_identifier}",
+            ),
+            node_type=_PERSON_NODE_TYPE,
+            identifier=_PERSON_NODE_IDENTIFIER_FIELD,
+        )
+        self.__bq_tables_to_cleanup_on_teardown.append(
+            null_node_data_reference.reference_uri
+        )
+        # Note: the NULL node id is intentionally not in the first record, since
+        # __upload_records_to_bq infers the BQ schema from the first record's value types.
+        records_with_null_node_id: list[dict[str, Any]] = (
+            _PERSON_NODE_FEATURE_RECORDS
+            + [
+                {
+                    _PERSON_NODE_IDENTIFIER_FIELD: None,
+                    "height": 4.0,
+                    "age": 4.0,
+                    "weight": 4.0,
+                }
+            ]
+        )
+        self.__upload_records_to_bq(
+            data_reference=null_node_data_reference,
+            records=records_with_null_node_id,
+        )
+
+        applied_task_identifier = AppliedTaskIdentifier(
+            f"{self.__applied_task_identifier}_null_node_id_enumeration"
+        )
+        # Register the would-be output table for cleanup in case of a regression where
+        # the enumeration query unexpectedly succeeds.
+        self.__bq_tables_to_cleanup_on_teardown.append(
+            get_enumerated_node_id_map_bq_table_name(
+                applied_task_identifier=applied_task_identifier,
+                node_type=_PERSON_NODE_TYPE,
+            )
+        )
+
+        # Enumerator.run() converts raised exceptions into sys.exit(...), so a failed
+        # enumeration surfaces as SystemExit.
+        with self.assertRaises(SystemExit) as ctx:
+            Enumerator().run(
+                applied_task_identifier=applied_task_identifier,
+                node_data_references=[null_node_data_reference],
+                edge_data_references=[],
+                gcp_project=get_resource_config().project,
+            )
+        self.assertIn("NULL node id", str(ctx.exception))
 
     def tearDown(self) -> None:
         for table_name in self.__bq_tables_to_cleanup_on_teardown:


### PR DESCRIPTION
Hi Snapchat,

This Fixes #288.

The problem from what I can surmise is there's A NULL node id in the source node table survives the `SELECT DISTINCT` in `UNIQUE_NODE_ENUMERATION_QUERY`, gets silently assigned its own enumerated `int_id`, and pollutes the graph. The existing row-count assertion cannot catch this (a single NULL keeps input/output counts equal), and downstream edge enumeration joins on the original node id never match NULL, producing NULL enumerated src/dst ids in the enumerated edge tables.

**Fix.** Add a NULL guard directly in the enumeration query using BigQuery's documented `IF(x IS NULL, ERROR(...), x)` pattern, so the enumeration job fails immediately with a clear message naming the offending column and table. Doing this in SQL avoids the extra table scan a separate validation query would cost on billion-row node tables, and covers both the full-table and sharded read paths, which share this query.

**Test.** Adds `test_enumeration_fails_on_null_node_ids` to the enumerator integration test: uploads a node table containing a NULL node id and asserts `Enumerator.run` fails (via `SystemExit`) with the new error message. The message assertion also guards against a false pass from unrelated failures.

**Verification performed locally:**
- Rendered query parses as valid BigQuery SQL (sqlglot, `bigquery` dialect)
- `ruff check` and `ruff format --check` clean with the repo-pinned `ruff==0.15.10`
- CHANGELOG formatted with repo-pinned `mdformat==0.7.22` (`wrap=120`)

I don't have GCP credentials to run the BQ-backed integration test myself; would appreciate a maintainer kicking off the integration CI. Happy to adjust if you'd prefer filtering NULLs with a warning instead of failing the job.
