### PR TITLE
Add residual top-up extraction to PPR forward push

### DIFF
--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -146,11 +146,11 @@ std::optional<std::unordered_map<int32_t, torch::Tensor>> PPRForwardPush::drainQ
     return result;
 }
 
-void PPRForwardPush::pushResiduals(
-    const std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>& fetchedByEtypeId) {
-    // Step 1: Unpack the input map into a C++ map keyed by packKey(nodeId, edgeTypeId)
-    // for fast lookup during the residual-push loop below.
-    std::unordered_map<uint64_t, std::vector<int32_t>> fetched;
+void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
+    // Step 1: Persist fetched neighbor lists in the per-state cache. drainQueue()
+    // consults this cache before requesting future lookups, so storing every
+    // fetched row here avoids re-fetching a (node, edge type) pair if it re-enters
+    // the frontier later in the same PPR channel.
     for (const auto& [edgeTypeId, neighborTensors] : fetchedByEtypeId) {
         const auto& nodeIdsTensor = std::get<0>(neighborTensors);
         const auto& flatNeighborIdsTensor = std::get<1>(neighborTensors);
@@ -172,7 +172,10 @@ void PPRForwardPush::pushResiduals(
             for (int64_t neighborIdx = 0; neighborIdx < count; ++neighborIdx) {
                 neighborIds[neighborIdx] = static_cast<int32_t>(flatNeighborIdsAccessor[offset + neighborIdx]);
             }
-            fetched[packKey(nodeId, edgeTypeId)] = std::move(neighborIds);
+            uint64_t cacheKey = packKey(nodeId, edgeTypeId);
+            if (_neighborCache.find(cacheKey) == _neighborCache.end()) {
+                _neighborCache.emplace(cacheKey, std::move(neighborIds));
+            }
             offset += count;
         }
     }
@@ -197,21 +200,16 @@ void PPRForwardPush::pushResiduals(
                 srcNodeTypeState.pprScores[sourceNodeId] += sourceResidual;
                 srcNodeTypeState.residuals[sourceNodeId] = 0.0;
 
-                // b. Count total fetched/cached neighbors across all edge types for
+                // b. Count total cached neighbors across all edge types for
                 // this source node.  We normalise by the number of neighbors we
                 // actually retrieved, not the true degree, so residual is fully
                 // distributed among known neighbors rather than leaking to unfetched
                 // ones (which matters when num_neighbors_per_hop < true_degree).
-                int32_t totalFetched = 0;
+                int32_t totalCachedNeighbors = 0;
                 for (int32_t edgeTypeId : _nodeTypeToEdgeTypeIds[nodeTypeId]) {
-                    auto fetchedEntry = fetched.find(packKey(sourceNodeId, edgeTypeId));
-                    if (fetchedEntry != fetched.end()) {
-                        totalFetched += static_cast<int32_t>(fetchedEntry->second.size());
-                    } else {
-                        auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
-                        if (cachedEntry != _neighborCache.end()) {
-                            totalFetched += static_cast<int32_t>(cachedEntry->second.size());
-                        }
+                    auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
+                    if (cachedEntry != _neighborCache.end()) {
+                        totalCachedNeighbors += static_cast<int32_t>(cachedEntry->second.size());
                     }
                 }
                 // Two cases reach here:
@@ -221,32 +219,23 @@ void PPRForwardPush::pushResiduals(
                 //      This overstates src and understates its neighbors.  This is expected
                 //      behavior when max_fetch_iterations is set, which intentionally trades
                 //      theoretical PPR correctness for better throughput.
-                if (totalFetched == 0) {
+                if (totalCachedNeighbors == 0) {
                     continue;
                 }
 
-                double residualPerNeighbor = (1.0 - _alpha) * sourceResidual / static_cast<double>(totalFetched);
+                double residualPerNeighbor =
+                    (1.0 - _alpha) * sourceResidual / static_cast<double>(totalCachedNeighbors);
 
                 for (int32_t edgeTypeId : _nodeTypeToEdgeTypeIds[nodeTypeId]) {
-                    // Invariant: fetched and _neighborCache are mutually exclusive for
-                    // any given (node, etype) key within one iteration.  drainQueue()
-                    // only requests a fetch for nodes absent from _neighborCache, so a
-                    // key is in at most one of the two.
-                    //
                     // Neighbor list for this (src, edgeTypeId) pair, borrowed from whichever
                     // map holds it.  reference_wrapper is used because std::optional cannot
                     // hold a reference directly, and we want to avoid copying the vector —
-                    // the data already exists in fetched or _neighborCache and both outlive
-                    // this loop body.  Access via neighborList->get().
+                    // the data already exists in _neighborCache and outlives this loop body.
+                    // Access via neighborList->get().
                     std::optional<std::reference_wrapper<const std::vector<int32_t>>> neighborList;
-                    auto fetchedEntry = fetched.find(packKey(sourceNodeId, edgeTypeId));
-                    if (fetchedEntry != fetched.end()) {
-                        neighborList = std::cref(fetchedEntry->second);
-                    } else {
-                        auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
-                        if (cachedEntry != _neighborCache.end()) {
-                            neighborList = std::cref(cachedEntry->second);
-                        }
+                    auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
+                    if (cachedEntry != _neighborCache.end()) {
+                        neighborList = std::cref(cachedEntry->second);
                     }
                     if (!neighborList || neighborList->get().empty()) {
                         continue;
@@ -267,18 +256,6 @@ void PPRForwardPush::pushResiduals(
                             dstNodeTypeState.residuals[neighborNodeId] >= threshold) {
                             dstNodeTypeState.queue.insert(neighborNodeId);
                             ++_numNodesInQueue;
-
-                            // Promote neighbor lists to the persistent cache: this node will
-                            // be processed next iteration, so caching avoids a re-fetch.
-                            for (int32_t neighborEdgeTypeId : _nodeTypeToEdgeTypeIds[dstNodeTypeId]) {
-                                uint64_t packedKey = packKey(neighborNodeId, neighborEdgeTypeId);
-                                if (_neighborCache.find(packedKey) == _neighborCache.end()) {
-                                    auto fetchedNeighborEntry = fetched.find(packedKey);
-                                    if (fetchedNeighborEntry != fetched.end()) {
-                                        _neighborCache[packedKey] = fetchedNeighborEntry->second;
-                                    }
-                                }
-                            }
                         }
                     }
                 }
@@ -287,9 +264,15 @@ void PPRForwardPush::pushResiduals(
     }
 }
 
-std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> PPRForwardPush::extractTopK(
-    int32_t maxPprNodes) {
-    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> result;
+PPRExtractResult PPRForwardPush::extractTopK(int32_t maxPprNodes) {
+    return extractTopKWithResidualTopUp(maxPprNodes, /*maxResidualNodes=*/0);
+}
+
+PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNodes, int32_t maxResidualNodes) {
+    TORCH_CHECK(maxPprNodes >= 0, "maxPprNodes must be non-negative, got ", maxPprNodes, ".");
+    TORCH_CHECK(maxResidualNodes >= 0, "maxResidualNodes must be non-negative, got ", maxResidualNodes, ".");
+
+    PPRExtractResult result;
     // Emit an entry for every node type, even if unreachable in this batch (empty tensors,
     // all-zero valid_counts).  This keeps the output shape consistent across batches so
     // downstream model architectures see a fixed set of PPR edge types every iteration.
@@ -299,9 +282,13 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
         std::vector<int64_t> validCounts;
 
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
-            const auto& scores = _state[seedIdx][nodeTypeId].pprScores;
+            const auto& nodeTypeState = _state[seedIdx][nodeTypeId];
+            const auto& scores = nodeTypeState.pprScores;
             int32_t topK = std::min(maxPprNodes, static_cast<int32_t>(scores.size()));
+            int32_t residualTopK = 0;
+            std::unordered_set<int32_t> selectedNodeIds;
             if (topK > 0) {
+                selectedNodeIds.reserve(static_cast<size_t>(topK));
                 std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
                 std::partial_sort(scorePairs.begin(),
                                   scorePairs.begin() + topK,
@@ -309,11 +296,44 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
                                   [](const auto& a, const auto& b) { return a.second > b.second; });
 
                 for (int32_t rankIdx = 0; rankIdx < topK; ++rankIdx) {
-                    flatIds.push_back(static_cast<int64_t>(scorePairs[rankIdx].first));
+                    int32_t nodeId = scorePairs[rankIdx].first;
+                    flatIds.push_back(static_cast<int64_t>(nodeId));
                     flatWeights.push_back(scorePairs[rankIdx].second);
+                    selectedNodeIds.insert(nodeId);
                 }
             }
-            validCounts.push_back(static_cast<int64_t>(topK));
+
+            if (maxResidualNodes > 0) {
+                std::vector<std::pair<int32_t, double>> residualPairs;
+                residualPairs.reserve(nodeTypeState.residuals.size());
+                for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
+                    if (residual <= 0.0 || selectedNodeIds.find(nodeId) != selectedNodeIds.end()) {
+                        continue;
+                    }
+
+                    auto scoreIter = scores.find(nodeId);
+                    double pprScore = (scoreIter != scores.end()) ? scoreIter->second : 0.0;
+                    double calibratedScore = pprScore + residual;
+                    if (calibratedScore <= 0.0) {
+                        continue;
+                    }
+                    residualPairs.emplace_back(nodeId, calibratedScore);
+                }
+
+                residualTopK = std::min(maxResidualNodes, static_cast<int32_t>(residualPairs.size()));
+                if (residualTopK > 0) {
+                    std::partial_sort(residualPairs.begin(),
+                                      residualPairs.begin() + residualTopK,
+                                      residualPairs.end(),
+                                      [](const auto& a, const auto& b) { return a.second > b.second; });
+
+                    for (int32_t rankIdx = 0; rankIdx < residualTopK; ++rankIdx) {
+                        flatIds.push_back(static_cast<int64_t>(residualPairs[rankIdx].first));
+                        flatWeights.push_back(residualPairs[rankIdx].second);
+                    }
+                }
+            }
+            validCounts.push_back(static_cast<int64_t>(topK + residualTopK));
         }
 
         result[nodeTypeId] = {torch::tensor(flatIds, torch::kLong),

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -20,11 +20,15 @@ namespace gigl {
 // not co-located in memory — only the control-plane metadata (size, bucket pointer)
 // lives inside the struct.
 struct SeedNodeTypeState {
-    std::unordered_map<int32_t, double> pprScores;   // absorbed PPR mass
-    std::unordered_map<int32_t, double> residuals;   // unabsorbed mass waiting to push
-    std::unordered_set<int32_t> queue;               // nodes queued for the next drain
-    std::unordered_set<int32_t> queuedNodes;         // snapshot captured by drainQueue()
+    std::unordered_map<int32_t, double> pprScores; // absorbed PPR mass
+    std::unordered_map<int32_t, double> residuals; // unabsorbed mass waiting to push
+    std::unordered_set<int32_t> queue;             // nodes queued for the next drain
+    std::unordered_set<int32_t> queuedNodes;       // snapshot captured by drainQueue()
 };
+
+using TensorTriplet = std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>;
+using NeighborFetchMap = std::unordered_map<int32_t, TensorTriplet>;
+using PPRExtractResult = std::unordered_map<int32_t, TensorTriplet>;
 
 // C++ kernel for PPR Forward Push (Andersen et al., 2006).
 // Hot-loop state lives here; distributed neighbor fetches are driven from Python.
@@ -37,14 +41,14 @@ struct SeedNodeTypeState {
 //   4. pushResiduals(fetchedByEtypeId)
 //   5. extractTopK(maxPprNodes)
 class PPRForwardPush {
-   public:
+public:
     PPRForwardPush(const torch::Tensor& seedNodes,
-                        int32_t seedNodeTypeId,
-                        double alpha,
-                        double requeueThresholdFactor,
-                        std::vector<std::vector<int32_t>> nodeTypeToEdgeTypeIds,
-                        std::vector<int32_t> edgeTypeToDstNtypeId,
-                        std::vector<torch::Tensor> degreeTensors);
+                   int32_t seedNodeTypeId,
+                   double alpha,
+                   double requeueThresholdFactor,
+                   std::vector<std::vector<int32_t>> nodeTypeToEdgeTypeIds,
+                   std::vector<int32_t> edgeTypeToDstNtypeId,
+                   std::vector<torch::Tensor> degreeTensors);
 
     // Drain queued nodes and return {etype_id: int64 node tensor} for neighbor lookup.
     // Returns nullopt when the queue is empty (convergence). Empty map means all nodes
@@ -53,30 +57,36 @@ class PPRForwardPush {
 
     // Push residuals given fetched neighbor data.
     // fetchedByEtypeId: {etype_id: (node_ids[N], flat_nbrs[sum(counts)], counts[N])}
-    void pushResiduals(const std::unordered_map<
-                       int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>&
-                           fetchedByEtypeId);
+    void pushResiduals(const NeighborFetchMap& fetchedByEtypeId);
 
     // Return top-k PPR nodes per seed per node type.
     // Result: {ntype_id: (flat_ids, flat_weights, valid_counts)} — one entry per node type,
     // including types unreachable in this batch (empty tensors, all-zero valid_counts).
-    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>
-    extractTopK(int32_t maxPprNodes);
+    PPRExtractResult extractTopK(int32_t maxPprNodes);
 
-   private:
+    // Return top-k PPR nodes, then append residual-mass top-up nodes.
+    //
+    // Residual top-up does not issue new neighbor fetches.  It only reads the
+    // residual table already built by Forward Push.  Scores are emitted on the
+    // same mass scale as PPR scores: ppr_score(node) + residual(node), i.e. the
+    // score the node would have if the remaining residual at that node were
+    // absorbed locally.
+    PPRExtractResult extractTopKWithResidualTopUp(int32_t maxPprNodes, int32_t maxResidualNodes);
+
+private:
     // Total out-degree of a node across all edge types. Returns 0 for sink nodes.
     [[nodiscard]] int32_t getTotalDegree(int32_t nodeId, int32_t nodeTypeId) const;
 
     double _alpha;
-    double _requeueThresholdFactor;  // alpha * eps; per-node requeue threshold = factor * degree
+    double _requeueThresholdFactor; // alpha * eps; per-node requeue threshold = factor * degree
 
     // NOTE: int32_t is used for batch size, node IDs, and type IDs throughout this class.
     // All of this code will break silently (overflow) if batch size or node IDs exceed ~2B
     // (INT32_MAX = 2,147,483,647).  This is not a realistic concern today, but if graph
     // scale ever approaches that threshold, these should be widened to int64_t.
-    int32_t _batchSize;       // number of seed nodes in the current batch
-    int32_t _numNodeTypes;    // total distinct node types (1 for homogeneous graphs)
-    int32_t _numNodesInQueue{0};  // running count of queued nodes across all seeds and types
+    int32_t _batchSize;          // number of seed nodes in the current batch
+    int32_t _numNodeTypes;       // total distinct node types (1 for homogeneous graphs)
+    int32_t _numNodesInQueue{0}; // running count of queued nodes across all seeds and types
 
     // Graph structure — set at construction, read-only during the algorithm.
     // _nodeTypeToEdgeTypeIds[ntype_id] → list of edge type IDs that originate from that node type.
@@ -102,7 +112,6 @@ class PPRForwardPush {
     // Hash map: nodeId is a sparse graph ID from a large graph, so a dense array is
     // impractical (contrast with _state above).  Populated incrementally; avoids re-fetching.
     std::unordered_map<uint64_t, std::vector<int32_t>> _neighborCache;
-
 };
 
-}  // namespace gigl
+} // namespace gigl

--- a/gigl-core/core/sampling/python_ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/python_ppr_forward_push.cpp
@@ -21,7 +21,7 @@ namespace gigl {
 // pybind11/stl.h handles all type conversions automatically; the other methods use
 // direct member function pointers for the same reason.
 static void pushResidualsWrapper(PPRForwardPush& state, const py::dict& fetchedByEtypeId) {
-    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> neighborTensorsByEtypeId;
+    NeighborFetchMap neighborTensorsByEtypeId;
     // Dict iteration touches Python objects — GIL must be held here.
     for (auto item : fetchedByEtypeId) {
         auto edgeTypeId = item.first.cast<int32_t>();
@@ -57,5 +57,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                       std::vector<torch::Tensor>>())
         .def("drain_queue", &gigl::PPRForwardPush::drainQueue)
         .def("push_residuals", gigl::pushResidualsWrapper)
-        .def("extract_top_k", &gigl::PPRForwardPush::extractTopK);
+        .def("extract_top_k", &gigl::PPRForwardPush::extractTopK)
+        .def("extract_top_k_with_residual_top_up", &gigl::PPRForwardPush::extractTopKWithResidualTopUp);
 }

--- a/gigl-core/src/gigl_core/ppr_forward_push.pyi
+++ b/gigl-core/src/gigl_core/ppr_forward_push.pyi
@@ -1,5 +1,9 @@
 import torch
 
+TensorTriplet = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+ExtractResult = dict[int, TensorTriplet]
+
+
 class PPRForwardPush:
     def __init__(
         self,
@@ -12,10 +16,10 @@ class PPRForwardPush:
         degree_tensors: list[torch.Tensor],
     ) -> None: ...
     def drain_queue(self) -> dict[int, torch.Tensor] | None: ...
-    def push_residuals(
+    def push_residuals(self, fetched_by_etype_id: dict[int, TensorTriplet]) -> None: ...
+    def extract_top_k(self, max_ppr_nodes: int) -> ExtractResult: ...
+    def extract_top_k_with_residual_top_up(
         self,
-        fetched_by_etype_id: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
-    ) -> None: ...
-    def extract_top_k(
-        self, max_ppr_nodes: int
-    ) -> dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: ...
+        max_ppr_nodes: int,
+        max_residual_nodes: int,
+    ) -> ExtractResult: ...

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -1,31 +1,31 @@
 #include <gtest/gtest.h>
 #include "sampling/ppr_forward_push.h"
 
+#include <unordered_map>
+
 using gigl::PPRForwardPush;
 
 // Builds a single-edge-type, single-node-type PPRForwardPush.
-static PPRForwardPush makeState(
-    const std::vector<int64_t>& seeds,
-    double alpha,
-    double requeueThresholdFactor,
-    const std::vector<int32_t>& degrees) {
-    return PPRForwardPush(
-        torch::tensor(seeds, torch::kLong),
-        /*seedNodeTypeId=*/0,
-        alpha,
-        requeueThresholdFactor,
-        /*nodeTypeToEdgeTypeIds=*/{{0}},
-        /*edgeTypeToDstNtypeId=*/{0},
-        {torch::tensor(degrees, torch::kInt)});
+static PPRForwardPush makeState(const std::vector<int64_t>& seeds,
+                                double alpha,
+                                double requeueThresholdFactor,
+                                const std::vector<int32_t>& degrees) {
+    return PPRForwardPush(torch::tensor(seeds, torch::kLong),
+                          /*seedNodeTypeId=*/0,
+                          alpha,
+                          requeueThresholdFactor,
+                          /*nodeTypeToEdgeTypeIds=*/{{0}},
+                          /*edgeTypeToDstNtypeId=*/{0},
+                          {torch::tensor(degrees, torch::kInt)});
 }
 
 // Convenience wrapper: build the fetchedByEtypeId argument for pushResiduals
 // from flat vectors, keeping test call sites readable.
-static std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>
-makeFetched(int32_t edgeTypeId,
-            const std::vector<int64_t>& nodeIds,
-            const std::vector<int64_t>& flatNeighborIds,
-            const std::vector<int64_t>& counts) {
+static std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> makeFetched(
+    int32_t edgeTypeId,
+    const std::vector<int64_t>& nodeIds,
+    const std::vector<int64_t>& flatNeighborIds,
+    const std::vector<int64_t>& counts) {
     return {{edgeTypeId,
              {torch::tensor(nodeIds, torch::kLong),
               torch::tensor(flatNeighborIds, torch::kLong),
@@ -89,6 +89,27 @@ TEST(PPRForwardPush, ResidualDistributedToNeighbor) {
     EXPECT_NEAR(weights[1].item<float>(), static_cast<float>((1.0 - alpha) * alpha), 1e-5F);
 }
 
+// Once a (node, edge type) neighbor list is fetched, it should be cached for the
+// rest of the PPR state. In a cycle, revisiting node 0 should therefore require
+// no second lookup for node 0.
+TEST(PPRForwardPush, NeighborCacheAvoidsRefetchingPreviouslyFetchedNode) {
+    auto state = makeState(/*seeds=*/{0}, /*alpha=*/0.5, /*requeueThresholdFactor=*/1e-9, /*degrees=*/{1, 1});
+
+    state.drainQueue();
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1}, /*counts=*/{1}));
+
+    auto iter2 = state.drainQueue();
+    ASSERT_TRUE(iter2.has_value());
+    ASSERT_NE(iter2->find(0), iter2->end());
+    ASSERT_EQ(iter2->at(0).size(0), 1);
+    EXPECT_EQ(iter2->at(0)[0].item<int64_t>(), 1);
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{1}, /*flatNeighborIds=*/{0}, /*counts=*/{1}));
+
+    auto iter3 = state.drainQueue();
+    ASSERT_TRUE(iter3.has_value());
+    EXPECT_TRUE(iter3->empty());
+}
+
 // Two seeds (0 and 1) both push residual to sink node 2.  The neighbor-lookup
 // request must deduplicate to one entry for node 2, yet both seeds must still
 // accumulate a PPR score for it.
@@ -96,13 +117,14 @@ TEST(PPRForwardPush, DeduplicatesNodesAcrossSeeds) {
     auto state = makeState(/*seeds=*/{0, 1}, /*alpha=*/0.15, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{1, 1, 0});
 
     state.drainQueue();
-    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0, 1}, /*flatNeighborIds=*/{2, 2}, /*counts=*/{1, 1}));
+    state.pushResiduals(
+        makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0, 1}, /*flatNeighborIds=*/{2, 2}, /*counts=*/{1, 1}));
 
     auto iter2 = state.drainQueue();
     ASSERT_TRUE(iter2.has_value());
     const auto& iter2Map = iter2.value();
     ASSERT_NE(iter2Map.find(0), iter2Map.end());
-    EXPECT_EQ(iter2Map.at(0).size(0), 1);  // node 2 deduplicated in the lookup request
+    EXPECT_EQ(iter2Map.at(0).size(0), 1); // node 2 deduplicated in the lookup request
 
     state.pushResiduals({});
     EXPECT_FALSE(state.drainQueue().has_value());
@@ -111,12 +133,12 @@ TEST(PPRForwardPush, DeduplicatesNodesAcrossSeeds) {
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     // Each seed (batch indices 0 and 1) should have 2 nodes in its top-k.
-    EXPECT_EQ(counts[0].item<int64_t>(), 2);  // seed 0: nodes {0, 2}
-    EXPECT_EQ(counts[1].item<int64_t>(), 2);  // seed 1: nodes {1, 2}
+    EXPECT_EQ(counts[0].item<int64_t>(), 2); // seed 0: nodes {0, 2}
+    EXPECT_EQ(counts[1].item<int64_t>(), 2); // seed 1: nodes {1, 2}
     // The flat id layout is [seed0_top1, seed0_top2, seed1_top1, seed1_top2].
     // Within each seed the highest scorer comes first, so seed-node beats node 2.
-    EXPECT_EQ(ids[1].item<int64_t>(), 2);  // seed 0's second node is node 2
-    EXPECT_EQ(ids[3].item<int64_t>(), 2);  // seed 1's second node is node 2
+    EXPECT_EQ(ids[1].item<int64_t>(), 2); // seed 0's second node is node 2
+    EXPECT_EQ(ids[3].item<int64_t>(), 2); // seed 1's second node is node 2
 }
 
 // extractTopK respects the maxPprNodes limit.
@@ -135,4 +157,35 @@ TEST(PPRForwardPush, ExtractTopKLimitsResults) {
     auto topk10 = state.extractTopK(10);
     ASSERT_NE(topk10.find(0), topk10.end());
     EXPECT_EQ(std::get<2>(topk10.at(0))[0].item<int64_t>(), 2);
+}
+
+// Residual top-up appends discovered nodes whose residual never crossed the
+// requeue threshold, without changing the default extractTopK behavior.
+TEST(PPRForwardPush, ExtractTopKWithResidualTopUpAppendsUnpushedResiduals) {
+    const double alpha = 0.5;
+    auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1.0, /*degrees=*/{2, 1, 1});
+
+    state.drainQueue();
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1, 2}, /*counts=*/{2}));
+    EXPECT_FALSE(state.drainQueue().has_value());
+
+    auto topk = state.extractTopK(10);
+    ASSERT_NE(topk.find(0), topk.end());
+    EXPECT_EQ(std::get<2>(topk.at(0))[0].item<int64_t>(), 1);
+    EXPECT_EQ(std::get<0>(topk.at(0))[0].item<int64_t>(), 0);
+
+    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/1, /*maxResidualNodes=*/2);
+    ASSERT_NE(topkWithResiduals.find(0), topkWithResiduals.end());
+    const auto& [ids, weights, counts] = topkWithResiduals.at(0);
+    ASSERT_EQ(counts[0].item<int64_t>(), 3);
+    EXPECT_EQ(ids[0].item<int64_t>(), 0);
+    EXPECT_NEAR(weights[0].item<float>(), static_cast<float>(alpha), 1e-5F);
+
+    std::unordered_map<int64_t, float> residualWeights;
+    residualWeights[ids[1].item<int64_t>()] = weights[1].item<float>();
+    residualWeights[ids[2].item<int64_t>()] = weights[2].item<float>();
+    ASSERT_NE(residualWeights.find(1), residualWeights.end());
+    ASSERT_NE(residualWeights.find(2), residualWeights.end());
+    EXPECT_NEAR(residualWeights[1], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
+    EXPECT_NEAR(residualWeights[2], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
 }


### PR DESCRIPTION
## Summary

Adds an opt-in residual top-up extraction API to `PPRForwardPush`.

The existing `extractTopK` behavior is unchanged. The new API returns the normal top-k finalized PPR nodes first, then appends additional candidates from residual mass that was discovered during forward push but did not necessarily cross the requeue threshold. This gives downstream samplers a way to fill more sequence slots without issuing extra neighbor fetches.

## Changes

- Adds `extractTopKWithResidualTopUp(maxPprNodes, maxResidualNodes)` in C++.
- Exposes the new method through pybind and the Python stub.
- Scores residual top-up candidates on the same scale as finalized candidates via `ppr_score + residual`.
- Improves neighbor cache behavior so previously fetched `(node, edge type)` neighbor lists are reused within a PPR state.
- Adds C++ tests for neighbor cache reuse and residual top-up extraction.