### PR TITLE
Derive with_edge from edge feature presence (perf)

### DIFF
--- a/gigl/distributed/base_dist_loader.py
+++ b/gigl/distributed/base_dist_loader.py
@@ -416,7 +416,7 @@ class BaseDistLoader(DistLoader):
             batch_size=batch_size,
             shuffle=shuffle,
             drop_last=drop_last,
-            with_edge=True,
+            with_edge=dataset_schema.edge_feature_info is not None,
             collect_features=True,
             with_neg=False,
             with_weight=with_weight,

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -316,6 +316,13 @@ def _run_ppr_loader_correctness_check(
 
     dataset = create_homogeneous_dataset(edge_index=_TEST_EDGE_INDEX, edge_dir=edge_dir)
 
+    # This dataset has no edge features, so with_edge is derived as False. PPR
+    # outputs come from metadata (ppr_edge_index/ppr_edge_attr), not sampled edge
+    # ids, so with_edge must not affect the PPR results verified below.
+    assert dataset.edge_features is None, (
+        "PPR regression fixture must be edge-feature-free so with_edge is False."
+    )
+
     loader = DistNeighborLoader(
         dataset=dataset,
         num_neighbors=[],  # Unused by PPR sampler; required by interface

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -320,7 +320,7 @@ def _run_ppr_loader_correctness_check(
     # outputs come from metadata (ppr_edge_index/ppr_edge_attr), not sampled edge
     # ids, so with_edge must not affect the PPR results verified below.
     assert dataset.edge_features is None, (
-        "PPR regression fixture must be edge-feature-free so with_edge is False."
+        "PPR fixture must be edge-feature-free so with_edge is False."
     )
 
     loader = DistNeighborLoader(

--- a/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/tests/unit/distributed/distributed_neighborloader_test.py
@@ -890,7 +890,11 @@ class DistributedNeighborLoaderTest(TestCase):
 
 
 class WithEdgeDerivationTest(TestCase):
-    """Regression coverage for deriving ``with_edge`` from edge-feature presence."""
+    """Covers ``create_sampling_config`` deriving ``with_edge`` from edge-feature presence.
+
+    Exercises both paths: ``with_edge=True`` when the dataset has edge features
+    (homogeneous or per-edge-type), and ``with_edge=False`` when it has none.
+    """
 
     def test_config_with_edge_false_when_no_edge_features(self) -> None:
         schema = DatasetSchema(

--- a/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/tests/unit/distributed/distributed_neighborloader_test.py
@@ -8,10 +8,12 @@ from graphlearn_torch.distributed import shutdown_rpc
 from parameterized import param, parameterized
 from torch_geometric.data import Data, HeteroData
 
+from gigl.distributed.base_dist_loader import BaseDistLoader
 from gigl.distributed.dataset_factory import build_dataset
 from gigl.distributed.dist_dataset import DistDataset
 from gigl.distributed.distributed_neighborloader import DistNeighborLoader
 from gigl.distributed.utils import get_free_port
+from gigl.distributed.utils.neighborloader import DatasetSchema
 from gigl.distributed.utils.serialized_graph_metadata_translator import (
     convert_pb_to_serialized_graph_metadata,
 )
@@ -26,6 +28,7 @@ from gigl.src.mocking.mocking_assets.mocked_datasets_for_pipeline_tests import (
 )
 from gigl.types.graph import (
     DEFAULT_HOMOGENEOUS_EDGE_TYPE,
+    FeatureInfo,
     FeaturePartitionData,
     GraphPartitionData,
     PartitionOutput,
@@ -890,9 +893,6 @@ class WithEdgeDerivationTest(TestCase):
     """Regression coverage for deriving ``with_edge`` from edge-feature presence."""
 
     def test_config_with_edge_false_when_no_edge_features(self) -> None:
-        from gigl.distributed.base_dist_loader import BaseDistLoader
-        from gigl.distributed.utils.neighborloader import DatasetSchema
-
         schema = DatasetSchema(
             is_homogeneous_with_labeled_edge_type=False,
             edge_types=None,
@@ -906,10 +906,6 @@ class WithEdgeDerivationTest(TestCase):
         self.assertFalse(config.with_edge)
 
     def test_config_with_edge_true_when_edge_features_present(self) -> None:
-        from gigl.distributed.base_dist_loader import BaseDistLoader
-        from gigl.distributed.utils.neighborloader import DatasetSchema
-        from gigl.types.graph import FeatureInfo
-
         schema = DatasetSchema(
             is_homogeneous_with_labeled_edge_type=False,
             edge_types=None,
@@ -923,10 +919,6 @@ class WithEdgeDerivationTest(TestCase):
         self.assertTrue(config.with_edge)
 
     def test_config_with_edge_true_for_heterogeneous_edge_feature_dict(self) -> None:
-        from gigl.distributed.base_dist_loader import BaseDistLoader
-        from gigl.distributed.utils.neighborloader import DatasetSchema
-        from gigl.types.graph import FeatureInfo
-
         schema = DatasetSchema(
             is_homogeneous_with_labeled_edge_type=False,
             edge_types=[_USER_TO_STORY, _STORY_TO_USER],

--- a/tests/unit/distributed/distributed_neighborloader_test.py
+++ b/tests/unit/distributed/distributed_neighborloader_test.py
@@ -1,5 +1,5 @@
 import unittest
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 
 import torch
 import torch.multiprocessing as mp
@@ -395,6 +395,31 @@ def _run_cora_supervised_node_classification(
             f"Number of labels should match number of nodes, got {datum.y.size(0)} labels and {datum.node.size(0)} nodes"
         )
 
+    shutdown_rpc()
+
+
+def _run_featureless_edge_ids_absent(
+    _,
+    dataset: DistDataset,
+    holder: MutableMapping,
+):
+    # A featureless dataset should sample with with_edge=False, so GLT never
+    # attaches sampled edge ids (``data.edge``) to the produced batches.
+    create_test_process_group()
+    loader = DistNeighborLoader(
+        dataset=dataset,
+        num_neighbors=[2, 2],
+        pin_memory_device=torch.device("cpu"),
+    )
+    count = 0
+    edge_ids_absent = True
+    for datum in loader:
+        assert isinstance(datum, Data)
+        if getattr(datum, "edge", None) is not None:
+            edge_ids_absent = False
+        count += 1
+    holder["edge_ids_absent"] = edge_ids_absent
+    holder["count"] = count
     shutdown_rpc()
 
 
@@ -859,6 +884,94 @@ class DistributedNeighborLoaderTest(TestCase):
         create_test_process_group()
         with self.assertRaises(expected_error):
             DistNeighborLoader(**kwargs)
+
+
+class WithEdgeDerivationTest(TestCase):
+    """Regression coverage for deriving ``with_edge`` from edge-feature presence."""
+
+    def test_config_with_edge_false_when_no_edge_features(self) -> None:
+        from gigl.distributed.base_dist_loader import BaseDistLoader
+        from gigl.distributed.utils.neighborloader import DatasetSchema
+
+        schema = DatasetSchema(
+            is_homogeneous_with_labeled_edge_type=False,
+            edge_types=None,
+            node_feature_info=None,
+            edge_feature_info=None,  # no edge features
+            edge_dir="out",
+        )
+        config = BaseDistLoader.create_sampling_config(
+            num_neighbors=[2, 2], dataset_schema=schema
+        )
+        self.assertFalse(config.with_edge)
+
+    def test_config_with_edge_true_when_edge_features_present(self) -> None:
+        from gigl.distributed.base_dist_loader import BaseDistLoader
+        from gigl.distributed.utils.neighborloader import DatasetSchema
+        from gigl.types.graph import FeatureInfo
+
+        schema = DatasetSchema(
+            is_homogeneous_with_labeled_edge_type=False,
+            edge_types=None,
+            node_feature_info=None,
+            edge_feature_info=FeatureInfo(dim=4, dtype=torch.float32),
+            edge_dir="out",
+        )
+        config = BaseDistLoader.create_sampling_config(
+            num_neighbors=[2, 2], dataset_schema=schema
+        )
+        self.assertTrue(config.with_edge)
+
+    def test_config_with_edge_true_for_heterogeneous_edge_feature_dict(self) -> None:
+        from gigl.distributed.base_dist_loader import BaseDistLoader
+        from gigl.distributed.utils.neighborloader import DatasetSchema
+        from gigl.types.graph import FeatureInfo
+
+        schema = DatasetSchema(
+            is_homogeneous_with_labeled_edge_type=False,
+            edge_types=[_USER_TO_STORY, _STORY_TO_USER],
+            node_feature_info=None,
+            edge_feature_info={
+                _USER_TO_STORY: FeatureInfo(dim=4, dtype=torch.float32),
+            },
+            edge_dir="out",
+        )
+        config = BaseDistLoader.create_sampling_config(
+            num_neighbors=[2, 2], dataset_schema=schema
+        )
+        self.assertTrue(config.with_edge)
+
+    def test_featureless_dataset_produces_batches_without_edge_ids(self) -> None:
+        # Homogeneous dataset with node features but no edge features: the loader
+        # must still yield batches, and none carry sampled edge ids.
+        partition_output = PartitionOutput(
+            node_partition_book=torch.zeros(5),
+            edge_partition_book=torch.zeros(5),
+            partitioned_edge_index=GraphPartitionData(
+                edge_index=torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0]]),
+                edge_ids=None,
+            ),
+            partitioned_node_features=FeaturePartitionData(
+                feats=torch.zeros(5, 2), ids=torch.arange(5)
+            ),
+            partitioned_edge_features=None,
+            partitioned_positive_labels=None,
+            partitioned_negative_labels=None,
+            partitioned_node_labels=None,
+        )
+        dataset = DistDataset(rank=0, world_size=1, edge_dir="out")
+        dataset.build(partition_output=partition_output)
+
+        manager = mp.Manager()
+        holder: MutableMapping = manager.dict()
+        proc = mp.spawn(
+            fn=_run_featureless_edge_ids_absent,
+            args=(dataset, holder),
+            join=False,
+        )
+        proc.join(timeout=120)
+        self.assertGreater(holder["count"], 0)
+        self.assertTrue(holder["edge_ids_absent"])
 
 
 if __name__ == "__main__":

--- a/tests/unit/distributed/distributed_weighted_sampling_test.py
+++ b/tests/unit/distributed/distributed_weighted_sampling_test.py
@@ -327,6 +327,12 @@ def _run_weighted_sampling_correctness_homogeneous(
     for datum in loader:
         assert isinstance(datum, Data), f"Expected Data, got {type(datum)}"
         assert datum.x is not None, "Node features missing from sampled subgraph"
+        # The graph has no edge features, so with_edge is derived as False and GLT
+        # must not attach sampled edge ids -- yet weighted sampling still works.
+        assert getattr(datum, "edge", None) is None, (
+            "Featureless weighted dataset should sample with with_edge=False, "
+            "but sampled edge ids were attached to the batch."
+        )
         # Bad nodes have feature 0.0; hub and good nodes have feature > 0.
         bad_mask = datum.x[:, 0] == 0.0
         assert not bad_mask.any(), (

--- a/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
+++ b/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
@@ -230,6 +230,28 @@ class TestRemoteDistDataset(RemoteDistDatasetTestBase):
         # The derivation used off-node by create_sampling_config.
         self.assertTrue(edge_feature_info is not None)
 
+    def test_fetch_edge_feature_info_none_without_edge_features(self, mock_request):
+        """Edge feature info is ``None`` off-node when the graph has no edge features.
+
+        Sibling of ``test_fetch_edge_feature_info_populated_from_server`` for the
+        other ``with_edge`` path: a graph without edge features yields a ``None``
+        ``edge_feature_info``, so ``BaseDistLoader.create_sampling_config`` derives
+        ``with_edge=False`` on the compute side.
+        """
+        global _test_server
+        dataset_without_edge_features = create_homogeneous_dataset(
+            edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
+            node_features=torch.zeros(10, 3),
+        )
+        _test_server = DistServer(dataset_without_edge_features)
+        dist_server_module._dist_server = _test_server
+
+        cluster_info = _create_mock_graph_store_info()
+        remote_dataset = RemoteDistDataset(cluster_info=cluster_info, local_rank=0)
+
+        # None edge_feature_info -> create_sampling_config derives with_edge=False.
+        self.assertIsNone(remote_dataset.fetch_edge_feature_info())
+
     def test_cluster_info_property(self, mock_request):
         cluster_info = _create_mock_graph_store_info(
             num_storage_nodes=3, num_compute_nodes=2

--- a/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
+++ b/tests/unit/distributed/graph_store/remote_dist_dataset_test.py
@@ -200,6 +200,36 @@ class TestRemoteDistDataset(RemoteDistDatasetTestBase):
         self.assertIsNone(remote_dataset.fetch_edge_types())
         self.assertIsNone(remote_dataset.fetch_node_types())
 
+    def test_fetch_edge_feature_info_populated_from_server(self, mock_request):
+        """Edge feature info is fetched from server rank 0 for the compute-side schema.
+
+        The ``with_edge`` sampling flag is derived on the compute side as
+        ``dataset_schema.edge_feature_info is not None`` (see
+        ``BaseDistLoader.create_sampling_config``). This test confirms the field
+        is populated from the storage cluster when the graph has edge features,
+        so that derivation yields ``with_edge=True`` off-node.
+        """
+        global _test_server
+        num_edges = DEFAULT_HOMOGENEOUS_EDGE_INDEX.shape[1]
+        dataset_with_edge_features = create_homogeneous_dataset(
+            edge_index=DEFAULT_HOMOGENEOUS_EDGE_INDEX,
+            node_features=torch.zeros(10, 3),
+            edge_features=torch.zeros(num_edges, 4),
+        )
+        _test_server = DistServer(dataset_with_edge_features)
+        dist_server_module._dist_server = _test_server
+
+        cluster_info = _create_mock_graph_store_info()
+        remote_dataset = RemoteDistDataset(cluster_info=cluster_info, local_rank=0)
+
+        edge_feature_info = remote_dataset.fetch_edge_feature_info()
+        self.assertEqual(
+            edge_feature_info,
+            FeatureInfo(dim=4, dtype=torch.float32),
+        )
+        # The derivation used off-node by create_sampling_config.
+        self.assertTrue(edge_feature_info is not None)
+
     def test_cluster_info_property(self, mock_request):
         cluster_info = _create_mock_graph_store_info(
             num_storage_nodes=3, num_compute_nodes=2


### PR DESCRIPTION
  ## What

  `BaseDistLoader.create_sampling_config` hardcoded `with_edge=True` for every
  loader. This derives it from whether the dataset actually has edge features:

      with_edge = dataset_schema.edge_feature_info is not None

  `DatasetSchema.edge_feature_info` is already populated in both colocated and
  graph-store modes (fetched from storage rank 0 in graph-store mode), so the
  derivation is correct on compute nodes as well.

  ## Why

  For datasets with no edge features anywhere, `with_edge=True` forces GLT to
  collect sampled edge ids per hop and transport them in every `SampleMessage`.
  Those eids are pure overhead when there are no edge features to gather: the
  sampler writes an `int64` eid tensor of one element per sampled edge (gated on
  `self.with_edge`). With `with_edge=False`, GLT takes the `sample` path instead
  of `sample_with_edge`, `output.edge` is `None`, no eids are collected or
  serialized, and edge-feature-store construction is skipped.

  ## Behavior change (changelog)

  Batches produced from featureless datasets no longer carry GLT's `data.edge`
  (homogeneous) or `data[etype].edge` (heterogeneous) sampled-edge-id attribute.
  A repo-wide grep found no consumer that reads this attribute off a produced
  batch — the only in-repo references are the sampler's own write sites. External
  code that reads `batch.edge` on a featureless dataset would now find it
  absent/`None`. Datasets that do have edge features are unaffected.

  ## Tests

  - Direct unit tests for `create_sampling_config`: `with_edge` is `False` when
    `edge_feature_info` is `None`, `True` for homogeneous and heterogeneous edge
    features.
  - End-to-end: a featureless homogeneous dataset yields batches with no sampled
    edge ids (`data.edge is None`).
  - Weighted sampling without edge features still avoids zero-weight edges.
  - PPR unaffected (outputs come from metadata, not sampled eids).
  - Graph-store provenance: compute-side `edge_feature_info` is populated from the
    storage cluster.

  All affected files pass; `make type_check` passes.