### PR TITLE
Surface swallowed sampler-coroutine exceptions + warn on partial feature coverage

### DIFF
--- a/gigl/distributed/base_dist_loader.py
+++ b/gigl/distributed/base_dist_loader.py
@@ -60,7 +60,7 @@ from gigl.distributed.utils.neighborloader import (
     patch_fanout_for_sampling,
     strip_non_ppr_edge_types,
 )
-from gigl.types.graph import DEFAULT_HOMOGENEOUS_NODE_TYPE
+from gigl.types.graph import DEFAULT_HOMOGENEOUS_NODE_TYPE, is_label_edge_type
 from gigl.utils.share_memory import share_memory
 
 logger = Logger()
@@ -242,6 +242,7 @@ class BaseDistLoader(DistLoader):
         )
         self._node_feature_info = dataset_schema.node_feature_info
         self._edge_feature_info = dataset_schema.edge_feature_info
+        self._warn_on_partial_feature_coverage(dataset_schema)
 
         self._sampler_options = sampler_options
         self._non_blocking_transfers = non_blocking_transfers
@@ -926,6 +927,79 @@ class BaseDistLoader(DistLoader):
                 f"total_elapsed={total_elapsed:.2f}s"
             )
         self._shutdowned = True
+
+    def _warn_on_partial_feature_coverage(self, dataset_schema: DatasetSchema) -> None:
+        """Warn (never raise) when a heterogeneous dataset has partial feature coverage.
+
+        A featureless message-passing edge type (or node type) is a legitimate,
+        supported shape. It only causes a sampling failure if it is actually
+        *reached* at runtime, and reachability is a frontier-dependent property we
+        cannot prove at construction: the sampler samples a type only when the
+        current frontier has source nodes for it. A type present in the schema and
+        fanout may still be unreachable from a given loader's seeds within its hops,
+        in which case the loader works fine.
+
+        We therefore emit an actionable warning here and rely on the sampling-error
+        poison pill to fast-fail (with a full traceback) if such a type is reached.
+
+        Only the heterogeneous case (dict-typed feature info) is checked; homogeneous
+        datasets carry a single feature tensor with no per-type coverage gaps.
+
+        Args:
+            dataset_schema: Schema carrying per-type feature info and edge types.
+        """
+        edge_feature_info = dataset_schema.edge_feature_info
+        if isinstance(edge_feature_info, dict) and edge_feature_info:
+            message_passing_edge_types = [
+                edge_type
+                for edge_type in (dataset_schema.edge_types or [])
+                if not is_label_edge_type(edge_type)
+            ]
+            featured_edge_types = [
+                edge_type
+                for edge_type in message_passing_edge_types
+                if edge_type in edge_feature_info
+            ]
+            featureless_edge_types = [
+                edge_type
+                for edge_type in message_passing_edge_types
+                if edge_type not in edge_feature_info
+            ]
+            if featureless_edge_types:
+                logger.warning(
+                    "Dataset has partial edge feature coverage: edge features will be "
+                    "fetched only for types %s; types %s have none. If a featureless "
+                    "type is sampled at runtime, sampling for that batch will fail fast "
+                    "with a traceback (a featureless message-passing type is otherwise "
+                    "harmless if never reached).",
+                    featured_edge_types,
+                    featureless_edge_types,
+                )
+
+        node_feature_info = dataset_schema.node_feature_info
+        if isinstance(node_feature_info, dict) and node_feature_info:
+            node_types: set[str] = set()
+            for edge_type in dataset_schema.edge_types or []:
+                node_types.add(edge_type[0])
+                node_types.add(edge_type[2])
+            featured_node_types = [
+                node_type for node_type in node_types if node_type in node_feature_info
+            ]
+            featureless_node_types = [
+                node_type
+                for node_type in node_types
+                if node_type not in node_feature_info
+            ]
+            if featureless_node_types:
+                logger.warning(
+                    "Dataset has partial node feature coverage: node features will be "
+                    "fetched only for types %s; types %s have none. If a featureless "
+                    "type is sampled at runtime, sampling for that batch will fail fast "
+                    "with a traceback (a featureless node type is otherwise harmless if "
+                    "never reached).",
+                    featured_node_types,
+                    featureless_node_types,
+                )
 
     def _apply_ppr_outputs(
         self,

--- a/gigl/distributed/base_dist_loader.py
+++ b/gigl/distributed/base_dist_loader.py
@@ -60,7 +60,7 @@ from gigl.distributed.utils.neighborloader import (
     patch_fanout_for_sampling,
     strip_non_ppr_edge_types,
 )
-from gigl.types.graph import DEFAULT_HOMOGENEOUS_NODE_TYPE, is_label_edge_type
+from gigl.types.graph import DEFAULT_HOMOGENEOUS_NODE_TYPE
 from gigl.utils.share_memory import share_memory
 
 logger = Logger()
@@ -242,7 +242,6 @@ class BaseDistLoader(DistLoader):
         )
         self._node_feature_info = dataset_schema.node_feature_info
         self._edge_feature_info = dataset_schema.edge_feature_info
-        self._warn_on_partial_feature_coverage(dataset_schema)
 
         self._sampler_options = sampler_options
         self._non_blocking_transfers = non_blocking_transfers
@@ -927,79 +926,6 @@ class BaseDistLoader(DistLoader):
                 f"total_elapsed={total_elapsed:.2f}s"
             )
         self._shutdowned = True
