### PR TITLE
Dispatch CustomLauncherConfig to launch_custom in GLT trainer/inferencer

### DIFF
--- a/gigl/src/inference/v2/glt_inferencer.py
+++ b/gigl/src/inference/v2/glt_inferencer.py
@@ -5,6 +5,7 @@ from gigl.common import Uri, UriFactory
 from gigl.common.logger import Logger
 from gigl.env.pipelines_config import get_resource_config
 from gigl.src.common.constants.components import GiGLComponents
+from gigl.src.common.custom_launcher import launch_custom
 from gigl.src.common.types import AppliedTaskIdentifier
 from gigl.src.common.types.pb_wrappers.gbml_config import GbmlConfigPbWrapper
 from gigl.src.common.types.pb_wrappers.gigl_resource_config import (
@@ -16,6 +17,7 @@ from gigl.src.common.vertex_ai_launcher import (
     launch_single_pool_job,
 )
 from snapchat.research.gbml.gigl_resource_config_pb2 import (
+    CustomLauncherConfig,
     LocalResourceConfig,
     VertexAiGraphStoreConfig,
     VertexAiResourceConfig,
@@ -109,6 +111,18 @@ class GLTInferencer:
         if isinstance(resource_config_wrapper.inferencer_config, LocalResourceConfig):
             raise NotImplementedError(
                 f"Local GLT Inferencer is not yet supported, please specify a {VertexAiResourceConfig.__name__} or {VertexAiGraphStoreConfig.__name__} resource config field."
+            )
+        elif isinstance(
+            resource_config_wrapper.inferencer_config, CustomLauncherConfig
+        ):
+            launch_custom(
+                custom_launcher_config=resource_config_wrapper.inferencer_config,
+                applied_task_identifier=applied_task_identifier,
+                task_config_uri=task_config_uri,
+                resource_config_uri=resource_config_uri,
+                cpu_docker_uri=cpu_docker_uri,
+                cuda_docker_uri=cuda_docker_uri,
+                component=GiGLComponents.Inferencer,
             )
         elif isinstance(
             resource_config_wrapper.inferencer_config, VertexAiResourceConfig

--- a/gigl/src/inference/v2/glt_inferencer.py
+++ b/gigl/src/inference/v2/glt_inferencer.py
@@ -110,7 +110,7 @@ class GLTInferencer:
 
         if isinstance(resource_config_wrapper.inferencer_config, LocalResourceConfig):
             raise NotImplementedError(
-                f"Local GLT Inferencer is not yet supported, please specify a {VertexAiResourceConfig.__name__} or {VertexAiGraphStoreConfig.__name__} resource config field."
+                f"Local GLT Inferencer is not yet supported, please specify a {VertexAiResourceConfig.__name__}, {VertexAiGraphStoreConfig.__name__}, or {CustomLauncherConfig.__name__} resource config field."
             )
         elif isinstance(
             resource_config_wrapper.inferencer_config, CustomLauncherConfig
@@ -138,7 +138,7 @@ class GLTInferencer:
             )
         else:
             raise NotImplementedError(
-                f"Unsupported resource config for glt inference: {type(resource_config_wrapper.inferencer_config).__name__}"
+                f"Unsupported resource config for glt inference: {type(resource_config_wrapper.inferencer_config).__name__}. Supported: {VertexAiResourceConfig.__name__}, {VertexAiGraphStoreConfig.__name__}, {CustomLauncherConfig.__name__}."
             )
 
 

--- a/gigl/src/training/v2/glt_trainer.py
+++ b/gigl/src/training/v2/glt_trainer.py
@@ -108,7 +108,7 @@ class GLTTrainer:
         if isinstance(trainer_config, LocalResourceConfig):
             # TODO: (svij) Implement local training
             raise NotImplementedError(
-                f"Local GLT Trainer is not yet supported, please specify a {VertexAiResourceConfig.__name__} or {VertexAiGraphStoreConfig.__name__} resource config field."
+                f"Local GLT Trainer is not yet supported, please specify a {VertexAiResourceConfig.__name__}, {VertexAiGraphStoreConfig.__name__}, or {CustomLauncherConfig.__name__} resource config field."
             )
         elif isinstance(trainer_config, CustomLauncherConfig):
             launch_custom(
@@ -132,7 +132,7 @@ class GLTTrainer:
             )
         else:
             raise NotImplementedError(
-                f"Unsupported resource config for glt training: {type(trainer_config).__name__}"
+                f"Unsupported resource config for glt training: {type(trainer_config).__name__}. Supported: {VertexAiResourceConfig.__name__}, {VertexAiGraphStoreConfig.__name__}, {CustomLauncherConfig.__name__}."
             )
 
 

--- a/gigl/src/training/v2/glt_trainer.py
+++ b/gigl/src/training/v2/glt_trainer.py
@@ -5,6 +5,7 @@ from gigl.common import Uri, UriFactory
 from gigl.common.logger import Logger
 from gigl.env.pipelines_config import get_resource_config
 from gigl.src.common.constants.components import GiGLComponents
+from gigl.src.common.custom_launcher import launch_custom
 from gigl.src.common.types import AppliedTaskIdentifier
 from gigl.src.common.types.pb_wrappers.gbml_config import GbmlConfigPbWrapper
 from gigl.src.common.types.pb_wrappers.gigl_resource_config import (
@@ -16,6 +17,7 @@ from gigl.src.common.vertex_ai_launcher import (
     launch_single_pool_job,
 )
 from snapchat.research.gbml.gigl_resource_config_pb2 import (
+    CustomLauncherConfig,
     LocalResourceConfig,
     VertexAiGraphStoreConfig,
     VertexAiResourceConfig,
@@ -107,6 +109,16 @@ class GLTTrainer:
             # TODO: (svij) Implement local training
             raise NotImplementedError(
                 f"Local GLT Trainer is not yet supported, please specify a {VertexAiResourceConfig.__name__} or {VertexAiGraphStoreConfig.__name__} resource config field."
+            )
+        elif isinstance(trainer_config, CustomLauncherConfig):
+            launch_custom(
+                custom_launcher_config=trainer_config,
+                applied_task_identifier=applied_task_identifier,
+                task_config_uri=task_config_uri,
+                resource_config_uri=resource_config_uri,
+                cpu_docker_uri=cpu_docker_uri,
+                cuda_docker_uri=cuda_docker_uri,
+                component=GiGLComponents.Trainer,
             )
         elif isinstance(trainer_config, VertexAiResourceConfig) or isinstance(
             trainer_config, VertexAiGraphStoreConfig

--- a/tests/unit/src/inference/v2/glt_inferencer_test.py
+++ b/tests/unit/src/inference/v2/glt_inferencer_test.py
@@ -79,20 +79,6 @@ def _build_resource_config_with_graph_store_inferencer() -> (
     )
 
 
-def _build_resource_config_with_custom_inferencer() -> (
-    gigl_resource_config_pb2.GiglResourceConfig
-):
-    return gigl_resource_config_pb2.GiglResourceConfig(
-        shared_resource_config=_build_shared_resource_config(),
-        inferencer_resource_config=gigl_resource_config_pb2.InferencerResourceConfig(
-            custom_inferencer_config=gigl_resource_config_pb2.CustomLauncherConfig(
-                command="python -m my.custom.inferencer",
-                args=["--foo=bar", "--noskip_inference"],
-            ),
-        ),
-    )
-
-
 def _build_gbml_config_with_inferencer_command() -> gbml_config_pb2.GbmlConfig:
     return gbml_config_pb2.GbmlConfig(
         inferencer_config=gbml_config_pb2.GbmlConfig.InferencerConfig(
@@ -188,50 +174,6 @@ class TestGLTInferencerVertexAiDispatch(TestCase):
             dict(call_kwargs["storage_args"]),
             {"dataset_uri": "gs://bucket/dataset"},
         )
-
-    @patch("gigl.src.inference.v2.glt_inferencer.launch_single_pool_job")
-    @patch("gigl.src.inference.v2.glt_inferencer.launch_graph_store_enabled_job")
-    @patch("gigl.src.inference.v2.glt_inferencer.launch_custom")
-    @patch("gigl.src.inference.v2.glt_inferencer.get_resource_config")
-    def test_custom_launcher_dispatch(
-        self,
-        mock_get_resource_config,
-        mock_launch_custom,
-        mock_launch_graph_store_enabled_job,
-        mock_launch_single_pool_job,
-    ) -> None:
-        resource_config = _build_resource_config_with_custom_inferencer()
-        mock_get_resource_config.return_value = GiglResourceConfigWrapper(
-            resource_config=resource_config
-        )
-
-        task_uri = Uri("gs://bucket/task.yaml")
-        resource_uri = Uri("gs://bucket/resource.yaml")
-        GLTInferencer().run(
-            applied_task_identifier=AppliedTaskIdentifier("job_custom"),
-            task_config_uri=task_uri,
-            resource_config_uri=resource_uri,
-            cpu_docker_uri="gcr.io/p/cpu:tag",
-            cuda_docker_uri="gcr.io/p/cuda:tag",
-        )
-
-        mock_launch_custom.assert_called_once()
-        call_kwargs = mock_launch_custom.call_args.kwargs
-        self.assertEqual(
-            call_kwargs["custom_launcher_config"],
-            resource_config.inferencer_resource_config.custom_inferencer_config,
-        )
-        self.assertEqual(
-            call_kwargs["applied_task_identifier"],
-            AppliedTaskIdentifier("job_custom"),
-        )
-        self.assertEqual(call_kwargs["task_config_uri"], task_uri)
-        self.assertEqual(call_kwargs["resource_config_uri"], resource_uri)
-        self.assertEqual(call_kwargs["cpu_docker_uri"], "gcr.io/p/cpu:tag")
-        self.assertEqual(call_kwargs["cuda_docker_uri"], "gcr.io/p/cuda:tag")
-        self.assertEqual(call_kwargs["component"], GiGLComponents.Inferencer)
-        mock_launch_single_pool_job.assert_not_called()
-        mock_launch_graph_store_enabled_job.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/src/inference/v2/glt_inferencer_test.py
+++ b/tests/unit/src/inference/v2/glt_inferencer_test.py
@@ -1,5 +1,7 @@
 """Tests for ``gigl.src.inference.v2.glt_inferencer`` Vertex AI dispatch."""
 
+import os
+import tempfile
 from typing import Final
 from unittest.mock import patch
 
@@ -74,6 +76,21 @@ def _build_resource_config_with_graph_store_inferencer() -> (
                         num_replicas=1,
                     ),
                 )
+            ),
+        ),
+    )
+
+
+def _build_resource_config_with_custom_inferencer(
+    command: str,
+    args: list[str],
+) -> gigl_resource_config_pb2.GiglResourceConfig:
+    return gigl_resource_config_pb2.GiglResourceConfig(
+        shared_resource_config=_build_shared_resource_config(),
+        inferencer_resource_config=gigl_resource_config_pb2.InferencerResourceConfig(
+            custom_inferencer_config=gigl_resource_config_pb2.CustomLauncherConfig(
+                command=command,
+                args=args,
             ),
         ),
     )
@@ -173,6 +190,65 @@ class TestGLTInferencerVertexAiDispatch(TestCase):
         self.assertEqual(
             dict(call_kwargs["storage_args"]),
             {"dataset_uri": "gs://bucket/dataset"},
+        )
+
+
+class TestGLTInferencerCustomLauncherDispatch(TestCase):
+    """Runs the ``CustomLauncherConfig`` branch through a real subprocess.
+
+    Only ``get_resource_config`` is patched (it caches into a module-level
+    global, so real YAML loading is not viable in-process). The configured
+    command actually executes and writes the ``GIGL_*`` env vars plus its
+    ``args[]`` to a temp file, which the test then asserts on.
+    """
+
+    @patch("gigl.src.inference.v2.glt_inferencer.get_resource_config")
+    def test_custom_launcher_dispatch_runs_command(
+        self, mock_get_resource_config
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "captured.txt")
+            # printf reuses the format string for each remaining argument, so
+            # every env var and every appended args[] element lands on its own
+            # line of the output file.
+            command = (
+                'printf "%s\\n" "$GIGL_APPLIED_TASK_IDENTIFIER" '
+                '"$GIGL_TASK_CONFIG_URI" "$GIGL_RESOURCE_CONFIG_URI" '
+                '"$GIGL_CPU_DOCKER_URI" "$GIGL_CUDA_DOCKER_URI" '
+                f'"$GIGL_COMPONENT" > {output_path}'
+            )
+            mock_get_resource_config.return_value = GiglResourceConfigWrapper(
+                resource_config=_build_resource_config_with_custom_inferencer(
+                    command=command,
+                    args=["--foo=bar", "arg with space"],
+                )
+            )
+
+            GLTInferencer().run(
+                applied_task_identifier=AppliedTaskIdentifier("job_101"),
+                task_config_uri=Uri("gs://bucket/task.yaml"),
+                resource_config_uri=Uri("gs://bucket/resource.yaml"),
+                cpu_docker_uri="gcr.io/p/cpu:tag",
+                cuda_docker_uri="gcr.io/p/cuda:tag",
+            )
+
+            with open(output_path) as output_file:
+                captured_lines = output_file.read().splitlines()
+
+        self.assertEqual(
+            captured_lines,
+            [
+                "job_101",
+                "gs://bucket/task.yaml",
+                "gs://bucket/resource.yaml",
+                "gcr.io/p/cpu:tag",
+                "gcr.io/p/cuda:tag",
+                "Inferencer",
+                "--foo=bar",
+                # A single args[] element containing a space stays one shell
+                # argument (shlex.quote), hence one output line.
+                "arg with space",
+            ],
         )
 
 

--- a/tests/unit/src/inference/v2/glt_inferencer_test.py
+++ b/tests/unit/src/inference/v2/glt_inferencer_test.py
@@ -79,6 +79,20 @@ def _build_resource_config_with_graph_store_inferencer() -> (
     )
 
 
+def _build_resource_config_with_custom_inferencer() -> (
+    gigl_resource_config_pb2.GiglResourceConfig
+):
+    return gigl_resource_config_pb2.GiglResourceConfig(
+        shared_resource_config=_build_shared_resource_config(),
+        inferencer_resource_config=gigl_resource_config_pb2.InferencerResourceConfig(
+            custom_inferencer_config=gigl_resource_config_pb2.CustomLauncherConfig(
+                command="python -m my.custom.inferencer",
+                args=["--foo=bar", "--noskip_inference"],
+            ),
+        ),
+    )
+
+
 def _build_gbml_config_with_inferencer_command() -> gbml_config_pb2.GbmlConfig:
     return gbml_config_pb2.GbmlConfig(
         inferencer_config=gbml_config_pb2.GbmlConfig.InferencerConfig(
@@ -174,6 +188,50 @@ class TestGLTInferencerVertexAiDispatch(TestCase):
             dict(call_kwargs["storage_args"]),
             {"dataset_uri": "gs://bucket/dataset"},
         )
+
+    @patch("gigl.src.inference.v2.glt_inferencer.launch_single_pool_job")
+    @patch("gigl.src.inference.v2.glt_inferencer.launch_graph_store_enabled_job")
+    @patch("gigl.src.inference.v2.glt_inferencer.launch_custom")
+    @patch("gigl.src.inference.v2.glt_inferencer.get_resource_config")
+    def test_custom_launcher_dispatch(
+        self,
+        mock_get_resource_config,
+        mock_launch_custom,
+        mock_launch_graph_store_enabled_job,
+        mock_launch_single_pool_job,
+    ) -> None:
+        resource_config = _build_resource_config_with_custom_inferencer()
+        mock_get_resource_config.return_value = GiglResourceConfigWrapper(
+            resource_config=resource_config
+        )
+
+        task_uri = Uri("gs://bucket/task.yaml")
+        resource_uri = Uri("gs://bucket/resource.yaml")
+        GLTInferencer().run(
+            applied_task_identifier=AppliedTaskIdentifier("job_custom"),
+            task_config_uri=task_uri,
+            resource_config_uri=resource_uri,
+            cpu_docker_uri="gcr.io/p/cpu:tag",
+            cuda_docker_uri="gcr.io/p/cuda:tag",
+        )
+
+        mock_launch_custom.assert_called_once()
+        call_kwargs = mock_launch_custom.call_args.kwargs
+        self.assertEqual(
+            call_kwargs["custom_launcher_config"],
+            resource_config.inferencer_resource_config.custom_inferencer_config,
+        )
+        self.assertEqual(
+            call_kwargs["applied_task_identifier"],
+            AppliedTaskIdentifier("job_custom"),
+        )
+        self.assertEqual(call_kwargs["task_config_uri"], task_uri)
+        self.assertEqual(call_kwargs["resource_config_uri"], resource_uri)
+        self.assertEqual(call_kwargs["cpu_docker_uri"], "gcr.io/p/cpu:tag")
+        self.assertEqual(call_kwargs["cuda_docker_uri"], "gcr.io/p/cuda:tag")
+        self.assertEqual(call_kwargs["component"], GiGLComponents.Inferencer)
+        mock_launch_single_pool_job.assert_not_called()
+        mock_launch_graph_store_enabled_job.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/src/training/v2/glt_trainer_test.py
+++ b/tests/unit/src/training/v2/glt_trainer_test.py
@@ -79,6 +79,20 @@ def _build_resource_config_with_graph_store_trainer() -> (
     )
 
 
+def _build_resource_config_with_custom_trainer() -> (
+    gigl_resource_config_pb2.GiglResourceConfig
+):
+    return gigl_resource_config_pb2.GiglResourceConfig(
+        shared_resource_config=_build_shared_resource_config(),
+        trainer_resource_config=gigl_resource_config_pb2.TrainerResourceConfig(
+            custom_trainer_config=gigl_resource_config_pb2.CustomLauncherConfig(
+                command="python -m my.custom.trainer",
+                args=["--foo=bar", "--noskip_training"],
+            ),
+        ),
+    )
+
+
 def _build_gbml_config_with_trainer_command() -> gbml_config_pb2.GbmlConfig:
     return gbml_config_pb2.GbmlConfig(
         trainer_config=gbml_config_pb2.GbmlConfig.TrainerConfig(
@@ -174,6 +188,50 @@ class TestGLTTrainerVertexAiDispatch(TestCase):
             dict(call_kwargs["storage_args"]),
             {"dataset_uri": "gs://bucket/dataset"},
         )
+
+    @patch("gigl.src.training.v2.glt_trainer.launch_single_pool_job")
+    @patch("gigl.src.training.v2.glt_trainer.launch_graph_store_enabled_job")
+    @patch("gigl.src.training.v2.glt_trainer.launch_custom")
+    @patch("gigl.src.training.v2.glt_trainer.get_resource_config")
+    def test_custom_launcher_dispatch(
+        self,
+        mock_get_resource_config,
+        mock_launch_custom,
+        mock_launch_graph_store_enabled_job,
+        mock_launch_single_pool_job,
+    ) -> None:
+        resource_config = _build_resource_config_with_custom_trainer()
+        mock_get_resource_config.return_value = GiglResourceConfigWrapper(
+            resource_config=resource_config
+        )
+
+        task_uri = Uri("gs://bucket/task.yaml")
+        resource_uri = Uri("gs://bucket/resource.yaml")
+        GLTTrainer().run(
+            applied_task_identifier=AppliedTaskIdentifier("job_custom"),
+            task_config_uri=task_uri,
+            resource_config_uri=resource_uri,
+            cpu_docker_uri="gcr.io/p/cpu:tag",
+            cuda_docker_uri="gcr.io/p/cuda:tag",
+        )
+
+        mock_launch_custom.assert_called_once()
+        call_kwargs = mock_launch_custom.call_args.kwargs
+        self.assertEqual(
+            call_kwargs["custom_launcher_config"],
+            resource_config.trainer_resource_config.custom_trainer_config,
+        )
+        self.assertEqual(
+            call_kwargs["applied_task_identifier"],
+            AppliedTaskIdentifier("job_custom"),
+        )
+        self.assertEqual(call_kwargs["task_config_uri"], task_uri)
+        self.assertEqual(call_kwargs["resource_config_uri"], resource_uri)
+        self.assertEqual(call_kwargs["cpu_docker_uri"], "gcr.io/p/cpu:tag")
+        self.assertEqual(call_kwargs["cuda_docker_uri"], "gcr.io/p/cuda:tag")
+        self.assertEqual(call_kwargs["component"], GiGLComponents.Trainer)
+        mock_launch_single_pool_job.assert_not_called()
+        mock_launch_graph_store_enabled_job.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/src/training/v2/glt_trainer_test.py
+++ b/tests/unit/src/training/v2/glt_trainer_test.py
@@ -79,20 +79,6 @@ def _build_resource_config_with_graph_store_trainer() -> (
     )
 
 
-def _build_resource_config_with_custom_trainer() -> (
-    gigl_resource_config_pb2.GiglResourceConfig
-):
-    return gigl_resource_config_pb2.GiglResourceConfig(
-        shared_resource_config=_build_shared_resource_config(),
-        trainer_resource_config=gigl_resource_config_pb2.TrainerResourceConfig(
-            custom_trainer_config=gigl_resource_config_pb2.CustomLauncherConfig(
-                command="python -m my.custom.trainer",
-                args=["--foo=bar", "--noskip_training"],
-            ),
-        ),
-    )
-
-
 def _build_gbml_config_with_trainer_command() -> gbml_config_pb2.GbmlConfig:
     return gbml_config_pb2.GbmlConfig(
         trainer_config=gbml_config_pb2.GbmlConfig.TrainerConfig(
@@ -188,50 +174,6 @@ class TestGLTTrainerVertexAiDispatch(TestCase):
             dict(call_kwargs["storage_args"]),
             {"dataset_uri": "gs://bucket/dataset"},
         )
-
-    @patch("gigl.src.training.v2.glt_trainer.launch_single_pool_job")
-    @patch("gigl.src.training.v2.glt_trainer.launch_graph_store_enabled_job")
-    @patch("gigl.src.training.v2.glt_trainer.launch_custom")
-    @patch("gigl.src.training.v2.glt_trainer.get_resource_config")
-    def test_custom_launcher_dispatch(
-        self,
-        mock_get_resource_config,
-        mock_launch_custom,
-        mock_launch_graph_store_enabled_job,
-        mock_launch_single_pool_job,
-    ) -> None:
-        resource_config = _build_resource_config_with_custom_trainer()
-        mock_get_resource_config.return_value = GiglResourceConfigWrapper(
-            resource_config=resource_config
-        )
-
-        task_uri = Uri("gs://bucket/task.yaml")
-        resource_uri = Uri("gs://bucket/resource.yaml")
-        GLTTrainer().run(
-            applied_task_identifier=AppliedTaskIdentifier("job_custom"),
-            task_config_uri=task_uri,
-            resource_config_uri=resource_uri,
-            cpu_docker_uri="gcr.io/p/cpu:tag",
-            cuda_docker_uri="gcr.io/p/cuda:tag",
-        )
-
-        mock_launch_custom.assert_called_once()
-        call_kwargs = mock_launch_custom.call_args.kwargs
-        self.assertEqual(
-            call_kwargs["custom_launcher_config"],
-            resource_config.trainer_resource_config.custom_trainer_config,
-        )
-        self.assertEqual(
-            call_kwargs["applied_task_identifier"],
-            AppliedTaskIdentifier("job_custom"),
-        )
-        self.assertEqual(call_kwargs["task_config_uri"], task_uri)
-        self.assertEqual(call_kwargs["resource_config_uri"], resource_uri)
-        self.assertEqual(call_kwargs["cpu_docker_uri"], "gcr.io/p/cpu:tag")
-        self.assertEqual(call_kwargs["cuda_docker_uri"], "gcr.io/p/cuda:tag")
-        self.assertEqual(call_kwargs["component"], GiGLComponents.Trainer)
-        mock_launch_single_pool_job.assert_not_called()
-        mock_launch_graph_store_enabled_job.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/unit/src/training/v2/glt_trainer_test.py
+++ b/tests/unit/src/training/v2/glt_trainer_test.py
@@ -1,5 +1,7 @@
 """Tests for ``gigl.src.training.v2.glt_trainer`` Vertex AI dispatch."""
 
+import os
+import tempfile
 from typing import Final
 from unittest.mock import patch
 
@@ -74,6 +76,21 @@ def _build_resource_config_with_graph_store_trainer() -> (
                         num_replicas=1,
                     ),
                 )
+            ),
+        ),
+    )
+
+
+def _build_resource_config_with_custom_trainer(
+    command: str,
+    args: list[str],
+) -> gigl_resource_config_pb2.GiglResourceConfig:
+    return gigl_resource_config_pb2.GiglResourceConfig(
+        shared_resource_config=_build_shared_resource_config(),
+        trainer_resource_config=gigl_resource_config_pb2.TrainerResourceConfig(
+            custom_trainer_config=gigl_resource_config_pb2.CustomLauncherConfig(
+                command=command,
+                args=args,
             ),
         ),
     )
@@ -173,6 +190,65 @@ class TestGLTTrainerVertexAiDispatch(TestCase):
         self.assertEqual(
             dict(call_kwargs["storage_args"]),
             {"dataset_uri": "gs://bucket/dataset"},
+        )
+
+
+class TestGLTTrainerCustomLauncherDispatch(TestCase):
+    """Runs the ``CustomLauncherConfig`` branch through a real subprocess.
+
+    Only ``get_resource_config`` is patched (it caches into a module-level
+    global, so real YAML loading is not viable in-process). The configured
+    command actually executes and writes the ``GIGL_*`` env vars plus its
+    ``args[]`` to a temp file, which the test then asserts on.
+    """
+
+    @patch("gigl.src.training.v2.glt_trainer.get_resource_config")
+    def test_custom_launcher_dispatch_runs_command(
+        self, mock_get_resource_config
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output_path = os.path.join(temp_dir, "captured.txt")
+            # printf reuses the format string for each remaining argument, so
+            # every env var and every appended args[] element lands on its own
+            # line of the output file.
+            command = (
+                'printf "%s\\n" "$GIGL_APPLIED_TASK_IDENTIFIER" '
+                '"$GIGL_TASK_CONFIG_URI" "$GIGL_RESOURCE_CONFIG_URI" '
+                '"$GIGL_CPU_DOCKER_URI" "$GIGL_CUDA_DOCKER_URI" '
+                f'"$GIGL_COMPONENT" > {output_path}'
+            )
+            mock_get_resource_config.return_value = GiglResourceConfigWrapper(
+                resource_config=_build_resource_config_with_custom_trainer(
+                    command=command,
+                    args=["--foo=bar", "arg with space"],
+                )
+            )
+
+            GLTTrainer().run(
+                applied_task_identifier=AppliedTaskIdentifier("job_77"),
+                task_config_uri=Uri("gs://bucket/task.yaml"),
+                resource_config_uri=Uri("gs://bucket/resource.yaml"),
+                cpu_docker_uri="gcr.io/p/cpu:tag",
+                cuda_docker_uri="gcr.io/p/cuda:tag",
+            )
+
+            with open(output_path) as output_file:
+                captured_lines = output_file.read().splitlines()
+
+        self.assertEqual(
+            captured_lines,
+            [
+                "job_77",
+                "gs://bucket/task.yaml",
+                "gs://bucket/resource.yaml",
+                "gcr.io/p/cpu:tag",
+                "gcr.io/p/cuda:tag",
+                "Trainer",
+                "--foo=bar",
+                # A single args[] element containing a space stays one shell
+                # argument (shlex.quote), hence one output line.
+                "arg with space",
+            ],
         )
 
 


### PR DESCRIPTION
Wire the CustomLauncherConfig resource-config branch into GLTTrainer.run() and GLTInferencer.run() so custom launchers shell out via launch_custom, routed with the appropriate GiGLComponents value. The branch is placed before the Vertex AI branch and does not go through the VAI execution path (whose command check is a VAI-specific concern).

Add unit tests covering the custom-launcher dispatch: assert launch_custom is called once with the right proto, URIs, docker URIs, and component, and that launch_single_pool_job / launch_graph_store_enabled_job are not called.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