-
-    def _warn_on_partial_feature_coverage(self, dataset_schema: DatasetSchema) -> None:
-        """Warn (never raise) when a heterogeneous dataset has partial feature coverage.
-
-        A featureless message-passing edge type (or node type) is a legitimate,
-        supported shape. It only causes a sampling failure if it is actually
-        *reached* at runtime, and reachability is a frontier-dependent property we
-        cannot prove at construction: the sampler samples a type only when the
-        current frontier has source nodes for it. A type present in the schema and
-        fanout may still be unreachable from a given loader's seeds within its hops,
-        in which case the loader works fine.
-
-        We therefore emit an actionable warning here and rely on the sampling-error
-        poison pill to fast-fail (with a full traceback) if such a type is reached.
-
-        Only the heterogeneous case (dict-typed feature info) is checked; homogeneous
-        datasets carry a single feature tensor with no per-type coverage gaps.
-
-        Args:
-            dataset_schema: Schema carrying per-type feature info and edge types.
-        """
-        edge_feature_info = dataset_schema.edge_feature_info
-        if isinstance(edge_feature_info, dict) and edge_feature_info:
-            message_passing_edge_types = [
-                edge_type
-                for edge_type in (dataset_schema.edge_types or [])
-                if not is_label_edge_type(edge_type)
-            ]
-            featured_edge_types = [
-                edge_type
-                for edge_type in message_passing_edge_types
-                if edge_type in edge_feature_info
-            ]
-            featureless_edge_types = [
-                edge_type
-                for edge_type in message_passing_edge_types
-                if edge_type not in edge_feature_info
-            ]
-            if featureless_edge_types:
-                logger.warning(
-                    "Dataset has partial edge feature coverage: edge features will be "
-                    "fetched only for types %s; types %s have none. If a featureless "
-                    "type is sampled at runtime, sampling for that batch will fail fast "
-                    "with a traceback (a featureless message-passing type is otherwise "
-                    "harmless if never reached).",
-                    featured_edge_types,
-                    featureless_edge_types,
-                )
-
-        node_feature_info = dataset_schema.node_feature_info
-        if isinstance(node_feature_info, dict) and node_feature_info:
-            node_types: set[str] = set()
-            for edge_type in dataset_schema.edge_types or []:
-                node_types.add(edge_type[0])
-                node_types.add(edge_type[2])
-            featured_node_types = [
-                node_type for node_type in node_types if node_type in node_feature_info
-            ]
-            featureless_node_types = [
-                node_type
-                for node_type in node_types
-                if node_type not in node_feature_info
-            ]
-            if featureless_node_types:
-                logger.warning(
-                    "Dataset has partial node feature coverage: node features will be "
-                    "fetched only for types %s; types %s have none. If a featureless "
-                    "type is sampled at runtime, sampling for that batch will fail fast "
-                    "with a traceback (a featureless node type is otherwise harmless if "
-                    "never reached).",
-                    featured_node_types,
-                    featureless_node_types,
-                )
 
     def _apply_ppr_outputs(
         self,

--- a/gigl/distributed/base_sampler.py
+++ b/gigl/distributed/base_sampler.py
@@ -1,3 +1,4 @@
+import traceback
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Optional, Union
@@ -15,12 +16,19 @@ from graphlearn_torch.sampler import (
 from graphlearn_torch.typing import NodeType, as_str
 from graphlearn_torch.utils import reverse_edge_type
 
+from gigl.common.logger import Logger
 from gigl.distributed.sampler import (
     NEGATIVE_LABEL_METADATA_KEY,
     POSITIVE_LABEL_METADATA_KEY,
     ABLPNodeSamplerInput,
 )
+from gigl.distributed.utils.sampling_errors import (
+    SAMPLING_ERROR_KEY,
+    encode_sampling_error,
+)
 from gigl.utils.data_splitters import PADDING_NODE
+
+logger = Logger()
 
 
 def _stable_unique_preserve_order(nodes: torch.Tensor) -> torch.Tensor:
@@ -90,6 +98,19 @@ class BaseDistNeighborSampler(GLTDistNeighborSampler):
     Subclasses must override ``_sample_from_nodes`` with their specific
     sampling strategy (e.g., k-hop neighbor sampling, PPR-based sampling).
     """
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize the sampler and the one-time sampling-error guard.
+
+        ``GLTDistNeighborSampler`` has no GiGL-owned state; we only add
+        ``_sampling_error_sent`` so ``_send_adapter`` can forward at most one
+        poison pill per sampler instance. Initializing it here (rather than
+        lazily) guarantees the failure handler never raises ``AttributeError``,
+        which GLT's event loop would swallow the same way it swallows the
+        original sampling exception.
+        """
+        super().__init__(*args, **kwargs)
+        self._sampling_error_sent: bool = False
 
     def _prepare_sample_loop_inputs(
         self,
@@ -212,9 +233,38 @@ class BaseDistNeighborSampler(GLTDistNeighborSampler):
 
         Copied from ``graphlearn_torch.distributed.DistNeighborSampler._send_adapter``
         (GLT 0.2.4) with the single change of ``_colloate_fn`` → ``_collate_fn``.
+
+        Additionally, any exception raised while sampling or collating is caught
+        and surfaced instead of swallowed. GLT's ``ConcurrentEventLoop`` logs a
+        failed coroutine as a one-line ``str(e)`` and drops the batch, so the
+        channel never receives a message and the loader hangs forever. Here we
+        log the full traceback and forward a one-time poison-pill ``SampleMessage``
+        (in channel mode) so the consumer raises promptly, or re-raise (in
+        channel-less mode, where GLT's ``run_task`` / torch RPC propagates it).
         """
-        sampler_output = await async_func(*args, **kwargs)
-        res = await self._collate_fn(sampler_output)
+        try:
+            sampler_output = await async_func(*args, **kwargs)
+            res = await self._collate_fn(sampler_output)
+        except Exception:
+            logger.exception(
+                "Sampling coroutine failed; forwarding error to the loader."
+            )
+            if self.channel is not None:
+                # Send at most one poison pill per sampler instance. The consumer
+                # raises on the first pill anyway, and ``ShmChannel.send`` blocks;
+                # a failure storm into a bounded channel that nobody drains would
+                # wedge the sampler-side event loop.
+                if not self._sampling_error_sent:
+                    self._sampling_error_sent = True
+                    self.channel.send(
+                        {
+                            SAMPLING_ERROR_KEY: encode_sampling_error(
+                                traceback.format_exc()
+                            )
+                        }
+                    )
+                return None
+            raise  # channel-less mode: propagates via run_task / torch RPC
         if self.channel is None:
             return res
         self.channel.send(res)

--- a/gigl/distributed/dist_ablp_neighborloader.py
+++ b/gigl/distributed/dist_ablp_neighborloader.py
@@ -37,6 +37,7 @@ from gigl.distributed.utils.neighborloader import (
     shard_nodes_by_process,
     strip_label_edges,
 )
+from gigl.distributed.utils.sampling_errors import raise_if_sampling_error
 from gigl.src.common.types.graph_data import (
     NodeType,  # TODO (mkolodner-sc): Change to use torch_geometric.typing
 )
@@ -856,6 +857,10 @@ class DistABLPLoader(BaseDistLoader):
         return data
 
     def _collate_fn(self, msg: SampleMessage) -> Union[Data, HeteroData]:
+        # A sampling worker that failed forwards a poison-pill message instead of
+        # a batch; surface it as a RuntimeError with the worker traceback before
+        # doing any parsing that would choke on the sentinel payload.
+        raise_if_sampling_error(msg)
         # extract_metadata separates #META. keys from the message to work
         # around a GLT bug in to_hetero_data.  extract_edge_type_metadata then
         # pulls out labels by prefix.

--- a/gigl/distributed/distributed_neighborloader.py
+++ b/gigl/distributed/distributed_neighborloader.py
@@ -33,6 +33,7 @@ from gigl.distributed.utils.neighborloader import (
     shard_nodes_by_process,
     strip_label_edges,
 )
+from gigl.distributed.utils.sampling_errors import raise_if_sampling_error
 from gigl.src.common.types.graph_data import (
     NodeType,  # TODO (mkolodner-sc): Change to use torch_geometric.typing
 )
@@ -531,6 +532,10 @@ class DistNeighborLoader(BaseDistLoader):
         )
 
     def _collate_fn(self, msg: SampleMessage) -> Union[Data, HeteroData]:
+        # A sampling worker that failed forwards a poison-pill message instead of
+        # a batch; surface it as a RuntimeError with the worker traceback before
+        # doing any parsing that would choke on the sentinel payload.
+        raise_if_sampling_error(msg)
         # Extract user-defined metadata before super()._collate_fn, which
         # calls GLT's to_hetero_data.  to_hetero_data misinterprets #META. keys
         # as edge types and fails when edge_dir="out" (tries to call

--- a/gigl/distributed/utils/sampling_errors.py
+++ b/gigl/distributed/utils/sampling_errors.py
@@ -1,0 +1,53 @@
+"""Wire format for forwarding a sampling-worker exception to the training loop.
+
+A GLT ``SampleMessage`` is a ``dict[str, torch.Tensor]``. We reserve one ``#``-prefixed
+key (matching GLT's ``#IS_HETERO`` / ``#META.`` convention) to carry a UTF-8 traceback
+encoded as a uint8 tensor, so a failed sampling coroutine can surface as a fast, explained
+error on the consumer instead of a silent hang.
+"""
+
+from typing import Final
+
+import torch
+from graphlearn_torch.channel import SampleMessage
+
+SAMPLING_ERROR_KEY: Final[str] = "#SAMPLING_ERROR"
+
+
+def encode_sampling_error(traceback_str: str) -> torch.Tensor:
+    """Encode a traceback string as a writable 1-D uint8 tensor.
+
+    Uses ``bytearray`` so the backing buffer is writable (``torch.frombuffer`` warns on
+    read-only buffers and raises on empty ones); a single sentinel byte represents the
+    empty string so the tensor is never zero-length.
+
+    Args:
+        traceback_str: The traceback text to transport.
+
+    Returns:
+        A 1-D ``torch.uint8`` tensor holding the UTF-8 bytes.
+    """
+    raw = traceback_str.encode("utf-8")
+    if not raw:
+        raw = b"\x00"
+    return torch.frombuffer(bytearray(raw), dtype=torch.uint8)
+
+
+def raise_if_sampling_error(msg: SampleMessage) -> None:
+    """Raise ``RuntimeError`` with the embedded traceback if ``msg`` is a poison pill.
+
+    No-op when the reserved key is absent.
+
+    Args:
+        msg: A received ``SampleMessage``.
+
+    Raises:
+        RuntimeError: If ``msg`` carries a sampling-error payload.
+    """
+    if SAMPLING_ERROR_KEY in msg:
+        decoded = bytes(msg[SAMPLING_ERROR_KEY].cpu().numpy()).decode(
+            "utf-8", errors="replace"
+        )
+        raise RuntimeError(
+            "A sampling worker failed while producing this batch:\n" + decoded
+        )

--- a/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/tests/unit/distributed/distributed_neighborloader_test.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock as mock
 from collections.abc import Mapping
 
 import torch
@@ -52,6 +53,12 @@ _USER = NodeType("user")
 _STORY = NodeType("story")
 _USER_TO_STORY = EdgeType(_USER, Relation("to"), _STORY)
 _STORY_TO_USER = EdgeType(_STORY, Relation("to"), _USER)
+# An isolated (item, to, tag) edge type used to test partial feature coverage: it is
+# never reachable from `user` seeds within a 2-hop fanout, so a loader over it still
+# completes.
+_ITEM = NodeType("item")
+_TAG = NodeType("tag")
+_ITEM_TO_TAG = EdgeType(_ITEM, Relation("to"), _TAG)
 
 # GLT requires subclasses of DistNeighborLoader to be run in a separate process. Otherwise, we may run into segmentation fault
 # or other memory issues. Calling these functions in separate proceses also allows us to use shutdown_rpc() to ensure cleanup of
@@ -859,6 +866,209 @@ class DistributedNeighborLoaderTest(TestCase):
         create_test_process_group()
         with self.assertRaises(expected_error):
             DistNeighborLoader(**kwargs)
+
+
+# NOTE on the Fix B test strategy: GiGL loaders always sample via the multiprocess
+# producer, which spawns worker subprocesses with a *fresh* interpreter
+# (`mp.get_context("spawn")`, dist_sampling_producer.py). A `mock.patch` applied in the
+# loader process therefore never reaches the sampler running in that subprocess, so we
+# cannot inject a synthetic failure by mocking the sampler. Instead we reproduce the real
+# production failure end-to-end: a heterogeneous dataset with edge features on only a
+# subset of its message-passing edge types. When the featureless type is reached during
+# sampling, its feature lookup raises `KeyError` inside the sampling coroutine — the exact
+# bug Fix B surfaces. Pre-fix this hangs forever, so the test uses a bounded join.
+
+
+def _run_partial_edge_feature_coverage_raises(
+    _,
+    dataset: DistDataset,
+    error_holder,
+):
+    create_test_process_group()
+    assert isinstance(dataset.node_ids, Mapping)
+    loader = DistNeighborLoader(
+        dataset=dataset,
+        input_nodes=(_USER, dataset.node_ids[_USER]),  # ty: ignore[invalid-argument-type]
+        num_neighbors=[2, 2],
+        pin_memory_device=torch.device("cpu"),
+    )
+    try:
+        for _datum in loader:
+            pass
+    except RuntimeError as e:
+        error_holder["msg"] = str(e)
+    finally:
+        shutdown_rpc()
+
+
+def _run_unreachable_partial_coverage_warns(
+    _,
+    dataset: DistDataset,
+    warn_holder,
+):
+    create_test_process_group()
+    import gigl.distributed.base_dist_loader as base_dist_loader_module
+
+    captured_warnings: list[str] = []
+
+    def _capture(msg, *args, **kwargs):
+        try:
+            captured_warnings.append(msg % args if args else str(msg))
+        except Exception:
+            captured_warnings.append(str(msg))
+
+    assert isinstance(dataset.node_ids, Mapping)
+    with mock.patch.object(
+        base_dist_loader_module.logger, "warning", side_effect=_capture
+    ):
+        loader = DistNeighborLoader(
+            dataset=dataset,
+            input_nodes=(_USER, dataset.node_ids[_USER]),  # ty: ignore[invalid-argument-type]
+            num_neighbors=[2, 2],
+            pin_memory_device=torch.device("cpu"),
+        )
+        count = sum(1 for _datum in loader)
+    warn_holder["count"] = count
+    warn_holder["warned"] = any("feature" in line.lower() for line in captured_warnings)
+    shutdown_rpc()
+
+
+class TestSamplingErrorPropagation(TestCase):
+    def _build_partial_edge_feature_dataset(self) -> DistDataset:
+        """Build a hetero dataset with edge features on only one message-passing type.
+
+        ``user-to-story`` has edge features; ``story-to-user`` does not. Both are
+        reachable from ``user`` seeds within a 2-hop fanout, so the featureless type is
+        actually sampled and its edge-feature lookup raises inside the coroutine.
+        """
+        n = 5
+        edge_index = torch.tensor([[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]])
+        partition_output = PartitionOutput(
+            node_partition_book={_USER: torch.zeros(n), _STORY: torch.zeros(n)},
+            edge_partition_book={
+                _USER_TO_STORY: torch.zeros(n),
+                _STORY_TO_USER: torch.zeros(n),
+            },
+            partitioned_edge_index={
+                _USER_TO_STORY: GraphPartitionData(
+                    edge_index=edge_index, edge_ids=None
+                ),
+                _STORY_TO_USER: GraphPartitionData(
+                    edge_index=edge_index, edge_ids=None
+                ),
+            },
+            partitioned_node_features={
+                _USER: FeaturePartitionData(feats=torch.zeros(n, 2), ids=torch.arange(n)),
+                _STORY: FeaturePartitionData(
+                    feats=torch.zeros(n, 2), ids=torch.arange(n)
+                ),
+            },
+            partitioned_edge_features={
+                _USER_TO_STORY: FeaturePartitionData(
+                    feats=torch.ones(n, 3), ids=torch.arange(n)
+                ),
+            },
+            partitioned_positive_labels=None,
+            partitioned_negative_labels=None,
+            partitioned_node_labels=None,
+        )
+        dataset = DistDataset(rank=0, world_size=1, edge_dir="out")
+        dataset.build(partition_output=partition_output)
+        return dataset
+
+    def test_reachable_sampler_failure_raises_not_hangs(self) -> None:
+        dataset = self._build_partial_edge_feature_dataset()
+        manager = mp.Manager()
+        error_holder = manager.dict()
+        proc = mp.get_context("spawn").Process(
+            target=_run_partial_edge_feature_coverage_raises,
+            args=(0, dataset, error_holder),
+        )
+        proc.start()
+        proc.join(timeout=180)  # bounded: the pre-fix behavior hangs indefinitely
+        alive = proc.is_alive()
+        if alive:
+            proc.terminate()
+            proc.join(timeout=10)
+        self.assertFalse(alive, "loader hung instead of failing fast on a sampler error")
+        message = error_holder.get("msg", "")
+        # The training process raised with the worker's real traceback embedded.
+        self.assertIn("sampling worker failed", message.lower())
+        self.assertIn("story-to-user", message)
+
+    def test_unreachable_partial_coverage_warns_but_completes(self) -> None:
+        # Featureless (item, to, tag) edge type is isolated from `user`, so it is never
+        # sampled: iteration completes with batches, proving construction does NOT raise
+        # on partial coverage, while still emitting the warning.
+        n = 5
+        edge_index = torch.tensor([[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]])
+        partition_output = PartitionOutput(
+            node_partition_book={
+                _USER: torch.zeros(n),
+                _STORY: torch.zeros(n),
+                _ITEM: torch.zeros(n),
+                _TAG: torch.zeros(n),
+            },
+            edge_partition_book={
+                _USER_TO_STORY: torch.zeros(n),
+                _STORY_TO_USER: torch.zeros(n),
+                _ITEM_TO_TAG: torch.zeros(n),
+            },
+            partitioned_edge_index={
+                _USER_TO_STORY: GraphPartitionData(
+                    edge_index=edge_index, edge_ids=None
+                ),
+                _STORY_TO_USER: GraphPartitionData(
+                    edge_index=edge_index, edge_ids=None
+                ),
+                _ITEM_TO_TAG: GraphPartitionData(edge_index=edge_index, edge_ids=None),
+            },
+            partitioned_node_features={
+                _USER: FeaturePartitionData(feats=torch.zeros(n, 2), ids=torch.arange(n)),
+                _STORY: FeaturePartitionData(
+                    feats=torch.zeros(n, 2), ids=torch.arange(n)
+                ),
+                _ITEM: FeaturePartitionData(feats=torch.zeros(n, 2), ids=torch.arange(n)),
+                _TAG: FeaturePartitionData(feats=torch.zeros(n, 2), ids=torch.arange(n)),
+            },
+            # Edge features on the user/story types only; (item, to, tag) is featureless.
+            partitioned_edge_features={
+                _USER_TO_STORY: FeaturePartitionData(
+                    feats=torch.ones(n, 3), ids=torch.arange(n)
+                ),
+                _STORY_TO_USER: FeaturePartitionData(
+                    feats=torch.ones(n, 3), ids=torch.arange(n)
+                ),
+            },
+            partitioned_positive_labels=None,
+            partitioned_negative_labels=None,
+            partitioned_node_labels=None,
+        )
+        dataset = DistDataset(rank=0, world_size=1, edge_dir="out")
+        dataset.build(partition_output=partition_output)
+
+        manager = mp.Manager()
+        warn_holder = manager.dict()
+        proc = mp.get_context("spawn").Process(
+            target=_run_unreachable_partial_coverage_warns,
+            args=(0, dataset, warn_holder),
+        )
+        proc.start()
+        proc.join(timeout=180)  # bounded: a false-positive failure would hang
+        alive = proc.is_alive()
+        if alive:
+            proc.terminate()
+            proc.join(timeout=10)
+        self.assertFalse(alive, "loader hung on an unreachable featureless edge type")
+        self.assertGreater(
+            warn_holder.get("count", 0),
+            0,
+            "expected batches; construction must not reject partial coverage",
+        )
+        self.assertTrue(
+            warn_holder.get("warned", False),
+            "expected a partial-feature-coverage warning at construction",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/tests/unit/distributed/distributed_neighborloader_test.py
@@ -868,15 +868,16 @@ class DistributedNeighborLoaderTest(TestCase):
             DistNeighborLoader(**kwargs)
 
 
-# NOTE on the Fix B test strategy: GiGL loaders always sample via the multiprocess
+# NOTE on the test strategy: GiGL loaders always sample via the multiprocess
 # producer, which spawns worker subprocesses with a *fresh* interpreter
 # (`mp.get_context("spawn")`, dist_sampling_producer.py). A `mock.patch` applied in the
 # loader process therefore never reaches the sampler running in that subprocess, so we
-# cannot inject a synthetic failure by mocking the sampler. Instead we reproduce the real
-# production failure end-to-end: a heterogeneous dataset with edge features on only a
+# cannot inject a synthetic failure by mocking the sampler. Instead we reproduce a real
+# sampler failure end-to-end: a heterogeneous dataset with edge features on only a
 # subset of its message-passing edge types. When the featureless type is reached during
 # sampling, its feature lookup raises `KeyError` inside the sampling coroutine — the exact
-# bug Fix B surfaces. Pre-fix this hangs forever, so the test uses a bounded join.
+# swallowed-exception case this change surfaces. Without the change this hangs forever, so
+# the test uses a bounded join.
 
 
 def _run_partial_edge_feature_coverage_raises(

--- a/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/tests/unit/distributed/distributed_neighborloader_test.py
@@ -889,6 +889,87 @@ class DistributedNeighborLoaderTest(TestCase):
             DistNeighborLoader(**kwargs)
 
 
+class WithEdgeDerivationTest(TestCase):
+    """Covers ``create_sampling_config`` deriving ``with_edge`` from edge-feature presence.
+
+    Exercises both paths: ``with_edge=True`` when the dataset has edge features
+    (homogeneous or per-edge-type), and ``with_edge=False`` when it has none.
+    """
+
+    def test_config_with_edge_false_when_no_edge_features(self) -> None:
+        schema = DatasetSchema(
+            is_homogeneous_with_labeled_edge_type=False,
+            edge_types=None,
+            node_feature_info=None,
+            edge_feature_info=None,  # no edge features
+            edge_dir="out",
+        )
+        config = BaseDistLoader.create_sampling_config(
+            num_neighbors=[2, 2], dataset_schema=schema
+        )
+        self.assertFalse(config.with_edge)
+
+    def test_config_with_edge_true_when_edge_features_present(self) -> None:
+        schema = DatasetSchema(
+            is_homogeneous_with_labeled_edge_type=False,
+            edge_types=None,
+            node_feature_info=None,
+            edge_feature_info=FeatureInfo(dim=4, dtype=torch.float32),
+            edge_dir="out",
+        )
+        config = BaseDistLoader.create_sampling_config(
+            num_neighbors=[2, 2], dataset_schema=schema
+        )
+        self.assertTrue(config.with_edge)
+
+    def test_config_with_edge_true_for_heterogeneous_edge_feature_dict(self) -> None:
+        schema = DatasetSchema(
+            is_homogeneous_with_labeled_edge_type=False,
+            edge_types=[_USER_TO_STORY, _STORY_TO_USER],
+            node_feature_info=None,
+            edge_feature_info={
+                _USER_TO_STORY: FeatureInfo(dim=4, dtype=torch.float32),
+            },
+            edge_dir="out",
+        )
+        config = BaseDistLoader.create_sampling_config(
+            num_neighbors=[2, 2], dataset_schema=schema
+        )
+        self.assertTrue(config.with_edge)
+
+    def test_featureless_dataset_produces_batches_without_edge_ids(self) -> None:
+        # Homogeneous dataset with node features but no edge features: the loader
+        # must still yield batches, and none carry sampled edge ids.
+        partition_output = PartitionOutput(
+            node_partition_book=torch.zeros(5),
+            edge_partition_book=torch.zeros(5),
+            partitioned_edge_index=GraphPartitionData(
+                edge_index=torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0]]),
+                edge_ids=None,
+            ),
+            partitioned_node_features=FeaturePartitionData(
+                feats=torch.zeros(5, 2), ids=torch.arange(5)
+            ),
+            partitioned_edge_features=None,
+            partitioned_positive_labels=None,
+            partitioned_negative_labels=None,
+            partitioned_node_labels=None,
+        )
+        dataset = DistDataset(rank=0, world_size=1, edge_dir="out")
+        dataset.build(partition_output=partition_output)
+
+        manager = mp.Manager()
+        holder: MutableMapping = manager.dict()
+        proc = mp.spawn(
+            fn=_run_featureless_edge_ids_absent,
+            args=(dataset, holder),
+            join=False,
+        )
+        proc.join(timeout=120)
+        self.assertGreater(holder["count"], 0)
+        self.assertTrue(holder["edge_ids_absent"])
+
+
 # NOTE on the test strategy: GiGL loaders always sample via the multiprocess
 # producer, which spawns worker subprocesses with a *fresh* interpreter
 # (`mp.get_context("spawn")`, dist_sampling_producer.py). A `mock.patch` applied in the
@@ -960,68 +1041,6 @@ class TestSamplingErrorPropagation(TestCase):
                     feats=torch.ones(n, 3), ids=torch.arange(n)
                 ),
             },
-class WithEdgeDerivationTest(TestCase):
-    """Covers ``create_sampling_config`` deriving ``with_edge`` from edge-feature presence.
-
-    Exercises both paths: ``with_edge=True`` when the dataset has edge features
-    (homogeneous or per-edge-type), and ``with_edge=False`` when it has none.
-    """
-
-    def test_config_with_edge_false_when_no_edge_features(self) -> None:
-        schema = DatasetSchema(
-            is_homogeneous_with_labeled_edge_type=False,
-            edge_types=None,
-            node_feature_info=None,
-            edge_feature_info=None,  # no edge features
-            edge_dir="out",
-        )
-        config = BaseDistLoader.create_sampling_config(
-            num_neighbors=[2, 2], dataset_schema=schema
-        )
-        self.assertFalse(config.with_edge)
-
-    def test_config_with_edge_true_when_edge_features_present(self) -> None:
-        schema = DatasetSchema(
-            is_homogeneous_with_labeled_edge_type=False,
-            edge_types=None,
-            node_feature_info=None,
-            edge_feature_info=FeatureInfo(dim=4, dtype=torch.float32),
-            edge_dir="out",
-        )
-        config = BaseDistLoader.create_sampling_config(
-            num_neighbors=[2, 2], dataset_schema=schema
-        )
-        self.assertTrue(config.with_edge)
-
-    def test_config_with_edge_true_for_heterogeneous_edge_feature_dict(self) -> None:
-        schema = DatasetSchema(
-            is_homogeneous_with_labeled_edge_type=False,
-            edge_types=[_USER_TO_STORY, _STORY_TO_USER],
-            node_feature_info=None,
-            edge_feature_info={
-                _USER_TO_STORY: FeatureInfo(dim=4, dtype=torch.float32),
-            },
-            edge_dir="out",
-        )
-        config = BaseDistLoader.create_sampling_config(
-            num_neighbors=[2, 2], dataset_schema=schema
-        )
-        self.assertTrue(config.with_edge)
-
-    def test_featureless_dataset_produces_batches_without_edge_ids(self) -> None:
-        # Homogeneous dataset with node features but no edge features: the loader
-        # must still yield batches, and none carry sampled edge ids.
-        partition_output = PartitionOutput(
-            node_partition_book=torch.zeros(5),
-            edge_partition_book=torch.zeros(5),
-            partitioned_edge_index=GraphPartitionData(
-                edge_index=torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0]]),
-                edge_ids=None,
-            ),
-            partitioned_node_features=FeaturePartitionData(
-                feats=torch.zeros(5, 2), ids=torch.arange(5)
-            ),
-            partitioned_edge_features=None,
             partitioned_positive_labels=None,
             partitioned_negative_labels=None,
             partitioned_node_labels=None,
@@ -1051,17 +1070,6 @@ class WithEdgeDerivationTest(TestCase):
         # The training process raised with the worker's real traceback embedded.
         self.assertIn("sampling worker failed", message.lower())
         self.assertIn("story-to-user", message)
-
-        manager = mp.Manager()
-        holder: MutableMapping = manager.dict()
-        proc = mp.spawn(
-            fn=_run_featureless_edge_ids_absent,
-            args=(dataset, holder),
-            join=False,
-        )
-        proc.join(timeout=120)
-        self.assertGreater(holder["count"], 0)
-        self.assertTrue(holder["edge_ids_absent"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/tests/unit/distributed/distributed_neighborloader_test.py
@@ -920,7 +920,9 @@ class TestSamplingErrorPropagation(TestCase):
                 ),
             },
             partitioned_node_features={
-                _USER: FeaturePartitionData(feats=torch.zeros(n, 2), ids=torch.arange(n)),
+                _USER: FeaturePartitionData(
+                    feats=torch.zeros(n, 2), ids=torch.arange(n)
+                ),
                 _STORY: FeaturePartitionData(
                     feats=torch.zeros(n, 2), ids=torch.arange(n)
                 ),
@@ -952,7 +954,9 @@ class TestSamplingErrorPropagation(TestCase):
         if alive:
             proc.terminate()
             proc.join(timeout=10)
-        self.assertFalse(alive, "loader hung instead of failing fast on a sampler error")
+        self.assertFalse(
+            alive, "loader hung instead of failing fast on a sampler error"
+        )
         message = error_holder.get("msg", "")
         # The training process raised with the worker's real traceback embedded.
         self.assertIn("sampling worker failed", message.lower())

--- a/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/tests/unit/distributed/distributed_neighborloader_test.py
@@ -1,5 +1,4 @@
 import unittest
-import unittest.mock as mock
 from collections.abc import Mapping
 
 import torch
@@ -53,12 +52,6 @@ _USER = NodeType("user")
 _STORY = NodeType("story")
 _USER_TO_STORY = EdgeType(_USER, Relation("to"), _STORY)
 _STORY_TO_USER = EdgeType(_STORY, Relation("to"), _USER)
-# An isolated (item, to, tag) edge type used to test partial feature coverage: it is
-# never reachable from `user` seeds within a 2-hop fanout, so a loader over it still
-# completes.
-_ITEM = NodeType("item")
-_TAG = NodeType("tag")
-_ITEM_TO_TAG = EdgeType(_ITEM, Relation("to"), _TAG)
 
 # GLT requires subclasses of DistNeighborLoader to be run in a separate process. Otherwise, we may run into segmentation fault
 # or other memory issues. Calling these functions in separate proceses also allows us to use shutdown_rpc() to ensure cleanup of
@@ -902,38 +895,6 @@ def _run_partial_edge_feature_coverage_raises(
         shutdown_rpc()
 
 
-def _run_unreachable_partial_coverage_warns(
-    _,
-    dataset: DistDataset,
-    warn_holder,
-):
-    create_test_process_group()
-    import gigl.distributed.base_dist_loader as base_dist_loader_module
-
-    captured_warnings: list[str] = []
-
-    def _capture(msg, *args, **kwargs):
-        try:
-            captured_warnings.append(msg % args if args else str(msg))
-        except Exception:
-            captured_warnings.append(str(msg))
-
-    assert isinstance(dataset.node_ids, Mapping)
-    with mock.patch.object(
-        base_dist_loader_module.logger, "warning", side_effect=_capture
-    ):
-        loader = DistNeighborLoader(
-            dataset=dataset,
-            input_nodes=(_USER, dataset.node_ids[_USER]),  # ty: ignore[invalid-argument-type]
-            num_neighbors=[2, 2],
-            pin_memory_device=torch.device("cpu"),
-        )
-        count = sum(1 for _datum in loader)
-    warn_holder["count"] = count
-    warn_holder["warned"] = any("feature" in line.lower() for line in captured_warnings)
-    shutdown_rpc()
-
-
 class TestSamplingErrorPropagation(TestCase):
     def _build_partial_edge_feature_dataset(self) -> DistDataset:
         """Build a hetero dataset with edge features on only one message-passing type.
@@ -996,80 +957,6 @@ class TestSamplingErrorPropagation(TestCase):
         # The training process raised with the worker's real traceback embedded.
         self.assertIn("sampling worker failed", message.lower())
         self.assertIn("story-to-user", message)
-
-    def test_unreachable_partial_coverage_warns_but_completes(self) -> None:
-        # Featureless (item, to, tag) edge type is isolated from `user`, so it is never
-        # sampled: iteration completes with batches, proving construction does NOT raise
-        # on partial coverage, while still emitting the warning.
-        n = 5
-        edge_index = torch.tensor([[0, 1, 2, 3, 4], [0, 1, 2, 3, 4]])
-        partition_output = PartitionOutput(
-            node_partition_book={
-                _USER: torch.zeros(n),
-                _STORY: torch.zeros(n),
-                _ITEM: torch.zeros(n),
-                _TAG: torch.zeros(n),
-            },
-            edge_partition_book={
-                _USER_TO_STORY: torch.zeros(n),
-                _STORY_TO_USER: torch.zeros(n),
-                _ITEM_TO_TAG: torch.zeros(n),
-            },
-            partitioned_edge_index={
-                _USER_TO_STORY: GraphPartitionData(
-                    edge_index=edge_index, edge_ids=None
-                ),
-                _STORY_TO_USER: GraphPartitionData(
-                    edge_index=edge_index, edge_ids=None
-                ),
-                _ITEM_TO_TAG: GraphPartitionData(edge_index=edge_index, edge_ids=None),
-            },
-            partitioned_node_features={
-                _USER: FeaturePartitionData(feats=torch.zeros(n, 2), ids=torch.arange(n)),
-                _STORY: FeaturePartitionData(
-                    feats=torch.zeros(n, 2), ids=torch.arange(n)
-                ),
-                _ITEM: FeaturePartitionData(feats=torch.zeros(n, 2), ids=torch.arange(n)),
-                _TAG: FeaturePartitionData(feats=torch.zeros(n, 2), ids=torch.arange(n)),
-            },
-            # Edge features on the user/story types only; (item, to, tag) is featureless.
-            partitioned_edge_features={
-                _USER_TO_STORY: FeaturePartitionData(
-                    feats=torch.ones(n, 3), ids=torch.arange(n)
-                ),
-                _STORY_TO_USER: FeaturePartitionData(
-                    feats=torch.ones(n, 3), ids=torch.arange(n)
-                ),
-            },
-            partitioned_positive_labels=None,
-            partitioned_negative_labels=None,
-            partitioned_node_labels=None,
-        )
-        dataset = DistDataset(rank=0, world_size=1, edge_dir="out")
-        dataset.build(partition_output=partition_output)
-
-        manager = mp.Manager()
-        warn_holder = manager.dict()
-        proc = mp.get_context("spawn").Process(
-            target=_run_unreachable_partial_coverage_warns,
-            args=(0, dataset, warn_holder),
-        )
-        proc.start()
-        proc.join(timeout=180)  # bounded: a false-positive failure would hang
-        alive = proc.is_alive()
-        if alive:
-            proc.terminate()
-            proc.join(timeout=10)
-        self.assertFalse(alive, "loader hung on an unreachable featureless edge type")
-        self.assertGreater(
-            warn_holder.get("count", 0),
-            0,
-            "expected batches; construction must not reject partial coverage",
-        )
-        self.assertTrue(
-            warn_holder.get("warned", False),
-            "expected a partial-feature-coverage warning at construction",
-        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/distributed/graph_store/remote_channel_test.py
+++ b/tests/unit/distributed/graph_store/remote_channel_test.py
@@ -166,7 +166,7 @@ class RemoteReceivingChannelTest(TestCase):
         channel.reset()
 
         pill = {SAMPLING_ERROR_KEY: encode_sampling_error("boom")}
-        # Responses are mocked returned messages from the server 
+        # Responses are mocked returned messages from the server
         responses = iter([(pill, False), (None, True)])
 
         def _mock_async_request_server(server_rank, func, channel_id):

--- a/tests/unit/distributed/graph_store/remote_channel_test.py
+++ b/tests/unit/distributed/graph_store/remote_channel_test.py
@@ -166,6 +166,7 @@ class RemoteReceivingChannelTest(TestCase):
         channel.reset()
 
         pill = {SAMPLING_ERROR_KEY: encode_sampling_error("boom")}
+        # Responses are mocked returned messages from the server 
         responses = iter([(pill, False), (None, True)])
 
         def _mock_async_request_server(server_rank, func, channel_id):

--- a/tests/unit/distributed/graph_store/remote_channel_test.py
+++ b/tests/unit/distributed/graph_store/remote_channel_test.py
@@ -3,6 +3,11 @@ from unittest.mock import patch
 import torch
 
 from gigl.distributed.graph_store.remote_channel import RemoteReceivingChannel
+from gigl.distributed.utils.sampling_errors import (
+    SAMPLING_ERROR_KEY,
+    encode_sampling_error,
+    raise_if_sampling_error,
+)
 from tests.test_assets.test_case import TestCase
 
 
@@ -144,3 +149,34 @@ class RemoteReceivingChannelTest(TestCase):
         ):
             with self.assertRaises(RuntimeError):
                 channel.recv()
+
+    def test_recv_forwards_sampling_error_pill_to_decoder(self) -> None:
+        """A sampling-error poison pill survives graph-store transport and raises.
+
+        The server-side sampler forwards the pill as an ordinary ``SampleMessage``;
+        ``RemoteReceivingChannel.recv`` passes it through content-agnostically, and the
+        loader-side ``raise_if_sampling_error`` decodes the embedded traceback.
+        """
+        channel = RemoteReceivingChannel(
+            server_rank=[0],
+            channel_id=[10],
+            prefetch_size=1,
+            active_mask=[True],
+        )
+        channel.reset()
+
+        pill = {SAMPLING_ERROR_KEY: encode_sampling_error("boom")}
+        responses = iter([(pill, False), (None, True)])
+
+        def _mock_async_request_server(server_rank, func, channel_id):
+            return _resolved_future(next(responses))
+
+        with patch(
+            "gigl.distributed.graph_store.remote_channel.async_request_server",
+            side_effect=_mock_async_request_server,
+        ):
+            msg = channel.recv()
+
+        with self.assertRaises(RuntimeError) as ctx:
+            raise_if_sampling_error(msg)
+        self.assertIn("boom", str(ctx.exception))

--- a/tests/unit/distributed/utils/sampling_errors_test.py
+++ b/tests/unit/distributed/utils/sampling_errors_test.py
@@ -1,0 +1,38 @@
+import torch
+
+from gigl.distributed.utils.sampling_errors import (
+    SAMPLING_ERROR_KEY,
+    encode_sampling_error,
+    raise_if_sampling_error,
+)
+from tests.test_assets.test_case import TestCase
+
+
+class TestSamplingErrors(TestCase):
+    def test_roundtrip_ascii(self) -> None:
+        tb = "Traceback (most recent call last):\n  KeyError: foo"
+        msg = {SAMPLING_ERROR_KEY: encode_sampling_error(tb)}
+        with self.assertRaises(RuntimeError) as ctx:
+            raise_if_sampling_error(msg)
+        self.assertIn(tb, str(ctx.exception))
+
+    def test_roundtrip_non_ascii(self) -> None:
+        tb = "boom – KeyError: user‑engages"
+        msg = {SAMPLING_ERROR_KEY: encode_sampling_error(tb)}
+        with self.assertRaises(RuntimeError) as ctx:
+            raise_if_sampling_error(msg)
+        self.assertIn(tb, str(ctx.exception))
+
+    def test_empty_string_does_not_crash(self) -> None:
+        # format_exc() is never empty in practice, but the codec must not crash.
+        msg = {SAMPLING_ERROR_KEY: encode_sampling_error("")}
+        with self.assertRaises(RuntimeError):
+            raise_if_sampling_error(msg)
+
+    def test_encoded_tensor_is_writable_uint8(self) -> None:
+        t = encode_sampling_error("hi")
+        self.assertEqual(t.dtype, torch.uint8)
+        t[0] = t[0]  # must not raise (writable)
+
+    def test_no_key_is_noop(self) -> None:
+        raise_if_sampling_error({"ids": torch.zeros(3)})  # returns None, no raise


### PR DESCRIPTION
  ## What & why

  GLT's `ConcurrentEventLoop` catches every exception raised inside a sampling
  coroutine and only logs `coroutine task failed: <str(e)>` — no traceback, no
  message sent to the channel. When that happens the loader blocks forever on
  `channel.recv()`, so a single sampler failure turns into a silent, indefinite
  hang.

  This PR makes those failures loud and immediate. It does **not** fix the
  underlying feature-coverage bug that triggered the incident (that's a
  separate PR) — it's the general guardrail that converts *any* swallowed sampler
  exception into a fast, actionable error.

  ## Changes

  - **`gigl/distributed/utils/sampling_errors.py`** (new): shared wire codec —
    reserved key `#SAMPLING_ERROR`, `encode_sampling_error()` (traceback → uint8
    tensor), `raise_if_sampling_error()` (decodes and raises `RuntimeError`). One
    source of truth so producer and consumer can't drift.
  - **`base_sampler.py`**: `BaseDistNeighborSampler` gains an `__init__` that
    initializes `_sampling_error_sent`; `_send_adapter` is wrapped in try/except —
    on failure it logs the full traceback via `logger.exception` and forwards a
    one-time poison-pill `SampleMessage` in channel mode (re-raises in
    channel-less mode). One pill per sampler instance, so a failure storm can't
    block a bounded channel.
  - **`distributed_neighborloader.py` / `dist_ablp_neighborloader.py`**:
    `raise_if_sampling_error(msg)` at the top of each `_collate_fn`, so the
    training process raises on the next `next(loader)` with the worker's real
    traceback.
  - **`base_dist_loader.py`**: `_warn_on_partial_feature_coverage` (called from
    `__init__`) — non-fatal warning when a heterogeneous dataset has features on
    only a subset of its node/edge types. Warning, never a raise: reachability of
    a featureless type is a runtime property that can't be proven at construction.

  ## Testing

  - `sampling_errors_test.py` (new): 5/5 — codec round-trip incl. non-ASCII and
    empty-string, writable-tensor, no-op-when-absent.
  - `remote_channel_test.py`: 6/6 — poison pill survives the graph-store receive
    path and raises loader-side.
  - `distributed_neighborloader_test.py`: 25/25 (1 pre-existing GPU skip) — incl.
    two loader-level tests under bounded `proc.join(timeout=...)`.
  - `make type_check`: clean.
  - Confirmed end-to-end that a reachable featureless edge type now raises
    `RuntimeError` ("A sampling worker failed... KeyError: ...") in ~30s instead
    of hanging.

