### PR TITLE
Add residual top-up extraction to PPR forward push

### DIFF
--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -287,7 +287,7 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
             const int32_t topK = std::min(maxPPRNodes, static_cast<int32_t>(scores.size()));
             const int32_t residualTopUpBudget = enableResidualTopUp ? maxPPRNodes - topK : 0;
             std::vector<std::pair<int32_t, double>> selectedPairs;
-            selectedPairs.reserve(static_cast<size_t>(topK + residualTopUpBudget));
+            selectedPairs.reserve(static_cast<size_t>(topK) + static_cast<size_t>(residualTopUpBudget));
             std::unordered_set<int32_t> selectedPPRNodeIds;
             if (topK > 0) {
                 if (residualTopUpBudget > 0) {

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -146,8 +146,7 @@ std::optional<std::unordered_map<int32_t, torch::Tensor>> PPRForwardPush::drainQ
     return result;
 }
 
-void PPRForwardPush::pushResiduals(
-    const std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>& fetchedByEtypeId) {
+void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
     // Step 1: Persist fetched neighbor lists in the per-state cache. drainQueue()
     // consults this cache before requesting future lookups, so storing every
     // fetched row here avoids re-fetching a (node, edge type) pair if it re-enters
@@ -265,9 +264,15 @@ void PPRForwardPush::pushResiduals(
     }
 }
 
-std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> PPRForwardPush::extractTopK(
-    int32_t maxPprNodes) {
-    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> result;
+PPRExtractResult PPRForwardPush::extractTopK(int32_t maxPprNodes) {
+    return extractTopKWithResidualTopUp(maxPprNodes, /*maxResidualNodes=*/0);
+}
+
+PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNodes, int32_t maxResidualNodes) {
+    TORCH_CHECK(maxPprNodes >= 0, "maxPprNodes must be non-negative, got ", maxPprNodes, ".");
+    TORCH_CHECK(maxResidualNodes >= 0, "maxResidualNodes must be non-negative, got ", maxResidualNodes, ".");
+
+    PPRExtractResult result;
     // Emit an entry for every node type, even if unreachable in this batch (empty tensors,
     // all-zero valid_counts).  This keeps the output shape consistent across batches so
     // downstream model architectures see a fixed set of PPR edge types every iteration.
@@ -277,9 +282,13 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
         std::vector<int64_t> validCounts;
 
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
-            const auto& scores = _state[seedIdx][nodeTypeId].pprScores;
+            const auto& nodeTypeState = _state[seedIdx][nodeTypeId];
+            const auto& scores = nodeTypeState.pprScores;
             int32_t topK = std::min(maxPprNodes, static_cast<int32_t>(scores.size()));
+            int32_t residualTopK = 0;
+            std::unordered_set<int32_t> selectedNodeIds;
             if (topK > 0) {
+                selectedNodeIds.reserve(static_cast<size_t>(topK));
                 std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
                 std::partial_sort(scorePairs.begin(),
                                   scorePairs.begin() + topK,
@@ -287,11 +296,44 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
                                   [](const auto& a, const auto& b) { return a.second > b.second; });
 
                 for (int32_t rankIdx = 0; rankIdx < topK; ++rankIdx) {
-                    flatIds.push_back(static_cast<int64_t>(scorePairs[rankIdx].first));
+                    int32_t nodeId = scorePairs[rankIdx].first;
+                    flatIds.push_back(static_cast<int64_t>(nodeId));
                     flatWeights.push_back(scorePairs[rankIdx].second);
+                    selectedNodeIds.insert(nodeId);
                 }
             }
-            validCounts.push_back(static_cast<int64_t>(topK));
+
+            if (maxResidualNodes > 0) {
+                std::vector<std::pair<int32_t, double>> residualPairs;
+                residualPairs.reserve(nodeTypeState.residuals.size());
+                for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
+                    if (residual <= 0.0 || selectedNodeIds.find(nodeId) != selectedNodeIds.end()) {
+                        continue;
+                    }
+
+                    auto scoreIter = scores.find(nodeId);
+                    double pprScore = (scoreIter != scores.end()) ? scoreIter->second : 0.0;
+                    double calibratedScore = pprScore + residual;
+                    if (calibratedScore <= 0.0) {
+                        continue;
+                    }
+                    residualPairs.emplace_back(nodeId, calibratedScore);
+                }
+
+                residualTopK = std::min(maxResidualNodes, static_cast<int32_t>(residualPairs.size()));
+                if (residualTopK > 0) {
+                    std::partial_sort(residualPairs.begin(),
+                                      residualPairs.begin() + residualTopK,
+                                      residualPairs.end(),
+                                      [](const auto& a, const auto& b) { return a.second > b.second; });
+
+                    for (int32_t rankIdx = 0; rankIdx < residualTopK; ++rankIdx) {
+                        flatIds.push_back(static_cast<int64_t>(residualPairs[rankIdx].first));
+                        flatWeights.push_back(residualPairs[rankIdx].second);
+                    }
+                }
+            }
+            validCounts.push_back(static_cast<int64_t>(topK + residualTopK));
         }
 
         result[nodeTypeId] = {torch::tensor(flatIds, torch::kLong),

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -267,10 +267,16 @@ void PPRForwardPush::pushResiduals(
 }
 
 std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> PPRForwardPush::
-    extractTopKWithResidualTopUp(int32_t maxPprNodes, int32_t maxResidualNodes, int32_t maxTotalNodes) {
-    TORCH_CHECK(maxPprNodes >= 0, "maxPprNodes must be non-negative, got ", maxPprNodes, ".");
+    extractTopKWithResidualTopUp(int32_t maxPPRNodes, int32_t maxResidualNodes, int32_t maxTotalNodes) {
+    TORCH_CHECK(maxPPRNodes >= 0, "maxPPRNodes must be non-negative, got ", maxPPRNodes, ".");
     TORCH_CHECK(maxResidualNodes >= 0, "maxResidualNodes must be non-negative, got ", maxResidualNodes, ".");
     TORCH_CHECK(maxTotalNodes >= -1, "maxTotalNodes must be >= -1 (-1 means unbounded), got ", maxTotalNodes, ".");
+    TORCH_CHECK(maxTotalNodes == -1 || maxTotalNodes >= maxPPRNodes,
+                "maxTotalNodes must be -1 or >= maxPPRNodes, got maxTotalNodes=",
+                maxTotalNodes,
+                " and maxPPRNodes=",
+                maxPPRNodes,
+                ".");
 
     std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> result;
     // Emit an entry for every node type, even if unreachable in this batch (empty tensors,
@@ -284,10 +290,8 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
             const auto& nodeTypeState = _state[seedIdx][nodeTypeId];
             const auto& scores = nodeTypeState.pprScores;
-            int32_t pprNodeLimit = maxPprNodes;
-            int32_t totalNodeLimit = maxPprNodes + maxResidualNodes;
+            int32_t totalNodeLimit = maxPPRNodes + maxResidualNodes;
             if (maxTotalNodes >= 0) {
-                pprNodeLimit = std::min(maxPprNodes, maxTotalNodes);
                 totalNodeLimit = maxTotalNodes;
             }
             // With no residual top-up budget, emit finalized PPR scores as-is.
@@ -297,15 +301,15 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
             // sorted consistently.
             bool includeResidualMassInOutputScores = maxResidualNodes > 0;
 
-            int32_t topK = std::min(pprNodeLimit, static_cast<int32_t>(scores.size()));
+            int32_t topK = std::min(maxPPRNodes, static_cast<int32_t>(scores.size()));
             int32_t residualBudget = std::min(maxResidualNodes, std::max<int32_t>(0, totalNodeLimit - topK));
             int32_t residualTopK = 0;
             std::vector<std::pair<int32_t, double>> selectedPairs;
             selectedPairs.reserve(static_cast<size_t>(topK + residualBudget));
-            std::unordered_set<int32_t> selectedNodeIds;
+            std::unordered_set<int32_t> selectedPPRNodeIds;
             if (topK > 0) {
                 if (residualBudget > 0) {
-                    selectedNodeIds.reserve(static_cast<size_t>(topK));
+                    selectedPPRNodeIds.reserve(static_cast<size_t>(topK));
                 }
                 std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
                 // Selection is intentionally two-phase: finalized nodes are selected
@@ -328,7 +332,7 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
                     }
                     selectedPairs.emplace_back(nodeId, outputScore);
                     if (residualBudget > 0) {
-                        selectedNodeIds.insert(nodeId);
+                        selectedPPRNodeIds.insert(nodeId);
                     }
                 }
             }
@@ -337,7 +341,7 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
                 std::vector<std::pair<int32_t, double>> residualPairs;
                 residualPairs.reserve(nodeTypeState.residuals.size());
                 for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
-                    if (residual <= 0.0 || selectedNodeIds.find(nodeId) != selectedNodeIds.end()) {
+                    if (residual <= 0.0 || selectedPPRNodeIds.find(nodeId) != selectedPPRNodeIds.end()) {
                         continue;
                     }
 

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -294,6 +294,7 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
                 pprNodeLimit = std::min(maxPprNodes, maxTotalNodes);
                 totalNodeLimit = maxTotalNodes;
             }
+            bool emitCalibratedScores = maxResidualNodes > 0;
 
             int32_t topK = std::min(pprNodeLimit, static_cast<int32_t>(scores.size()));
             int32_t residualBudget = std::min(maxResidualNodes, std::max<int32_t>(0, totalNodeLimit - topK));
@@ -313,7 +314,14 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
 
                 for (int32_t rankIdx = 0; rankIdx < topK; ++rankIdx) {
                     int32_t nodeId = scorePairs[rankIdx].first;
-                    selectedPairs.emplace_back(nodeId, scorePairs[rankIdx].second);
+                    double calibratedScore = scorePairs[rankIdx].second;
+                    if (emitCalibratedScores) {
+                        auto residualIter = nodeTypeState.residuals.find(nodeId);
+                        if (residualIter != nodeTypeState.residuals.end()) {
+                            calibratedScore += residualIter->second;
+                        }
+                    }
+                    selectedPairs.emplace_back(nodeId, calibratedScore);
                     if (residualBudget > 0) {
                         selectedNodeIds.insert(nodeId);
                     }
@@ -350,11 +358,10 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
                 }
             }
 
-            if (topK > 0 && residualTopK > 0) {
-                std::sort(
-                    selectedPairs.begin(), selectedPairs.end(), [](const auto& a, const auto& b) {
-                        return a.second > b.second;
-                    });
+            if (emitCalibratedScores && selectedPairs.size() > 1) {
+                std::sort(selectedPairs.begin(), selectedPairs.end(), [](const auto& a, const auto& b) {
+                    return a.second > b.second;
+                });
             }
             for (const auto& [nodeId, score] : selectedPairs) {
                 flatIds.push_back(static_cast<int64_t>(nodeId));

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -147,7 +147,8 @@ std::optional<std::unordered_map<int32_t, torch::Tensor>> PPRForwardPush::drainQ
     return result;
 }
 
-void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
+void PPRForwardPush::pushResiduals(
+    const std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>& fetchedByEtypeId) {
     // Step 1: Persist fetched neighbor lists in the per-state cache. drainQueue()
     // consults this cache before requesting future lookups, so storing every
     // fetched row here avoids re-fetching a (node, edge type) pair if it re-enters
@@ -265,18 +266,13 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
     }
 }
 
-PPRExtractResult PPRForwardPush::extractTopK(int32_t maxPprNodes) {
-    return extractTopKWithResidualTopUp(maxPprNodes, /*maxResidualNodes=*/0);
-}
-
-PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNodes,
-                                                              int32_t maxResidualNodes,
-                                                              int32_t maxTotalNodes) {
+std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> PPRForwardPush::
+    extractTopKWithResidualTopUp(int32_t maxPprNodes, int32_t maxResidualNodes, int32_t maxTotalNodes) {
     TORCH_CHECK(maxPprNodes >= 0, "maxPprNodes must be non-negative, got ", maxPprNodes, ".");
     TORCH_CHECK(maxResidualNodes >= 0, "maxResidualNodes must be non-negative, got ", maxResidualNodes, ".");
-    TORCH_CHECK(maxTotalNodes >= -1, "maxTotalNodes must be -1 or non-negative, got ", maxTotalNodes, ".");
+    TORCH_CHECK(maxTotalNodes >= -1, "maxTotalNodes must be >= -1 (-1 means unbounded), got ", maxTotalNodes, ".");
 
-    PPRExtractResult result;
+    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> result;
     // Emit an entry for every node type, even if unreachable in this batch (empty tensors,
     // all-zero valid_counts).  This keeps the output shape consistent across batches so
     // downstream model architectures see a fixed set of PPR edge types every iteration.
@@ -294,7 +290,12 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
                 pprNodeLimit = std::min(maxPprNodes, maxTotalNodes);
                 totalNodeLimit = maxTotalNodes;
             }
-            bool emitCalibratedScores = maxResidualNodes > 0;
+            // With no residual top-up budget, emit finalized PPR scores as-is.
+            // When residual top-up is enabled, residual candidates are scored as
+            // ppr_score + residual; selected finalized PPR nodes must use that
+            // same output score scale so the merged list is comparable and
+            // sorted consistently.
+            bool includeResidualMassInOutputScores = maxResidualNodes > 0;
 
             int32_t topK = std::min(pprNodeLimit, static_cast<int32_t>(scores.size()));
             int32_t residualBudget = std::min(maxResidualNodes, std::max<int32_t>(0, totalNodeLimit - topK));
@@ -307,6 +308,10 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
                     selectedNodeIds.reserve(static_cast<size_t>(topK));
                 }
                 std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
+                // Selection is intentionally two-phase: finalized nodes are selected
+                // first by raw PPR score, and residual candidates only compete for
+                // the remaining budget. After selection, rows are emitted and sorted
+                // by outputScore.
                 std::partial_sort(scorePairs.begin(),
                                   scorePairs.begin() + topK,
                                   scorePairs.end(),
@@ -314,14 +319,14 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
 
                 for (int32_t rankIdx = 0; rankIdx < topK; ++rankIdx) {
                     int32_t nodeId = scorePairs[rankIdx].first;
-                    double calibratedScore = scorePairs[rankIdx].second;
-                    if (emitCalibratedScores) {
+                    double outputScore = scorePairs[rankIdx].second;
+                    if (includeResidualMassInOutputScores) {
                         auto residualIter = nodeTypeState.residuals.find(nodeId);
                         if (residualIter != nodeTypeState.residuals.end()) {
-                            calibratedScore += residualIter->second;
+                            outputScore += residualIter->second;
                         }
                     }
-                    selectedPairs.emplace_back(nodeId, calibratedScore);
+                    selectedPairs.emplace_back(nodeId, outputScore);
                     if (residualBudget > 0) {
                         selectedNodeIds.insert(nodeId);
                     }
@@ -338,11 +343,8 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
 
                     auto scoreIter = scores.find(nodeId);
                     double pprScore = (scoreIter != scores.end()) ? scoreIter->second : 0.0;
-                    double calibratedScore = pprScore + residual;
-                    if (calibratedScore <= 0.0) {
-                        continue;
-                    }
-                    residualPairs.emplace_back(nodeId, calibratedScore);
+                    double outputScore = pprScore + residual;
+                    residualPairs.emplace_back(nodeId, outputScore);
                 }
 
                 residualTopK = std::min(residualBudget, static_cast<int32_t>(residualPairs.size()));
@@ -358,7 +360,7 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
                 }
             }
 
-            if (emitCalibratedScores && selectedPairs.size() > 1) {
+            if (includeResidualMassInOutputScores && selectedPairs.size() > 1) {
                 std::sort(selectedPairs.begin(), selectedPairs.end(), [](const auto& a, const auto& b) {
                     return a.second > b.second;
                 });

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -2,6 +2,7 @@
 
 #include <torch/torch.h>
 
+#include <algorithm>
 #include <climits>
 #include <cstdint>
 #include <optional>
@@ -297,6 +298,8 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
             int32_t topK = std::min(pprNodeLimit, static_cast<int32_t>(scores.size()));
             int32_t residualBudget = std::min(maxResidualNodes, std::max<int32_t>(0, totalNodeLimit - topK));
             int32_t residualTopK = 0;
+            std::vector<std::pair<int32_t, double>> selectedPairs;
+            selectedPairs.reserve(static_cast<size_t>(topK + residualBudget));
             std::unordered_set<int32_t> selectedNodeIds;
             if (topK > 0) {
                 if (residualBudget > 0) {
@@ -310,8 +313,7 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
 
                 for (int32_t rankIdx = 0; rankIdx < topK; ++rankIdx) {
                     int32_t nodeId = scorePairs[rankIdx].first;
-                    flatIds.push_back(static_cast<int64_t>(nodeId));
-                    flatWeights.push_back(scorePairs[rankIdx].second);
+                    selectedPairs.emplace_back(nodeId, scorePairs[rankIdx].second);
                     if (residualBudget > 0) {
                         selectedNodeIds.insert(nodeId);
                     }
@@ -343,12 +345,22 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
                                       [](const auto& a, const auto& b) { return a.second > b.second; });
 
                     for (int32_t rankIdx = 0; rankIdx < residualTopK; ++rankIdx) {
-                        flatIds.push_back(static_cast<int64_t>(residualPairs[rankIdx].first));
-                        flatWeights.push_back(residualPairs[rankIdx].second);
+                        selectedPairs.emplace_back(residualPairs[rankIdx].first, residualPairs[rankIdx].second);
                     }
                 }
             }
-            validCounts.push_back(static_cast<int64_t>(topK + residualTopK));
+
+            if (topK > 0 && residualTopK > 0) {
+                std::sort(
+                    selectedPairs.begin(), selectedPairs.end(), [](const auto& a, const auto& b) {
+                        return a.second > b.second;
+                    });
+            }
+            for (const auto& [nodeId, score] : selectedPairs) {
+                flatIds.push_back(static_cast<int64_t>(nodeId));
+                flatWeights.push_back(score);
+            }
+            validCounts.push_back(static_cast<int64_t>(selectedPairs.size()));
         }
 
         result[nodeTypeId] = {torch::tensor(flatIds, torch::kLong),

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -268,9 +268,12 @@ PPRExtractResult PPRForwardPush::extractTopK(int32_t maxPprNodes) {
     return extractTopKWithResidualTopUp(maxPprNodes, /*maxResidualNodes=*/0);
 }
 
-PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNodes, int32_t maxResidualNodes) {
+PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNodes,
+                                                              int32_t maxResidualNodes,
+                                                              int32_t maxTotalNodes) {
     TORCH_CHECK(maxPprNodes >= 0, "maxPprNodes must be non-negative, got ", maxPprNodes, ".");
     TORCH_CHECK(maxResidualNodes >= 0, "maxResidualNodes must be non-negative, got ", maxResidualNodes, ".");
+    TORCH_CHECK(maxTotalNodes >= -1, "maxTotalNodes must be -1 or non-negative, got ", maxTotalNodes, ".");
 
     PPRExtractResult result;
     // Emit an entry for every node type, even if unreachable in this batch (empty tensors,
@@ -284,11 +287,21 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
             const auto& nodeTypeState = _state[seedIdx][nodeTypeId];
             const auto& scores = nodeTypeState.pprScores;
-            int32_t topK = std::min(maxPprNodes, static_cast<int32_t>(scores.size()));
+            int32_t pprNodeLimit = maxPprNodes;
+            int32_t totalNodeLimit = maxPprNodes + maxResidualNodes;
+            if (maxTotalNodes >= 0) {
+                pprNodeLimit = std::min(maxPprNodes, maxTotalNodes);
+                totalNodeLimit = maxTotalNodes;
+            }
+
+            int32_t topK = std::min(pprNodeLimit, static_cast<int32_t>(scores.size()));
+            int32_t residualBudget = std::min(maxResidualNodes, std::max<int32_t>(0, totalNodeLimit - topK));
             int32_t residualTopK = 0;
             std::unordered_set<int32_t> selectedNodeIds;
             if (topK > 0) {
-                selectedNodeIds.reserve(static_cast<size_t>(topK));
+                if (residualBudget > 0) {
+                    selectedNodeIds.reserve(static_cast<size_t>(topK));
+                }
                 std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
                 std::partial_sort(scorePairs.begin(),
                                   scorePairs.begin() + topK,
@@ -299,11 +312,13 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
                     int32_t nodeId = scorePairs[rankIdx].first;
                     flatIds.push_back(static_cast<int64_t>(nodeId));
                     flatWeights.push_back(scorePairs[rankIdx].second);
-                    selectedNodeIds.insert(nodeId);
+                    if (residualBudget > 0) {
+                        selectedNodeIds.insert(nodeId);
+                    }
                 }
             }
 
-            if (maxResidualNodes > 0) {
+            if (residualBudget > 0) {
                 std::vector<std::pair<int32_t, double>> residualPairs;
                 residualPairs.reserve(nodeTypeState.residuals.size());
                 for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
@@ -320,7 +335,7 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPprNode
                     residualPairs.emplace_back(nodeId, calibratedScore);
                 }
 
-                residualTopK = std::min(maxResidualNodes, static_cast<int32_t>(residualPairs.size()));
+                residualTopK = std::min(residualBudget, static_cast<int32_t>(residualPairs.size()));
                 if (residualTopK > 0) {
                     std::partial_sort(residualPairs.begin(),
                                       residualPairs.begin() + residualTopK,

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -282,9 +282,7 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
             const auto& nodeTypeState = _state[seedIdx][nodeTypeId];
             const auto& scores = nodeTypeState.pprScores;
-            const auto higherScore = [](const auto& a, const auto& b) {
-                return a.second > b.second;
-            };
+            const auto higherScore = [](const auto& a, const auto& b) { return a.second > b.second; };
 
             const int32_t topK = std::min(maxPPRNodes, static_cast<int32_t>(scores.size()));
             const int32_t residualTopUpBudget = enableResidualTopUp ? maxPPRNodes - topK : 0;
@@ -304,16 +302,10 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
                     // after top-up candidates are selected, so this pass only
                     // needs to partition out the raw-PPR top K.
                     if (topK < static_cast<int32_t>(scorePairs.size())) {
-                        std::nth_element(scorePairs.begin(),
-                                         scorePairs.begin() + topK,
-                                         scorePairs.end(),
-                                         higherScore);
+                        std::nth_element(scorePairs.begin(), scorePairs.begin() + topK, scorePairs.end(), higherScore);
                     }
                 } else {
-                    std::partial_sort(scorePairs.begin(),
-                                      scorePairs.begin() + topK,
-                                      scorePairs.end(),
-                                      higherScore);
+                    std::partial_sort(scorePairs.begin(), scorePairs.begin() + topK, scorePairs.end(), higherScore);
                 }
 
                 for (int32_t rankIdx = 0; rankIdx < topK; ++rankIdx) {
@@ -346,8 +338,7 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
                     residualPairs.emplace_back(nodeId, outputScore);
                 }
 
-                const int32_t residualTopK =
-                    std::min(residualTopUpBudget, static_cast<int32_t>(residualPairs.size()));
+                const int32_t residualTopK = std::min(residualTopUpBudget, static_cast<int32_t>(residualPairs.size()));
                 if (residualTopK > 0) {
                     // Residual candidates only need selection here; selected
                     // finalized and residual rows are sorted together below.

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -148,9 +148,10 @@ std::optional<std::unordered_map<int32_t, torch::Tensor>> PPRForwardPush::drainQ
 
 void PPRForwardPush::pushResiduals(
     const std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>& fetchedByEtypeId) {
-    // Step 1: Unpack the input map into a C++ map keyed by packKey(nodeId, edgeTypeId)
-    // for fast lookup during the residual-push loop below.
-    std::unordered_map<uint64_t, std::vector<int32_t>> fetched;
+    // Step 1: Persist fetched neighbor lists in the per-state cache. drainQueue()
+    // consults this cache before requesting future lookups, so storing every
+    // fetched row here avoids re-fetching a (node, edge type) pair if it re-enters
+    // the frontier later in the same PPR channel.
     for (const auto& [edgeTypeId, neighborTensors] : fetchedByEtypeId) {
         const auto& nodeIdsTensor = std::get<0>(neighborTensors);
         const auto& flatNeighborIdsTensor = std::get<1>(neighborTensors);
@@ -172,7 +173,10 @@ void PPRForwardPush::pushResiduals(
             for (int64_t neighborIdx = 0; neighborIdx < count; ++neighborIdx) {
                 neighborIds[neighborIdx] = static_cast<int32_t>(flatNeighborIdsAccessor[offset + neighborIdx]);
             }
-            fetched[packKey(nodeId, edgeTypeId)] = std::move(neighborIds);
+            uint64_t cacheKey = packKey(nodeId, edgeTypeId);
+            if (_neighborCache.find(cacheKey) == _neighborCache.end()) {
+                _neighborCache.emplace(cacheKey, std::move(neighborIds));
+            }
             offset += count;
         }
     }
@@ -197,21 +201,16 @@ void PPRForwardPush::pushResiduals(
                 srcNodeTypeState.pprScores[sourceNodeId] += sourceResidual;
                 srcNodeTypeState.residuals[sourceNodeId] = 0.0;
 
-                // b. Count total fetched/cached neighbors across all edge types for
+                // b. Count total cached neighbors across all edge types for
                 // this source node.  We normalise by the number of neighbors we
                 // actually retrieved, not the true degree, so residual is fully
                 // distributed among known neighbors rather than leaking to unfetched
                 // ones (which matters when num_neighbors_per_hop < true_degree).
-                int32_t totalFetched = 0;
+                int32_t totalCachedNeighbors = 0;
                 for (int32_t edgeTypeId : _nodeTypeToEdgeTypeIds[nodeTypeId]) {
-                    auto fetchedEntry = fetched.find(packKey(sourceNodeId, edgeTypeId));
-                    if (fetchedEntry != fetched.end()) {
-                        totalFetched += static_cast<int32_t>(fetchedEntry->second.size());
-                    } else {
-                        auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
-                        if (cachedEntry != _neighborCache.end()) {
-                            totalFetched += static_cast<int32_t>(cachedEntry->second.size());
-                        }
+                    auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
+                    if (cachedEntry != _neighborCache.end()) {
+                        totalCachedNeighbors += static_cast<int32_t>(cachedEntry->second.size());
                     }
                 }
                 // Two cases reach here:
@@ -221,32 +220,23 @@ void PPRForwardPush::pushResiduals(
                 //      This overstates src and understates its neighbors.  This is expected
                 //      behavior when max_fetch_iterations is set, which intentionally trades
                 //      theoretical PPR correctness for better throughput.
-                if (totalFetched == 0) {
+                if (totalCachedNeighbors == 0) {
                     continue;
                 }
 
-                double residualPerNeighbor = (1.0 - _alpha) * sourceResidual / static_cast<double>(totalFetched);
+                double residualPerNeighbor =
+                    (1.0 - _alpha) * sourceResidual / static_cast<double>(totalCachedNeighbors);
 
                 for (int32_t edgeTypeId : _nodeTypeToEdgeTypeIds[nodeTypeId]) {
-                    // Invariant: fetched and _neighborCache are mutually exclusive for
-                    // any given (node, etype) key within one iteration.  drainQueue()
-                    // only requests a fetch for nodes absent from _neighborCache, so a
-                    // key is in at most one of the two.
-                    //
                     // Neighbor list for this (src, edgeTypeId) pair, borrowed from whichever
                     // map holds it.  reference_wrapper is used because std::optional cannot
                     // hold a reference directly, and we want to avoid copying the vector —
-                    // the data already exists in fetched or _neighborCache and both outlive
-                    // this loop body.  Access via neighborList->get().
+                    // the data already exists in _neighborCache and outlives this loop body.
+                    // Access via neighborList->get().
                     std::optional<std::reference_wrapper<const std::vector<int32_t>>> neighborList;
-                    auto fetchedEntry = fetched.find(packKey(sourceNodeId, edgeTypeId));
-                    if (fetchedEntry != fetched.end()) {
-                        neighborList = std::cref(fetchedEntry->second);
-                    } else {
-                        auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
-                        if (cachedEntry != _neighborCache.end()) {
-                            neighborList = std::cref(cachedEntry->second);
-                        }
+                    auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
+                    if (cachedEntry != _neighborCache.end()) {
+                        neighborList = std::cref(cachedEntry->second);
                     }
                     if (!neighborList || neighborList->get().empty()) {
                         continue;
@@ -267,18 +257,6 @@ void PPRForwardPush::pushResiduals(
                             dstNodeTypeState.residuals[neighborNodeId] >= threshold) {
                             dstNodeTypeState.queue.insert(neighborNodeId);
                             ++_numNodesInQueue;
-
-                            // Promote neighbor lists to the persistent cache: this node will
-                            // be processed next iteration, so caching avoids a re-fetch.
-                            for (int32_t neighborEdgeTypeId : _nodeTypeToEdgeTypeIds[dstNodeTypeId]) {
-                                uint64_t packedKey = packKey(neighborNodeId, neighborEdgeTypeId);
-                                if (_neighborCache.find(packedKey) == _neighborCache.end()) {
-                                    auto fetchedNeighborEntry = fetched.find(packedKey);
-                                    if (fetchedNeighborEntry != fetched.end()) {
-                                        _neighborCache[packedKey] = fetchedNeighborEntry->second;
-                                    }
-                                }
-                            }
                         }
                     }
                 }

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -282,50 +282,57 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
             const auto& nodeTypeState = _state[seedIdx][nodeTypeId];
             const auto& scores = nodeTypeState.pprScores;
-            // With no residual top-up budget, emit finalized PPR scores as-is.
-            // When residual top-up is enabled, residual candidates are scored as
-            // ppr_score + residual; selected finalized PPR nodes must use that
-            // same output score scale so the merged list is comparable and
-            // sorted consistently.
-            bool includeResidualMassInOutputScores = enableResidualTopUp;
+            const auto higherScore = [](const auto& a, const auto& b) {
+                return a.second > b.second;
+            };
 
-            int32_t topK = std::min(maxPPRNodes, static_cast<int32_t>(scores.size()));
-            int32_t residualBudget = enableResidualTopUp ? std::max<int32_t>(0, maxPPRNodes - topK) : 0;
-            int32_t residualTopK = 0;
+            const int32_t topK = std::min(maxPPRNodes, static_cast<int32_t>(scores.size()));
+            const int32_t residualTopUpBudget = enableResidualTopUp ? maxPPRNodes - topK : 0;
             std::vector<std::pair<int32_t, double>> selectedPairs;
-            selectedPairs.reserve(static_cast<size_t>(topK + residualBudget));
+            selectedPairs.reserve(static_cast<size_t>(topK + residualTopUpBudget));
             std::unordered_set<int32_t> selectedPPRNodeIds;
             if (topK > 0) {
-                if (residualBudget > 0) {
+                if (residualTopUpBudget > 0) {
                     selectedPPRNodeIds.reserve(static_cast<size_t>(topK));
                 }
                 std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
                 // Selection is intentionally two-phase: finalized nodes are selected
                 // first by raw PPR score, and residual candidates only compete for
-                // the remaining budget. After selection, rows are emitted and sorted
-                // by outputScore.
-                std::partial_sort(scorePairs.begin(),
-                                  scorePairs.begin() + topK,
-                                  scorePairs.end(),
-                                  [](const auto& a, const auto& b) { return a.second > b.second; });
+                // the remaining budget.
+                if (enableResidualTopUp) {
+                    // The final emitted order is sorted by ppr_score + residual
+                    // after top-up candidates are selected, so this pass only
+                    // needs to partition out the raw-PPR top K.
+                    if (topK < static_cast<int32_t>(scorePairs.size())) {
+                        std::nth_element(scorePairs.begin(),
+                                         scorePairs.begin() + topK,
+                                         scorePairs.end(),
+                                         higherScore);
+                    }
+                } else {
+                    std::partial_sort(scorePairs.begin(),
+                                      scorePairs.begin() + topK,
+                                      scorePairs.end(),
+                                      higherScore);
+                }
 
                 for (int32_t rankIdx = 0; rankIdx < topK; ++rankIdx) {
                     int32_t nodeId = scorePairs[rankIdx].first;
                     double outputScore = scorePairs[rankIdx].second;
-                    if (includeResidualMassInOutputScores) {
+                    if (enableResidualTopUp) {
                         auto residualIter = nodeTypeState.residuals.find(nodeId);
                         if (residualIter != nodeTypeState.residuals.end()) {
                             outputScore += residualIter->second;
                         }
                     }
                     selectedPairs.emplace_back(nodeId, outputScore);
-                    if (residualBudget > 0) {
+                    if (residualTopUpBudget > 0) {
                         selectedPPRNodeIds.insert(nodeId);
                     }
                 }
             }
 
-            if (residualBudget > 0) {
+            if (residualTopUpBudget > 0) {
                 std::vector<std::pair<int32_t, double>> residualPairs;
                 residualPairs.reserve(nodeTypeState.residuals.size());
                 for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
@@ -339,12 +346,17 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
                     residualPairs.emplace_back(nodeId, outputScore);
                 }
 
-                residualTopK = std::min(residualBudget, static_cast<int32_t>(residualPairs.size()));
+                const int32_t residualTopK =
+                    std::min(residualTopUpBudget, static_cast<int32_t>(residualPairs.size()));
                 if (residualTopK > 0) {
-                    std::partial_sort(residualPairs.begin(),
-                                      residualPairs.begin() + residualTopK,
-                                      residualPairs.end(),
-                                      [](const auto& a, const auto& b) { return a.second > b.second; });
+                    // Residual candidates only need selection here; selected
+                    // finalized and residual rows are sorted together below.
+                    if (residualTopK < static_cast<int32_t>(residualPairs.size())) {
+                        std::nth_element(residualPairs.begin(),
+                                         residualPairs.begin() + residualTopK,
+                                         residualPairs.end(),
+                                         higherScore);
+                    }
 
                     for (int32_t rankIdx = 0; rankIdx < residualTopK; ++rankIdx) {
                         selectedPairs.emplace_back(residualPairs[rankIdx].first, residualPairs[rankIdx].second);
@@ -352,10 +364,8 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
                 }
             }
 
-            if (includeResidualMassInOutputScores && selectedPairs.size() > 1) {
-                std::sort(selectedPairs.begin(), selectedPairs.end(), [](const auto& a, const auto& b) {
-                    return a.second > b.second;
-                });
+            if (enableResidualTopUp && selectedPairs.size() > 1) {
+                std::sort(selectedPairs.begin(), selectedPairs.end(), higherScore);
             }
             for (const auto& [nodeId, score] : selectedPairs) {
                 flatIds.push_back(static_cast<int64_t>(nodeId));

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -267,16 +267,8 @@ void PPRForwardPush::pushResiduals(
 }
 
 std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> PPRForwardPush::
-    extractTopKWithResidualTopUp(int32_t maxPPRNodes, int32_t maxResidualNodes, int32_t maxTotalNodes) {
+    extractTopKWithResidualTopUp(int32_t maxPPRNodes, bool enableResidualTopUp) {
     TORCH_CHECK(maxPPRNodes >= 0, "maxPPRNodes must be non-negative, got ", maxPPRNodes, ".");
-    TORCH_CHECK(maxResidualNodes >= 0, "maxResidualNodes must be non-negative, got ", maxResidualNodes, ".");
-    TORCH_CHECK(maxTotalNodes >= -1, "maxTotalNodes must be >= -1 (-1 means unbounded), got ", maxTotalNodes, ".");
-    TORCH_CHECK(maxTotalNodes == -1 || maxTotalNodes >= maxPPRNodes,
-                "maxTotalNodes must be -1 or >= maxPPRNodes, got maxTotalNodes=",
-                maxTotalNodes,
-                " and maxPPRNodes=",
-                maxPPRNodes,
-                ".");
 
     std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> result;
     // Emit an entry for every node type, even if unreachable in this batch (empty tensors,
@@ -290,19 +282,15 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
             const auto& nodeTypeState = _state[seedIdx][nodeTypeId];
             const auto& scores = nodeTypeState.pprScores;
-            int32_t totalNodeLimit = maxPPRNodes + maxResidualNodes;
-            if (maxTotalNodes >= 0) {
-                totalNodeLimit = maxTotalNodes;
-            }
             // With no residual top-up budget, emit finalized PPR scores as-is.
             // When residual top-up is enabled, residual candidates are scored as
             // ppr_score + residual; selected finalized PPR nodes must use that
             // same output score scale so the merged list is comparable and
             // sorted consistently.
-            bool includeResidualMassInOutputScores = maxResidualNodes > 0;
+            bool includeResidualMassInOutputScores = enableResidualTopUp;
 
             int32_t topK = std::min(maxPPRNodes, static_cast<int32_t>(scores.size()));
-            int32_t residualBudget = std::min(maxResidualNodes, std::max<int32_t>(0, totalNodeLimit - topK));
+            int32_t residualBudget = enableResidualTopUp ? std::max<int32_t>(0, maxPPRNodes - topK) : 0;
             int32_t residualTopK = 0;
             std::vector<std::pair<int32_t, double>> selectedPairs;
             selectedPairs.reserve(static_cast<size_t>(topK + residualBudget));

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -20,11 +20,15 @@ namespace gigl {
 // not co-located in memory — only the control-plane metadata (size, bucket pointer)
 // lives inside the struct.
 struct SeedNodeTypeState {
-    std::unordered_map<int32_t, double> pprScores;   // absorbed PPR mass
-    std::unordered_map<int32_t, double> residuals;   // unabsorbed mass waiting to push
-    std::unordered_set<int32_t> queue;               // nodes queued for the next drain
-    std::unordered_set<int32_t> queuedNodes;         // snapshot captured by drainQueue()
+    std::unordered_map<int32_t, double> pprScores; // absorbed PPR mass
+    std::unordered_map<int32_t, double> residuals; // unabsorbed mass waiting to push
+    std::unordered_set<int32_t> queue;             // nodes queued for the next drain
+    std::unordered_set<int32_t> queuedNodes;       // snapshot captured by drainQueue()
 };
+
+using TensorTriplet = std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>;
+using NeighborFetchMap = std::unordered_map<int32_t, TensorTriplet>;
+using PPRExtractResult = std::unordered_map<int32_t, TensorTriplet>;
 
 // C++ kernel for PPR Forward Push (Andersen et al., 2006).
 // Hot-loop state lives here; distributed neighbor fetches are driven from Python.
@@ -37,14 +41,14 @@ struct SeedNodeTypeState {
 //   4. pushResiduals(fetchedByEtypeId)
 //   5. extractTopK(maxPprNodes)
 class PPRForwardPush {
-   public:
+public:
     PPRForwardPush(const torch::Tensor& seedNodes,
-                        int32_t seedNodeTypeId,
-                        double alpha,
-                        double requeueThresholdFactor,
-                        std::vector<std::vector<int32_t>> nodeTypeToEdgeTypeIds,
-                        std::vector<int32_t> edgeTypeToDstNtypeId,
-                        std::vector<torch::Tensor> degreeTensors);
+                   int32_t seedNodeTypeId,
+                   double alpha,
+                   double requeueThresholdFactor,
+                   std::vector<std::vector<int32_t>> nodeTypeToEdgeTypeIds,
+                   std::vector<int32_t> edgeTypeToDstNtypeId,
+                   std::vector<torch::Tensor> degreeTensors);
 
     // Drain queued nodes and return {etype_id: int64 node tensor} for neighbor lookup.
     // Returns nullopt when the queue is empty (convergence). Empty map means all nodes
@@ -53,30 +57,36 @@ class PPRForwardPush {
 
     // Push residuals given fetched neighbor data.
     // fetchedByEtypeId: {etype_id: (node_ids[N], flat_nbrs[sum(counts)], counts[N])}
-    void pushResiduals(const std::unordered_map<
-                       int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>&
-                           fetchedByEtypeId);
+    void pushResiduals(const NeighborFetchMap& fetchedByEtypeId);
 
     // Return top-k PPR nodes per seed per node type.
     // Result: {ntype_id: (flat_ids, flat_weights, valid_counts)} — one entry per node type,
     // including types unreachable in this batch (empty tensors, all-zero valid_counts).
-    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>
-    extractTopK(int32_t maxPprNodes);
+    PPRExtractResult extractTopK(int32_t maxPprNodes);
 
-   private:
+    // Return top-k PPR nodes, then append residual-mass top-up nodes.
+    //
+    // Residual top-up does not issue new neighbor fetches.  It only reads the
+    // residual table already built by Forward Push.  Scores are emitted on the
+    // same mass scale as PPR scores: ppr_score(node) + residual(node), i.e. the
+    // score the node would have if the remaining residual at that node were
+    // absorbed locally.
+    PPRExtractResult extractTopKWithResidualTopUp(int32_t maxPprNodes, int32_t maxResidualNodes);
+
+private:
     // Total out-degree of a node across all edge types. Returns 0 for sink nodes.
     [[nodiscard]] int32_t getTotalDegree(int32_t nodeId, int32_t nodeTypeId) const;
 
     double _alpha;
-    double _requeueThresholdFactor;  // alpha * eps; per-node requeue threshold = factor * degree
+    double _requeueThresholdFactor; // alpha * eps; per-node requeue threshold = factor * degree
 
     // NOTE: int32_t is used for batch size, node IDs, and type IDs throughout this class.
     // All of this code will break silently (overflow) if batch size or node IDs exceed ~2B
     // (INT32_MAX = 2,147,483,647).  This is not a realistic concern today, but if graph
     // scale ever approaches that threshold, these should be widened to int64_t.
-    int32_t _batchSize;       // number of seed nodes in the current batch
-    int32_t _numNodeTypes;    // total distinct node types (1 for homogeneous graphs)
-    int32_t _numNodesInQueue{0};  // running count of queued nodes across all seeds and types
+    int32_t _batchSize;          // number of seed nodes in the current batch
+    int32_t _numNodeTypes;       // total distinct node types (1 for homogeneous graphs)
+    int32_t _numNodesInQueue{0}; // running count of queued nodes across all seeds and types
 
     // Graph structure — set at construction, read-only during the algorithm.
     // _nodeTypeToEdgeTypeIds[ntype_id] → list of edge type IDs that originate from that node type.
@@ -102,7 +112,6 @@ class PPRForwardPush {
     // Hash map: nodeId is a sparse graph ID from a large graph, so a dense array is
     // impractical (contrast with _state above).  Populated incrementally; avoids re-fetching.
     std::unordered_map<uint64_t, std::vector<int32_t>> _neighborCache;
-
 };
 
-}  // namespace gigl
+} // namespace gigl

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -34,7 +34,7 @@ struct SeedNodeTypeState {
 //   2. drainQueue()                         → nodes needing neighbor lookup
 //   3. <Python: _batch_fetch_neighbors()>
 //   4. pushResiduals(fetchedByEtypeId)
-//   5. extractTopKWithResidualTopUp(maxPPRNodes, maxResidualNodes, maxTotalNodes)
+//   5. extractTopKWithResidualTopUp(maxPPRNodes, enableResidualTopUp)
 class PPRForwardPush {
 public:
     PPRForwardPush(const torch::Tensor& seedNodes,
@@ -67,14 +67,13 @@ public:
     // same mass scale as PPR scores: ppr_score(node) + residual(node), i.e. the
     // score the node would have if the remaining residual at that node were
     // absorbed locally.  Residual candidates only fill the requested top-up
-    // budget; they do not displace selected finalized-PPR nodes.  The returned
+    // budget; they do not displace selected finalized-PPR nodes. The returned
     // set is selected by this two-phase policy, then sorted by emitted score;
-    // it is not a global top-k over ppr_score + residual when maxTotalNodes is tight.
-    //
-    // maxTotalNodes caps finalized-PPR plus residual nodes per seed.  Pass -1
-    // to keep the uncapped "maxPPRNodes + maxResidualNodes" candidate behavior.
+    // it is not a global top-k over ppr_score + residual when maxPPRNodes is tight.
+    // maxPPRNodes is the final per-seed cap across finalized PPR and residual
+    // top-up candidates.
     std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> extractTopKWithResidualTopUp(
-        int32_t maxPPRNodes, int32_t maxResidualNodes, int32_t maxTotalNodes = -1);
+        int32_t maxPPRNodes, bool enableResidualTopUp);
 
 private:
     // Total out-degree of a node across all edge types. Returns 0 for sink nodes.

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -2,7 +2,6 @@
 
 #include <torch/torch.h>
 
-#include <algorithm>
 #include <cstdint>
 #include <optional>
 #include <tuple>
@@ -35,7 +34,7 @@ struct SeedNodeTypeState {
 //   2. drainQueue()                         → nodes needing neighbor lookup
 //   3. <Python: _batch_fetch_neighbors()>
 //   4. pushResiduals(fetchedByEtypeId)
-//   5. extractTopKWithResidualTopUp(maxPprNodes, maxResidualNodes, maxTotalNodes)
+//   5. extractTopKWithResidualTopUp(maxPPRNodes, maxResidualNodes, maxTotalNodes)
 class PPRForwardPush {
 public:
     PPRForwardPush(const torch::Tensor& seedNodes,
@@ -73,9 +72,9 @@ public:
     // it is not a global top-k over ppr_score + residual when maxTotalNodes is tight.
     //
     // maxTotalNodes caps finalized-PPR plus residual nodes per seed.  Pass -1
-    // to keep the uncapped "maxPprNodes + maxResidualNodes" candidate behavior.
+    // to keep the uncapped "maxPPRNodes + maxResidualNodes" candidate behavior.
     std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> extractTopKWithResidualTopUp(
-        int32_t maxPprNodes, int32_t maxResidualNodes, int32_t maxTotalNodes = -1);
+        int32_t maxPPRNodes, int32_t maxResidualNodes, int32_t maxTotalNodes = -1);
 
 private:
     // Total out-degree of a node across all edge types. Returns 0 for sink nodes.

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -64,13 +64,14 @@ public:
     // including types unreachable in this batch (empty tensors, all-zero valid_counts).
     PPRExtractResult extractTopK(int32_t maxPprNodes);
 
-    // Return top-k PPR nodes, then append residual-mass top-up nodes.
+    // Return top-k PPR nodes plus residual-mass top-up nodes, sorted by score.
     //
     // Residual top-up does not issue new neighbor fetches.  It only reads the
     // residual table already built by Forward Push.  Scores are emitted on the
     // same mass scale as PPR scores: ppr_score(node) + residual(node), i.e. the
     // score the node would have if the remaining residual at that node were
-    // absorbed locally.
+    // absorbed locally.  Residual candidates only fill the requested top-up
+    // budget; they do not displace selected finalized-PPR nodes.
     //
     // maxTotalNodes caps finalized-PPR plus residual nodes per seed.  Pass -1
     // to keep the uncapped "maxPprNodes + maxResidualNodes" candidate behavior.

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -26,10 +26,6 @@ struct SeedNodeTypeState {
     std::unordered_set<int32_t> queuedNodes;       // snapshot captured by drainQueue()
 };
 
-using TensorTriplet = std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>;
-using NeighborFetchMap = std::unordered_map<int32_t, TensorTriplet>;
-using PPRExtractResult = std::unordered_map<int32_t, TensorTriplet>;
-
 // C++ kernel for PPR Forward Push (Andersen et al., 2006).
 // Hot-loop state lives here; distributed neighbor fetches are driven from Python.
 //
@@ -39,7 +35,7 @@ using PPRExtractResult = std::unordered_map<int32_t, TensorTriplet>;
 //   2. drainQueue()                         → nodes needing neighbor lookup
 //   3. <Python: _batch_fetch_neighbors()>
 //   4. pushResiduals(fetchedByEtypeId)
-//   5. extractTopK(maxPprNodes)
+//   5. extractTopKWithResidualTopUp(maxPprNodes, maxResidualNodes, maxTotalNodes)
 class PPRForwardPush {
 public:
     PPRForwardPush(const torch::Tensor& seedNodes,
@@ -57,27 +53,29 @@ public:
 
     // Push residuals given fetched neighbor data.
     // fetchedByEtypeId: {etype_id: (node_ids[N], flat_nbrs[sum(counts)], counts[N])}
-    void pushResiduals(const NeighborFetchMap& fetchedByEtypeId);
-
-    // Return top-k PPR nodes per seed per node type.
-    // Result: {ntype_id: (flat_ids, flat_weights, valid_counts)} — one entry per node type,
-    // including types unreachable in this batch (empty tensors, all-zero valid_counts).
-    PPRExtractResult extractTopK(int32_t maxPprNodes);
+    // TODO: Move these repeated tensor tuple/map types into aliases in a follow-up
+    // refactor-only PR.
+    void pushResiduals(
+        const std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>& fetchedByEtypeId);
 
     // Return top-k PPR nodes plus residual-mass top-up nodes, sorted by score.
     //
     // Residual top-up does not issue new neighbor fetches.  It only reads the
-    // residual table already built by Forward Push.  Scores are emitted on the
+    // residual table already built by Forward Push.  This gives callers a way
+    // to fill short sequences with nodes that were discovered but did not cross
+    // the requeue threshold, without lowering eps and running more push steps.
+    // Scores are emitted on the
     // same mass scale as PPR scores: ppr_score(node) + residual(node), i.e. the
     // score the node would have if the remaining residual at that node were
     // absorbed locally.  Residual candidates only fill the requested top-up
-    // budget; they do not displace selected finalized-PPR nodes.
+    // budget; they do not displace selected finalized-PPR nodes.  The returned
+    // set is selected by this two-phase policy, then sorted by emitted score;
+    // it is not a global top-k over ppr_score + residual when maxTotalNodes is tight.
     //
     // maxTotalNodes caps finalized-PPR plus residual nodes per seed.  Pass -1
     // to keep the uncapped "maxPprNodes + maxResidualNodes" candidate behavior.
-    PPRExtractResult extractTopKWithResidualTopUp(int32_t maxPprNodes,
-                                                  int32_t maxResidualNodes,
-                                                  int32_t maxTotalNodes = -1);
+    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> extractTopKWithResidualTopUp(
+        int32_t maxPprNodes, int32_t maxResidualNodes, int32_t maxTotalNodes = -1);
 
 private:
     // Total out-degree of a node across all edge types. Returns 0 for sink nodes.

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -71,7 +71,12 @@ public:
     // same mass scale as PPR scores: ppr_score(node) + residual(node), i.e. the
     // score the node would have if the remaining residual at that node were
     // absorbed locally.
-    PPRExtractResult extractTopKWithResidualTopUp(int32_t maxPprNodes, int32_t maxResidualNodes);
+    //
+    // maxTotalNodes caps finalized-PPR plus residual nodes per seed.  Pass -1
+    // to keep the uncapped "maxPprNodes + maxResidualNodes" candidate behavior.
+    PPRExtractResult extractTopKWithResidualTopUp(int32_t maxPprNodes,
+                                                  int32_t maxResidualNodes,
+                                                  int32_t maxTotalNodes = -1);
 
 private:
     // Total out-degree of a node across all edge types. Returns 0 for sink nodes.

--- a/gigl-core/core/sampling/python_ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/python_ppr_forward_push.cpp
@@ -21,7 +21,7 @@ namespace gigl {
 // pybind11/stl.h handles all type conversions automatically; the other methods use
 // direct member function pointers for the same reason.
 static void pushResidualsWrapper(PPRForwardPush& state, const py::dict& fetchedByEtypeId) {
-    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> neighborTensorsByEtypeId;
+    NeighborFetchMap neighborTensorsByEtypeId;
     // Dict iteration touches Python objects — GIL must be held here.
     for (auto item : fetchedByEtypeId) {
         auto edgeTypeId = item.first.cast<int32_t>();
@@ -57,5 +57,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                       std::vector<torch::Tensor>>())
         .def("drain_queue", &gigl::PPRForwardPush::drainQueue)
         .def("push_residuals", gigl::pushResidualsWrapper)
-        .def("extract_top_k", &gigl::PPRForwardPush::extractTopK);
+        .def("extract_top_k", &gigl::PPRForwardPush::extractTopK)
+        .def("extract_top_k_with_residual_top_up", &gigl::PPRForwardPush::extractTopKWithResidualTopUp);
 }

--- a/gigl-core/core/sampling/python_ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/python_ppr_forward_push.cpp
@@ -58,5 +58,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def("drain_queue", &gigl::PPRForwardPush::drainQueue)
         .def("push_residuals", gigl::pushResidualsWrapper)
         .def("extract_top_k", &gigl::PPRForwardPush::extractTopK)
-        .def("extract_top_k_with_residual_top_up", &gigl::PPRForwardPush::extractTopKWithResidualTopUp);
+        .def("extract_top_k_with_residual_top_up",
+             &gigl::PPRForwardPush::extractTopKWithResidualTopUp,
+             py::arg("max_ppr_nodes"),
+             py::arg("max_residual_nodes"),
+             py::arg("max_total_nodes") = -1);
 }

--- a/gigl-core/core/sampling/python_ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/python_ppr_forward_push.cpp
@@ -21,7 +21,7 @@ namespace gigl {
 // pybind11/stl.h handles all type conversions automatically; the other methods use
 // direct member function pointers for the same reason.
 static void pushResidualsWrapper(PPRForwardPush& state, const py::dict& fetchedByEtypeId) {
-    NeighborFetchMap neighborTensorsByEtypeId;
+    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> neighborTensorsByEtypeId;
     // Dict iteration touches Python objects — GIL must be held here.
     for (auto item : fetchedByEtypeId) {
         auto edgeTypeId = item.first.cast<int32_t>();
@@ -57,7 +57,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
                       std::vector<torch::Tensor>>())
         .def("drain_queue", &gigl::PPRForwardPush::drainQueue)
         .def("push_residuals", gigl::pushResidualsWrapper)
-        .def("extract_top_k", &gigl::PPRForwardPush::extractTopK)
         .def("extract_top_k_with_residual_top_up",
              &gigl::PPRForwardPush::extractTopKWithResidualTopUp,
              py::arg("max_ppr_nodes"),

--- a/gigl-core/core/sampling/python_ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/python_ppr_forward_push.cpp
@@ -60,6 +60,5 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         .def("extract_top_k_with_residual_top_up",
              &gigl::PPRForwardPush::extractTopKWithResidualTopUp,
              py::arg("max_ppr_nodes"),
-             py::arg("max_residual_nodes"),
-             py::arg("max_total_nodes") = -1);
+             py::arg("enable_residual_topup"));
 }

--- a/gigl-core/src/gigl_core/ppr_forward_push.pyi
+++ b/gigl-core/src/gigl_core/ppr_forward_push.pyi
@@ -1,9 +1,5 @@
 import torch
 
-TensorTriplet = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
-ExtractResult = dict[int, TensorTriplet]
-
-
 class PPRForwardPush:
     def __init__(
         self,
@@ -16,11 +12,13 @@ class PPRForwardPush:
         degree_tensors: list[torch.Tensor],
     ) -> None: ...
     def drain_queue(self) -> dict[int, torch.Tensor] | None: ...
-    def push_residuals(self, fetched_by_etype_id: dict[int, TensorTriplet]) -> None: ...
-    def extract_top_k(self, max_ppr_nodes: int) -> ExtractResult: ...
+    def push_residuals(
+        self,
+        fetched_by_etype_id: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+    ) -> None: ...
     def extract_top_k_with_residual_top_up(
         self,
         max_ppr_nodes: int,
         max_residual_nodes: int,
         max_total_nodes: int = -1,
-    ) -> ExtractResult: ...
+    ) -> dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: ...

--- a/gigl-core/src/gigl_core/ppr_forward_push.pyi
+++ b/gigl-core/src/gigl_core/ppr_forward_push.pyi
@@ -19,6 +19,5 @@ class PPRForwardPush:
     def extract_top_k_with_residual_top_up(
         self,
         max_ppr_nodes: int,
-        max_residual_nodes: int,
-        max_total_nodes: int = -1,
+        enable_residual_topup: bool,
     ) -> dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: ...

--- a/gigl-core/src/gigl_core/ppr_forward_push.pyi
+++ b/gigl-core/src/gigl_core/ppr_forward_push.pyi
@@ -22,4 +22,5 @@ class PPRForwardPush:
         self,
         max_ppr_nodes: int,
         max_residual_nodes: int,
+        max_total_nodes: int = -1,
     ) -> ExtractResult: ...

--- a/gigl-core/src/gigl_core/ppr_forward_push.pyi
+++ b/gigl-core/src/gigl_core/ppr_forward_push.pyi
@@ -1,5 +1,9 @@
 import torch
 
+TensorTriplet = tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+ExtractResult = dict[int, TensorTriplet]
+
+
 class PPRForwardPush:
     def __init__(
         self,
@@ -12,10 +16,10 @@ class PPRForwardPush:
         degree_tensors: list[torch.Tensor],
     ) -> None: ...
     def drain_queue(self) -> dict[int, torch.Tensor] | None: ...
-    def push_residuals(
+    def push_residuals(self, fetched_by_etype_id: dict[int, TensorTriplet]) -> None: ...
+    def extract_top_k(self, max_ppr_nodes: int) -> ExtractResult: ...
+    def extract_top_k_with_residual_top_up(
         self,
-        fetched_by_etype_id: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
-    ) -> None: ...
-    def extract_top_k(
-        self, max_ppr_nodes: int
-    ) -> dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: ...
+        max_ppr_nodes: int,
+        max_residual_nodes: int,
+    ) -> ExtractResult: ...

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -159,9 +159,9 @@ TEST(PPRForwardPush, ExtractTopKLimitsResults) {
     EXPECT_EQ(std::get<2>(topk10.at(0))[0].item<int64_t>(), 2);
 }
 
-// Residual top-up appends discovered nodes whose residual never crossed the
+// Residual top-up includes discovered nodes whose residual never crossed the
 // requeue threshold, without changing the default extractTopK behavior.
-TEST(PPRForwardPush, ExtractTopKWithResidualTopUpAppendsUnpushedResiduals) {
+TEST(PPRForwardPush, ExtractTopKWithResidualTopUpIncludesUnpushedResiduals) {
     const double alpha = 0.5;
     auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1.0, /*degrees=*/{2, 1, 1});
 
@@ -188,6 +188,43 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpAppendsUnpushedResiduals) {
     ASSERT_NE(residualWeights.find(2), residualWeights.end());
     EXPECT_NEAR(residualWeights[1], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
     EXPECT_NEAR(residualWeights[2], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
+}
+
+// Residual top-up cannot displace finalized PPR nodes from the selected set,
+// but the final emitted sequence should still be sorted by emitted score.
+TEST(PPRForwardPush, ExtractTopKWithResidualTopUpSortsSelectedResultsByScore) {
+    const double alpha = 0.5;
+    auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/0.1, /*degrees=*/{2, 2, 1, 0});
+
+    state.drainQueue();
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1, 2}, /*counts=*/{2}));
+
+    state.drainQueue();
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{2}, /*flatNeighborIds=*/{3}, /*counts=*/{1}));
+
+    state.drainQueue();
+    state.pushResiduals({});
+    EXPECT_FALSE(state.drainQueue().has_value());
+
+    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/3, /*maxResidualNodes=*/1);
+    ASSERT_NE(topkWithResiduals.find(0), topkWithResiduals.end());
+    const auto& [ids, weights, counts] = topkWithResiduals.at(0);
+    ASSERT_EQ(counts[0].item<int64_t>(), 4);
+
+    EXPECT_EQ(ids[0].item<int64_t>(), 0);
+    EXPECT_EQ(ids[3].item<int64_t>(), 3);
+    for (int64_t index = 1; index < counts[0].item<int64_t>(); ++index) {
+        EXPECT_GE(weights[index - 1].item<float>(), weights[index].item<float>());
+    }
+
+    std::unordered_map<int64_t, float> weightsByNodeId;
+    for (int64_t index = 0; index < counts[0].item<int64_t>(); ++index) {
+        weightsByNodeId[ids[index].item<int64_t>()] = weights[index].item<float>();
+    }
+    EXPECT_NEAR(weightsByNodeId[0], static_cast<float>(alpha), 1e-5F);
+    EXPECT_NEAR(weightsByNodeId[1], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
+    EXPECT_NEAR(weightsByNodeId[2], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
+    EXPECT_NEAR(weightsByNodeId[3], static_cast<float>((1.0 - alpha) * (1.0 - alpha) * alpha / 2.0), 1e-5F);
 }
 
 // A total cap lets callers request residual top-up without materializing more

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -1,31 +1,31 @@
 #include <gtest/gtest.h>
 #include "sampling/ppr_forward_push.h"
 
+#include <unordered_map>
+
 using gigl::PPRForwardPush;
 
 // Builds a single-edge-type, single-node-type PPRForwardPush.
-static PPRForwardPush makeState(
-    const std::vector<int64_t>& seeds,
-    double alpha,
-    double requeueThresholdFactor,
-    const std::vector<int32_t>& degrees) {
-    return PPRForwardPush(
-        torch::tensor(seeds, torch::kLong),
-        /*seedNodeTypeId=*/0,
-        alpha,
-        requeueThresholdFactor,
-        /*nodeTypeToEdgeTypeIds=*/{{0}},
-        /*edgeTypeToDstNtypeId=*/{0},
-        {torch::tensor(degrees, torch::kInt)});
+static PPRForwardPush makeState(const std::vector<int64_t>& seeds,
+                                double alpha,
+                                double requeueThresholdFactor,
+                                const std::vector<int32_t>& degrees) {
+    return PPRForwardPush(torch::tensor(seeds, torch::kLong),
+                          /*seedNodeTypeId=*/0,
+                          alpha,
+                          requeueThresholdFactor,
+                          /*nodeTypeToEdgeTypeIds=*/{{0}},
+                          /*edgeTypeToDstNtypeId=*/{0},
+                          {torch::tensor(degrees, torch::kInt)});
 }
 
 // Convenience wrapper: build the fetchedByEtypeId argument for pushResiduals
 // from flat vectors, keeping test call sites readable.
-static std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>>
-makeFetched(int32_t edgeTypeId,
-            const std::vector<int64_t>& nodeIds,
-            const std::vector<int64_t>& flatNeighborIds,
-            const std::vector<int64_t>& counts) {
+static std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> makeFetched(
+    int32_t edgeTypeId,
+    const std::vector<int64_t>& nodeIds,
+    const std::vector<int64_t>& flatNeighborIds,
+    const std::vector<int64_t>& counts) {
     return {{edgeTypeId,
              {torch::tensor(nodeIds, torch::kLong),
               torch::tensor(flatNeighborIds, torch::kLong),
@@ -117,13 +117,14 @@ TEST(PPRForwardPush, DeduplicatesNodesAcrossSeeds) {
     auto state = makeState(/*seeds=*/{0, 1}, /*alpha=*/0.15, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{1, 1, 0});
 
     state.drainQueue();
-    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0, 1}, /*flatNeighborIds=*/{2, 2}, /*counts=*/{1, 1}));
+    state.pushResiduals(
+        makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0, 1}, /*flatNeighborIds=*/{2, 2}, /*counts=*/{1, 1}));
 
     auto iter2 = state.drainQueue();
     ASSERT_TRUE(iter2.has_value());
     const auto& iter2Map = iter2.value();
     ASSERT_NE(iter2Map.find(0), iter2Map.end());
-    EXPECT_EQ(iter2Map.at(0).size(0), 1);  // node 2 deduplicated in the lookup request
+    EXPECT_EQ(iter2Map.at(0).size(0), 1); // node 2 deduplicated in the lookup request
 
     state.pushResiduals({});
     EXPECT_FALSE(state.drainQueue().has_value());
@@ -132,12 +133,12 @@ TEST(PPRForwardPush, DeduplicatesNodesAcrossSeeds) {
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     // Each seed (batch indices 0 and 1) should have 2 nodes in its top-k.
-    EXPECT_EQ(counts[0].item<int64_t>(), 2);  // seed 0: nodes {0, 2}
-    EXPECT_EQ(counts[1].item<int64_t>(), 2);  // seed 1: nodes {1, 2}
+    EXPECT_EQ(counts[0].item<int64_t>(), 2); // seed 0: nodes {0, 2}
+    EXPECT_EQ(counts[1].item<int64_t>(), 2); // seed 1: nodes {1, 2}
     // The flat id layout is [seed0_top1, seed0_top2, seed1_top1, seed1_top2].
     // Within each seed the highest scorer comes first, so seed-node beats node 2.
-    EXPECT_EQ(ids[1].item<int64_t>(), 2);  // seed 0's second node is node 2
-    EXPECT_EQ(ids[3].item<int64_t>(), 2);  // seed 1's second node is node 2
+    EXPECT_EQ(ids[1].item<int64_t>(), 2); // seed 0's second node is node 2
+    EXPECT_EQ(ids[3].item<int64_t>(), 2); // seed 1's second node is node 2
 }
 
 // extractTopK respects the maxPprNodes limit.
@@ -156,4 +157,35 @@ TEST(PPRForwardPush, ExtractTopKLimitsResults) {
     auto topk10 = state.extractTopK(10);
     ASSERT_NE(topk10.find(0), topk10.end());
     EXPECT_EQ(std::get<2>(topk10.at(0))[0].item<int64_t>(), 2);
+}
+
+// Residual top-up appends discovered nodes whose residual never crossed the
+// requeue threshold, without changing the default extractTopK behavior.
+TEST(PPRForwardPush, ExtractTopKWithResidualTopUpAppendsUnpushedResiduals) {
+    const double alpha = 0.5;
+    auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1.0, /*degrees=*/{2, 1, 1});
+
+    state.drainQueue();
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1, 2}, /*counts=*/{2}));
+    EXPECT_FALSE(state.drainQueue().has_value());
+
+    auto topk = state.extractTopK(10);
+    ASSERT_NE(topk.find(0), topk.end());
+    EXPECT_EQ(std::get<2>(topk.at(0))[0].item<int64_t>(), 1);
+    EXPECT_EQ(std::get<0>(topk.at(0))[0].item<int64_t>(), 0);
+
+    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/1, /*maxResidualNodes=*/2);
+    ASSERT_NE(topkWithResiduals.find(0), topkWithResiduals.end());
+    const auto& [ids, weights, counts] = topkWithResiduals.at(0);
+    ASSERT_EQ(counts[0].item<int64_t>(), 3);
+    EXPECT_EQ(ids[0].item<int64_t>(), 0);
+    EXPECT_NEAR(weights[0].item<float>(), static_cast<float>(alpha), 1e-5F);
+
+    std::unordered_map<int64_t, float> residualWeights;
+    residualWeights[ids[1].item<int64_t>()] = weights[1].item<float>();
+    residualWeights[ids[2].item<int64_t>()] = weights[2].item<float>();
+    ASSERT_NE(residualWeights.find(1), residualWeights.end());
+    ASSERT_NE(residualWeights.find(2), residualWeights.end());
+    EXPECT_NEAR(residualWeights[1], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
+    EXPECT_NEAR(residualWeights[2], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
 }

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -89,6 +89,27 @@ TEST(PPRForwardPush, ResidualDistributedToNeighbor) {
     EXPECT_NEAR(weights[1].item<float>(), static_cast<float>((1.0 - alpha) * alpha), 1e-5F);
 }
 
+// Once a (node, edge type) neighbor list is fetched, it should be cached for the
+// rest of the PPR state. In a cycle, revisiting node 0 should therefore require
+// no second lookup for node 0.
+TEST(PPRForwardPush, NeighborCacheAvoidsRefetchingPreviouslyFetchedNode) {
+    auto state = makeState(/*seeds=*/{0}, /*alpha=*/0.5, /*requeueThresholdFactor=*/1e-9, /*degrees=*/{1, 1});
+
+    state.drainQueue();
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1}, /*counts=*/{1}));
+
+    auto iter2 = state.drainQueue();
+    ASSERT_TRUE(iter2.has_value());
+    ASSERT_NE(iter2->find(0), iter2->end());
+    ASSERT_EQ(iter2->at(0).size(0), 1);
+    EXPECT_EQ(iter2->at(0)[0].item<int64_t>(), 1);
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{1}, /*flatNeighborIds=*/{0}, /*counts=*/{1}));
+
+    auto iter3 = state.drainQueue();
+    ASSERT_TRUE(iter3.has_value());
+    EXPECT_TRUE(iter3->empty());
+}
+
 // Two seeds (0 and 1) both push residual to sink node 2.  The neighbor-lookup
 // request must deduplicate to one entry for node 2, yet both seeds must still
 // accumulate a PPR score for it.

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -189,3 +189,25 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpAppendsUnpushedResiduals) {
     EXPECT_NEAR(residualWeights[1], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
     EXPECT_NEAR(residualWeights[2], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
 }
+
+// A total cap lets callers request residual top-up without materializing more
+// candidates than the downstream sampler can emit.
+TEST(PPRForwardPush, ExtractTopKWithResidualTopUpHonorsTotalCap) {
+    const double alpha = 0.5;
+    auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1.0, /*degrees=*/{2, 1, 1});
+
+    state.drainQueue();
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1, 2}, /*counts=*/{2}));
+    EXPECT_FALSE(state.drainQueue().has_value());
+
+    auto cappedTopk = state.extractTopKWithResidualTopUp(
+        /*maxPprNodes=*/2,
+        /*maxResidualNodes=*/2,
+        /*maxTotalNodes=*/2);
+    ASSERT_NE(cappedTopk.find(0), cappedTopk.end());
+    const auto& [ids, weights, counts] = cappedTopk.at(0);
+
+    ASSERT_EQ(counts[0].item<int64_t>(), 2);
+    EXPECT_EQ(ids[0].item<int64_t>(), 0);
+    EXPECT_NEAR(weights[0].item<float>(), static_cast<float>(alpha), 1e-5F);
+}

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -57,7 +57,7 @@ TEST(PPRForwardPush, PprScoreAbsorbsAlpha) {
     auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{0});
     state.drainQueue();
     state.pushResiduals({});
-    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*enableResidualTopUp=*/false);
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
@@ -79,7 +79,7 @@ TEST(PPRForwardPush, ResidualDistributedToNeighbor) {
 
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*enableResidualTopUp=*/false);
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     ASSERT_EQ(counts[0].item<int64_t>(), 2);
@@ -129,7 +129,7 @@ TEST(PPRForwardPush, DeduplicatesNodesAcrossSeeds) {
     state.pushResiduals({});
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*enableResidualTopUp=*/false);
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     // Each seed (batch indices 0 and 1) should have 2 nodes in its top-k.
@@ -150,17 +150,17 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpLimitsResultsWithoutResidualTop
     state.drainQueue();
     state.pushResiduals({});
 
-    auto topk1 = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/1, /*maxResidualNodes=*/0);
+    auto topk1 = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/1, /*enableResidualTopUp=*/false);
     ASSERT_NE(topk1.find(0), topk1.end());
     EXPECT_EQ(std::get<2>(topk1.at(0))[0].item<int64_t>(), 1);
 
-    auto topk10 = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk10 = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*enableResidualTopUp=*/false);
     ASSERT_NE(topk10.find(0), topk10.end());
     EXPECT_EQ(std::get<2>(topk10.at(0))[0].item<int64_t>(), 2);
 }
 
 // Residual top-up includes discovered nodes whose residual never crossed the
-// requeue threshold, while maxResidualNodes=0 keeps finalized-PPR-only behavior.
+// requeue threshold, while enableResidualTopUp=false keeps finalized-PPR-only behavior.
 TEST(PPRForwardPush, ExtractTopKWithResidualTopUpIncludesUnpushedResiduals) {
     const double alpha = 0.5;
     auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1.0, /*degrees=*/{2, 1, 1});
@@ -169,12 +169,12 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpIncludesUnpushedResiduals) {
     state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1, 2}, /*counts=*/{2}));
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*enableResidualTopUp=*/false);
     ASSERT_NE(topk.find(0), topk.end());
     EXPECT_EQ(std::get<2>(topk.at(0))[0].item<int64_t>(), 1);
     EXPECT_EQ(std::get<0>(topk.at(0))[0].item<int64_t>(), 0);
 
-    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/1, /*maxResidualNodes=*/2);
+    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/3, /*enableResidualTopUp=*/true);
     ASSERT_NE(topkWithResiduals.find(0), topkWithResiduals.end());
     const auto& [ids, weights, counts] = topkWithResiduals.at(0);
     ASSERT_EQ(counts[0].item<int64_t>(), 3);
@@ -206,7 +206,7 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpSortsSelectedResultsByScore) {
     state.pushResiduals({});
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/3, /*maxResidualNodes=*/1);
+    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/4, /*enableResidualTopUp=*/true);
     ASSERT_NE(topkWithResiduals.find(0), topkWithResiduals.end());
     const auto& [ids, weights, counts] = topkWithResiduals.at(0);
     ASSERT_EQ(counts[0].item<int64_t>(), 4);
@@ -227,9 +227,9 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpSortsSelectedResultsByScore) {
     EXPECT_NEAR(weightsByNodeId[3], static_cast<float>((1.0 - alpha) * (1.0 - alpha) * alpha / 2.0), 1e-5F);
 }
 
-// A total cap lets callers request residual top-up without materializing more
-// candidates than the downstream sampler can emit.
-TEST(PPRForwardPush, ExtractTopKWithResidualTopUpHonorsTotalCap) {
+// maxPPRNodes is the total output cap across finalized PPR and residual top-up
+// candidates.
+TEST(PPRForwardPush, ExtractTopKWithResidualTopUpUsesMaxPPRNodesAsTotalCap) {
     const double alpha = 0.5;
     auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1.0, /*degrees=*/{2, 1, 1});
 
@@ -237,10 +237,7 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpHonorsTotalCap) {
     state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1, 2}, /*counts=*/{2}));
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto cappedTopk = state.extractTopKWithResidualTopUp(
-        /*maxPPRNodes=*/2,
-        /*maxResidualNodes=*/2,
-        /*maxTotalNodes=*/2);
+    auto cappedTopk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/2, /*enableResidualTopUp=*/true);
     ASSERT_NE(cappedTopk.find(0), cappedTopk.end());
     const auto& [ids, weights, counts] = cappedTopk.at(0);
 
@@ -249,11 +246,7 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpHonorsTotalCap) {
     EXPECT_NEAR(weights[0].item<float>(), static_cast<float>(alpha), 1e-5F);
 }
 
-TEST(PPRForwardPush, ExtractTopKWithResidualTopUpRejectsTotalCapBelowPprCap) {
+TEST(PPRForwardPush, ExtractTopKWithResidualTopUpRejectsNegativeMaxPPRNodes) {
     auto state = makeState(/*seeds=*/{0}, /*alpha=*/0.15, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{0});
-    EXPECT_THROW(state.extractTopKWithResidualTopUp(
-                     /*maxPPRNodes=*/2,
-                     /*maxResidualNodes=*/1,
-                     /*maxTotalNodes=*/1),
-                 c10::Error);
+    EXPECT_THROW(state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/-1, /*enableResidualTopUp=*/true), c10::Error);
 }

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -57,7 +57,7 @@ TEST(PPRForwardPush, PprScoreAbsorbsAlpha) {
     auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{0});
     state.drainQueue();
     state.pushResiduals({});
-    auto topk = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
@@ -79,7 +79,7 @@ TEST(PPRForwardPush, ResidualDistributedToNeighbor) {
 
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topk = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     ASSERT_EQ(counts[0].item<int64_t>(), 2);
@@ -129,7 +129,7 @@ TEST(PPRForwardPush, DeduplicatesNodesAcrossSeeds) {
     state.pushResiduals({});
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topk = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     // Each seed (batch indices 0 and 1) should have 2 nodes in its top-k.
@@ -141,7 +141,7 @@ TEST(PPRForwardPush, DeduplicatesNodesAcrossSeeds) {
     EXPECT_EQ(ids[3].item<int64_t>(), 2); // seed 1's second node is node 2
 }
 
-// extractTopKWithResidualTopUp respects the maxPprNodes limit when residual top-up is disabled.
+// extractTopKWithResidualTopUp respects the maxPPRNodes limit when residual top-up is disabled.
 TEST(PPRForwardPush, ExtractTopKWithResidualTopUpLimitsResultsWithoutResidualTopUp) {
     auto state = makeState(/*seeds=*/{0}, /*alpha=*/0.15, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{1, 0});
 
@@ -150,11 +150,11 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpLimitsResultsWithoutResidualTop
     state.drainQueue();
     state.pushResiduals({});
 
-    auto topk1 = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/1, /*maxResidualNodes=*/0);
+    auto topk1 = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/1, /*maxResidualNodes=*/0);
     ASSERT_NE(topk1.find(0), topk1.end());
     EXPECT_EQ(std::get<2>(topk1.at(0))[0].item<int64_t>(), 1);
 
-    auto topk10 = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk10 = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk10.find(0), topk10.end());
     EXPECT_EQ(std::get<2>(topk10.at(0))[0].item<int64_t>(), 2);
 }
@@ -169,12 +169,12 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpIncludesUnpushedResiduals) {
     state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1, 2}, /*counts=*/{2}));
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topk = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk.find(0), topk.end());
     EXPECT_EQ(std::get<2>(topk.at(0))[0].item<int64_t>(), 1);
     EXPECT_EQ(std::get<0>(topk.at(0))[0].item<int64_t>(), 0);
 
-    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/1, /*maxResidualNodes=*/2);
+    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/1, /*maxResidualNodes=*/2);
     ASSERT_NE(topkWithResiduals.find(0), topkWithResiduals.end());
     const auto& [ids, weights, counts] = topkWithResiduals.at(0);
     ASSERT_EQ(counts[0].item<int64_t>(), 3);
@@ -206,7 +206,7 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpSortsSelectedResultsByScore) {
     state.pushResiduals({});
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/3, /*maxResidualNodes=*/1);
+    auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/3, /*maxResidualNodes=*/1);
     ASSERT_NE(topkWithResiduals.find(0), topkWithResiduals.end());
     const auto& [ids, weights, counts] = topkWithResiduals.at(0);
     ASSERT_EQ(counts[0].item<int64_t>(), 4);
@@ -238,7 +238,7 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpHonorsTotalCap) {
     EXPECT_FALSE(state.drainQueue().has_value());
 
     auto cappedTopk = state.extractTopKWithResidualTopUp(
-        /*maxPprNodes=*/2,
+        /*maxPPRNodes=*/2,
         /*maxResidualNodes=*/2,
         /*maxTotalNodes=*/2);
     ASSERT_NE(cappedTopk.find(0), cappedTopk.end());
@@ -247,4 +247,13 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpHonorsTotalCap) {
     ASSERT_EQ(counts[0].item<int64_t>(), 2);
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
     EXPECT_NEAR(weights[0].item<float>(), static_cast<float>(alpha), 1e-5F);
+}
+
+TEST(PPRForwardPush, ExtractTopKWithResidualTopUpRejectsTotalCapBelowPprCap) {
+    auto state = makeState(/*seeds=*/{0}, /*alpha=*/0.15, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{0});
+    EXPECT_THROW(state.extractTopKWithResidualTopUp(
+                     /*maxPPRNodes=*/2,
+                     /*maxResidualNodes=*/1,
+                     /*maxTotalNodes=*/1),
+                 c10::Error);
 }

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -57,7 +57,7 @@ TEST(PPRForwardPush, PprScoreAbsorbsAlpha) {
     auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{0});
     state.drainQueue();
     state.pushResiduals({});
-    auto topk = state.extractTopK(10);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
@@ -79,7 +79,7 @@ TEST(PPRForwardPush, ResidualDistributedToNeighbor) {
 
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topk = state.extractTopK(10);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     ASSERT_EQ(counts[0].item<int64_t>(), 2);
@@ -129,7 +129,7 @@ TEST(PPRForwardPush, DeduplicatesNodesAcrossSeeds) {
     state.pushResiduals({});
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topk = state.extractTopK(10);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     // Each seed (batch indices 0 and 1) should have 2 nodes in its top-k.
@@ -141,8 +141,8 @@ TEST(PPRForwardPush, DeduplicatesNodesAcrossSeeds) {
     EXPECT_EQ(ids[3].item<int64_t>(), 2); // seed 1's second node is node 2
 }
 
-// extractTopK respects the maxPprNodes limit.
-TEST(PPRForwardPush, ExtractTopKLimitsResults) {
+// extractTopKWithResidualTopUp respects the maxPprNodes limit when residual top-up is disabled.
+TEST(PPRForwardPush, ExtractTopKWithResidualTopUpLimitsResultsWithoutResidualTopUp) {
     auto state = makeState(/*seeds=*/{0}, /*alpha=*/0.15, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{1, 0});
 
     state.drainQueue();
@@ -150,17 +150,17 @@ TEST(PPRForwardPush, ExtractTopKLimitsResults) {
     state.drainQueue();
     state.pushResiduals({});
 
-    auto topk1 = state.extractTopK(1);
+    auto topk1 = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/1, /*maxResidualNodes=*/0);
     ASSERT_NE(topk1.find(0), topk1.end());
     EXPECT_EQ(std::get<2>(topk1.at(0))[0].item<int64_t>(), 1);
 
-    auto topk10 = state.extractTopK(10);
+    auto topk10 = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk10.find(0), topk10.end());
     EXPECT_EQ(std::get<2>(topk10.at(0))[0].item<int64_t>(), 2);
 }
 
 // Residual top-up includes discovered nodes whose residual never crossed the
-// requeue threshold, without changing the default extractTopK behavior.
+// requeue threshold, while maxResidualNodes=0 keeps finalized-PPR-only behavior.
 TEST(PPRForwardPush, ExtractTopKWithResidualTopUpIncludesUnpushedResiduals) {
     const double alpha = 0.5;
     auto state = makeState(/*seeds=*/{0}, alpha, /*requeueThresholdFactor=*/1.0, /*degrees=*/{2, 1, 1});
@@ -169,7 +169,7 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpIncludesUnpushedResiduals) {
     state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1, 2}, /*counts=*/{2}));
     EXPECT_FALSE(state.drainQueue().has_value());
 
-    auto topk = state.extractTopK(10);
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPprNodes=*/10, /*maxResidualNodes=*/0);
     ASSERT_NE(topk.find(0), topk.end());
     EXPECT_EQ(std::get<2>(topk.at(0))[0].item<int64_t>(), 1);
     EXPECT_EQ(std::get<0>(topk.at(0))[0].item<int64_t>(), 0);

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -37,6 +37,20 @@ _PPR_HOMOGENEOUS_EDGE_TYPE = (
 )
 
 
+def _extract_top_k_from_ppr_state(
+    ppr_state,
+    max_ppr_nodes: int,
+    residual_topup_nodes: int,
+    max_total_nodes: int,
+) -> dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
+    """Call the shared C++ extraction path for the configured quotas."""
+    return ppr_state.extract_top_k_with_residual_top_up(
+        max_ppr_nodes,
+        residual_topup_nodes,
+        max_total_nodes,
+    )
+
+
 class DistPPRNeighborSampler(BaseDistNeighborSampler):
     """Personalized PageRank (PPR) based distributed neighbor sampler.
 
@@ -47,6 +61,13 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
     (PPR) scores to select the most relevant neighbors for each seed node. PPR
     scores are approximated here using the Forward Push algorithm (Andersen et
     al., 2006).
+
+    Residual top-up provides a cheaper way to increase returned sequence volume
+    without lowering ``eps``.  Lower ``eps`` thresholds re-enqueue more
+    low-residual nodes, but also increase push iterations and neighbor-fetch
+    work.  Top-up instead fills unused output slots with positive-residual nodes
+    already discovered during Forward Push; these are the nodes that are closest
+    to being re-enqueued if the threshold were lower.
 
     This sampler supports both homogeneous and heterogeneous graphs. For heterogeneous graphs,
     the PPR algorithm traverses across all edge types, switching edge types based on the
@@ -76,7 +97,8 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             PPR scores produce fewer than this cap and residual top-up is
             enabled, discovered residual candidates fill the remaining slots
             with score ``ppr_score + residual``.  Returned nodes are sorted by
-            emitted score.
+            emitted score, but residual candidates do not displace finalized
+            PPR nodes when finalized scores already fill the cap.
         enable_residual_topup: Whether to include residual candidates discovered
             during Forward Push when fewer than ``max_ppr_nodes`` finalized PPR
             scores are available.
@@ -286,9 +308,9 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         self,
         ppr_state,
         device: torch.device,
-        max_ppr_nodes: Optional[int] = None,
-        residual_topup_nodes: int = 0,
-        max_total_nodes: Optional[int] = None,
+        max_ppr_nodes: int,
+        residual_topup_nodes: int,
+        max_total_nodes: int,
     ) -> tuple[
         Union[torch.Tensor, dict[NodeType, torch.Tensor]],
         Union[torch.Tensor, dict[NodeType, torch.Tensor]],
@@ -301,11 +323,11 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         preserves the homogeneous return shape expected by the rest of the
         sampler.
 
-        ``residual_topup_nodes`` controls how many discovered residual
-        candidates may be considered after finalized PPR scores.  ``max_total_nodes``
-        is a combined per-seed cap across finalized and residual candidates.
-        When set, the cap is passed into C++ so residual candidates are not
-        materialized only to be discarded later in Python.
+        The quota arguments are passed in explicitly by the caller so this
+        helper only translates the C++ output shape.  ``residual_topup_nodes``
+        controls how many discovered residual candidates may be considered
+        after finalized PPR scores.  ``max_total_nodes`` is a combined per-seed
+        cap across finalized and residual candidates.
         """
         # Translate ntype_id integer keys back to NodeType strings for the rest
         # of the pipeline, and move tensors to the correct device.
@@ -313,20 +335,12 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         ntype_to_flat_weights: dict[NodeType, torch.Tensor] = {}
         ntype_to_valid_counts: dict[NodeType, torch.Tensor] = {}
 
-        ppr_node_quota = (
-            max_ppr_nodes if max_ppr_nodes is not None else self._max_ppr_nodes
+        extracted_results = _extract_top_k_from_ppr_state(
+            ppr_state,
+            max_ppr_nodes,
+            residual_topup_nodes,
+            max_total_nodes,
         )
-        if residual_topup_nodes > 0:
-            max_total_nodes_for_extraction = (
-                max_total_nodes if max_total_nodes is not None else -1
-            )
-            extracted_results = ppr_state.extract_top_k_with_residual_top_up(
-                ppr_node_quota,
-                residual_topup_nodes,
-                max_total_nodes_for_extraction,
-            )
-        else:
-            extracted_results = ppr_state.extract_top_k(ppr_node_quota)
 
         for ntype_id, (
             flat_ids,
@@ -456,9 +470,10 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
                 None, ppr_state.push_residuals, fetched_by_etype_id
             )
 
-        residual_topup_nodes = (
-            self._max_ppr_nodes if self._enable_residual_topup else 0
-        )
+        # Regular sampling uses residual top-up as fill-only under the
+        # max_ppr_nodes cap.  If finalized PPR scores already fill that cap,
+        # max_total_nodes leaves no budget for residual candidates.
+        residual_topup_nodes = self._max_ppr_nodes if self._enable_residual_topup else 0
         return self._extract_ppr_state_top_k(
             ppr_state,
             device,

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -74,9 +74,10 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
              but require more computation. Typical values: 1e-4 to 1e-6.
         max_ppr_nodes: Maximum number of nodes to return per seed. If finalized
             PPR scores produce fewer than this cap and residual top-up is
-            enabled, discovered residual candidates are appended with score
-            ``ppr_score + residual``.
-        enable_residual_topup: Whether to append residual candidates discovered
+            enabled, discovered residual candidates fill the remaining slots
+            with score ``ppr_score + residual``.  Returned nodes are sorted by
+            emitted score.
+        enable_residual_topup: Whether to include residual candidates discovered
             during Forward Push when fewer than ``max_ppr_nodes`` finalized PPR
             scores are available.
         num_neighbors_per_hop: Maximum number of neighbors to fetch per hop.

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -295,7 +295,6 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         ppr_state,
         device: torch.device,
         max_ppr_nodes: int,
-        residual_topup_nodes: int,
     ) -> tuple[
         Union[torch.Tensor, dict[NodeType, torch.Tensor]],
         Union[torch.Tensor, dict[NodeType, torch.Tensor]],
@@ -308,11 +307,10 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         preserves the homogeneous return shape expected by the rest of the
         sampler.
 
-        The quota arguments are passed in explicitly by the caller so this
-        helper only translates the C++ output shape.  ``residual_topup_nodes``
-        controls how many discovered residual candidates may be considered
-        after finalized PPR scores.  Regular PPR uses ``max_ppr_nodes`` as the
-        combined per-seed cap across finalized and residual candidates.
+        ``max_ppr_nodes`` is the combined per-seed cap across finalized PPR and
+        residual top-up candidates. If residual top-up is enabled, C++ derives
+        the residual candidate budget from this cap after selecting finalized
+        PPR nodes.
 
         Returns:
             ``(flat_ids, flat_weights, valid_counts)`` for homogeneous graphs,
@@ -328,8 +326,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
 
         extracted_results = ppr_state.extract_top_k_with_residual_top_up(
             max_ppr_nodes,
-            residual_topup_nodes,
-            max_ppr_nodes,
+            self._enable_residual_topup,
         )
 
         for ntype_id, (
@@ -462,13 +459,11 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
 
         # Regular sampling uses residual top-up as fill-only under the
         # max_ppr_nodes cap.  If finalized PPR scores already fill that cap,
-        # max_total_nodes leaves no budget for residual candidates.
-        residual_topup_nodes = self._max_ppr_nodes if self._enable_residual_topup else 0
+        # there is no remaining budget for residual candidates.
         return self._extract_ppr_state_top_k(
             ppr_state,
             device,
             max_ppr_nodes=self._max_ppr_nodes,
-            residual_topup_nodes=residual_topup_nodes,
         )
 
     async def _sample_from_nodes(

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -72,7 +72,9 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
                keep samples closer to seeds. Typical values: 0.15-0.25.
         eps: Convergence threshold. Smaller values give more accurate PPR scores
              but require more computation. Typical values: 1e-4 to 1e-6.
-        max_ppr_nodes: Maximum number of nodes to return per seed based on PPR scores.
+        max_ppr_nodes: Maximum number of nodes to return per seed. If finalized
+            PPR scores produce fewer than this cap, discovered residual
+            candidates are appended with score ``ppr_score + residual``.
         num_neighbors_per_hop: Maximum number of neighbors to fetch per hop.
         degree_tensors: Pre-computed total-degree tensors (int32). Homogeneous
             graphs use a single tensor; heterogeneous graphs use tensors keyed
@@ -273,6 +275,112 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             for eid, output in zip(eids, outputs)
         }
 
+    def _extract_ppr_state_top_k(
+        self,
+        ppr_state,
+        device: torch.device,
+        max_ppr_nodes: Optional[int] = None,
+        residual_topup_nodes: int = 0,
+        max_total_nodes: Optional[int] = None,
+    ) -> tuple[
+        Union[torch.Tensor, dict[NodeType, torch.Tensor]],
+        Union[torch.Tensor, dict[NodeType, torch.Tensor]],
+        Union[torch.Tensor, dict[NodeType, torch.Tensor]],
+    ]:
+        # Translate ntype_id integer keys back to NodeType strings for the rest
+        # of the pipeline, and move tensors to the correct device.
+        ntype_to_flat_ids: dict[NodeType, torch.Tensor] = {}
+        ntype_to_flat_weights: dict[NodeType, torch.Tensor] = {}
+        ntype_to_valid_counts: dict[NodeType, torch.Tensor] = {}
+
+        ppr_node_quota = (
+            max_ppr_nodes if max_ppr_nodes is not None else self._max_ppr_nodes
+        )
+        if residual_topup_nodes > 0:
+            extracted_results = ppr_state.extract_top_k_with_residual_top_up(
+                ppr_node_quota,
+                residual_topup_nodes,
+            )
+        else:
+            extracted_results = ppr_state.extract_top_k(ppr_node_quota)
+
+        for ntype_id, (
+            flat_ids,
+            flat_weights,
+            valid_counts,
+        ) in extracted_results.items():
+            ntype = self._ntype_id_to_ntype[ntype_id]
+            ntype_to_flat_ids[ntype] = flat_ids.to(device)
+            ntype_to_flat_weights[ntype] = flat_weights.to(device)
+            ntype_to_valid_counts[ntype] = valid_counts.to(device)
+
+        if max_total_nodes is not None:
+            for ntype in ntype_to_flat_ids:
+                (
+                    ntype_to_flat_ids[ntype],
+                    ntype_to_flat_weights[ntype],
+                    ntype_to_valid_counts[ntype],
+                ) = self._truncate_flat_ppr_result_to_max_nodes(
+                    flat_ids=ntype_to_flat_ids[ntype],
+                    flat_weights=ntype_to_flat_weights[ntype],
+                    valid_counts=ntype_to_valid_counts[ntype],
+                    max_nodes=max_total_nodes,
+                )
+
+        if self._is_homogeneous:
+            assert (
+                len(ntype_to_flat_ids) == 1
+                and DEFAULT_HOMOGENEOUS_NODE_TYPE in ntype_to_flat_ids
+            )
+            return (
+                ntype_to_flat_ids[DEFAULT_HOMOGENEOUS_NODE_TYPE],
+                ntype_to_flat_weights[DEFAULT_HOMOGENEOUS_NODE_TYPE],
+                ntype_to_valid_counts[DEFAULT_HOMOGENEOUS_NODE_TYPE],
+            )
+        else:
+            return (
+                ntype_to_flat_ids,
+                ntype_to_flat_weights,
+                ntype_to_valid_counts,
+            )
+
+    @staticmethod
+    def _truncate_flat_ppr_result_to_max_nodes(
+        flat_ids: torch.Tensor,
+        flat_weights: torch.Tensor,
+        valid_counts: torch.Tensor,
+        max_nodes: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Cap each seed's flat PPR result after residual top-up."""
+        if max_nodes < 0:
+            raise ValueError(f"max_nodes must be non-negative, got {max_nodes}.")
+
+        id_parts: list[torch.Tensor] = []
+        weight_parts: list[torch.Tensor] = []
+        capped_counts: list[int] = []
+        offset = 0
+        for count in valid_counts.detach().cpu().tolist():
+            count = int(count)
+            keep_count = min(count, max_nodes)
+            if keep_count > 0:
+                id_parts.append(flat_ids[offset : offset + keep_count])
+                weight_parts.append(flat_weights[offset : offset + keep_count])
+            capped_counts.append(keep_count)
+            offset += count
+
+        capped_flat_ids = torch.cat(id_parts) if id_parts else flat_ids.new_empty((0,))
+        capped_flat_weights = (
+            torch.cat(weight_parts)
+            if weight_parts
+            else flat_weights.new_empty((0, *flat_weights.shape[1:]))
+        )
+        capped_valid_counts = torch.tensor(
+            capped_counts,
+            dtype=valid_counts.dtype,
+            device=valid_counts.device,
+        )
+        return capped_flat_ids, capped_flat_weights, capped_valid_counts
+
     async def _compute_ppr_scores(
         self,
         seed_nodes: torch.Tensor,
@@ -374,36 +482,13 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
                 None, ppr_state.push_residuals, fetched_by_etype_id
             )
 
-        # Translate ntype_id integer keys back to NodeType strings for the rest
-        # of the pipeline, and move tensors to the correct device.
-        ntype_to_flat_ids: dict[NodeType, torch.Tensor] = {}
-        ntype_to_flat_weights: dict[NodeType, torch.Tensor] = {}
-        ntype_to_valid_counts: dict[NodeType, torch.Tensor] = {}
-
-        for ntype_id, (flat_ids, flat_weights, valid_counts) in ppr_state.extract_top_k(
-            self._max_ppr_nodes
-        ).items():
-            ntype = self._ntype_id_to_ntype[ntype_id]
-            ntype_to_flat_ids[ntype] = flat_ids.to(device)
-            ntype_to_flat_weights[ntype] = flat_weights.to(device)
-            ntype_to_valid_counts[ntype] = valid_counts.to(device)
-
-        if self._is_homogeneous:
-            assert (
-                len(ntype_to_flat_ids) == 1
-                and DEFAULT_HOMOGENEOUS_NODE_TYPE in ntype_to_flat_ids
-            )
-            return (
-                ntype_to_flat_ids[DEFAULT_HOMOGENEOUS_NODE_TYPE],
-                ntype_to_flat_weights[DEFAULT_HOMOGENEOUS_NODE_TYPE],
-                ntype_to_valid_counts[DEFAULT_HOMOGENEOUS_NODE_TYPE],
-            )
-        else:
-            return (
-                ntype_to_flat_ids,
-                ntype_to_flat_weights,
-                ntype_to_valid_counts,
-            )
+        return self._extract_ppr_state_top_k(
+            ppr_state,
+            device,
+            max_ppr_nodes=self._max_ppr_nodes,
+            residual_topup_nodes=self._max_ppr_nodes,
+            max_total_nodes=self._max_ppr_nodes,
+        )
 
     async def _sample_from_nodes(
         self,

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -303,8 +303,8 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         ``residual_topup_nodes`` controls how many discovered residual
         candidates may be considered after finalized PPR scores.  ``max_total_nodes``
         is a combined per-seed cap across finalized and residual candidates.
-        When both are set, the cap is passed into C++ so residual candidates are
-        not materialized only to be discarded later in Python.
+        When set, the cap is passed into C++ so residual candidates are not
+        materialized only to be discarded later in Python.
         """
         # Translate ntype_id integer keys back to NodeType strings for the rest
         # of the pipeline, and move tensors to the correct device.
@@ -315,7 +315,6 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         ppr_node_quota = (
             max_ppr_nodes if max_ppr_nodes is not None else self._max_ppr_nodes
         )
-        extraction_is_total_capped = False
         if residual_topup_nodes > 0:
             max_total_nodes_for_extraction = (
                 max_total_nodes if max_total_nodes is not None else -1
@@ -325,12 +324,8 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
                 residual_topup_nodes,
                 max_total_nodes_for_extraction,
             )
-            extraction_is_total_capped = max_total_nodes is not None
         else:
             extracted_results = ppr_state.extract_top_k(ppr_node_quota)
-            extraction_is_total_capped = (
-                max_total_nodes is None or ppr_node_quota <= max_total_nodes
-            )
 
         for ntype_id, (
             flat_ids,
@@ -341,19 +336,6 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             ntype_to_flat_ids[ntype] = flat_ids.to(device)
             ntype_to_flat_weights[ntype] = flat_weights.to(device)
             ntype_to_valid_counts[ntype] = valid_counts.to(device)
-
-        if max_total_nodes is not None and not extraction_is_total_capped:
-            for ntype in ntype_to_flat_ids:
-                (
-                    ntype_to_flat_ids[ntype],
-                    ntype_to_flat_weights[ntype],
-                    ntype_to_valid_counts[ntype],
-                ) = self._truncate_flat_ppr_result_to_max_nodes(
-                    flat_ids=ntype_to_flat_ids[ntype],
-                    flat_weights=ntype_to_flat_weights[ntype],
-                    valid_counts=ntype_to_valid_counts[ntype],
-                    max_nodes=max_total_nodes,
-                )
 
         if self._is_homogeneous:
             assert (
@@ -371,49 +353,6 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
                 ntype_to_flat_weights,
                 ntype_to_valid_counts,
             )
-
-    @staticmethod
-    def _truncate_flat_ppr_result_to_max_nodes(
-        flat_ids: torch.Tensor,
-        flat_weights: torch.Tensor,
-        valid_counts: torch.Tensor,
-        max_nodes: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Cap each seed's flat PPR result while preserving flat tensor layout.
-
-        ``flat_ids`` and ``flat_weights`` concatenate variable-length per-seed
-        candidate lists.  ``valid_counts`` stores the segment length for each
-        seed.  This fallback trims each segment independently and rebuilds the
-        same flat representation.
-        """
-        if max_nodes < 0:
-            raise ValueError(f"max_nodes must be non-negative, got {max_nodes}.")
-
-        id_parts: list[torch.Tensor] = []
-        weight_parts: list[torch.Tensor] = []
-        capped_counts: list[int] = []
-        offset = 0
-        for count in valid_counts.detach().cpu().tolist():
-            count = int(count)
-            keep_count = min(count, max_nodes)
-            if keep_count > 0:
-                id_parts.append(flat_ids[offset : offset + keep_count])
-                weight_parts.append(flat_weights[offset : offset + keep_count])
-            capped_counts.append(keep_count)
-            offset += count
-
-        capped_flat_ids = torch.cat(id_parts) if id_parts else flat_ids.new_empty((0,))
-        capped_flat_weights = (
-            torch.cat(weight_parts)
-            if weight_parts
-            else flat_weights.new_empty((0, *flat_weights.shape[1:]))
-        )
-        capped_valid_counts = torch.tensor(
-            capped_counts,
-            dtype=valid_counts.dtype,
-            device=valid_counts.device,
-        )
-        return capped_flat_ids, capped_flat_weights, capped_valid_counts
 
     async def _compute_ppr_scores(
         self,

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -73,8 +73,12 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         eps: Convergence threshold. Smaller values give more accurate PPR scores
              but require more computation. Typical values: 1e-4 to 1e-6.
         max_ppr_nodes: Maximum number of nodes to return per seed. If finalized
-            PPR scores produce fewer than this cap, discovered residual
-            candidates are appended with score ``ppr_score + residual``.
+            PPR scores produce fewer than this cap and residual top-up is
+            enabled, discovered residual candidates are appended with score
+            ``ppr_score + residual``.
+        enable_residual_topup: Whether to append residual candidates discovered
+            during Forward Push when fewer than ``max_ppr_nodes`` finalized PPR
+            scores are available.
         num_neighbors_per_hop: Maximum number of neighbors to fetch per hop.
         degree_tensors: Pre-computed total-degree tensors (int32). Homogeneous
             graphs use a single tensor; heterogeneous graphs use tensors keyed
@@ -89,6 +93,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         alpha: float = 0.5,
         eps: float = 1e-4,
         max_ppr_nodes: int = 50,
+        enable_residual_topup: bool = True,
         num_neighbors_per_hop: int = 100_000,
         degree_tensors: Union[torch.Tensor, dict[NodeType, torch.Tensor]],
         max_fetch_iterations: Optional[int] = None,
@@ -97,6 +102,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         super().__init__(*args, **kwargs)
         self._alpha = alpha
         self._max_ppr_nodes = max_ppr_nodes
+        self._enable_residual_topup = enable_residual_topup
         self._requeue_threshold_factor = alpha * eps
         self._num_neighbors_per_hop = num_neighbors_per_hop
         self._max_fetch_iterations = max_fetch_iterations
@@ -482,11 +488,14 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
                 None, ppr_state.push_residuals, fetched_by_etype_id
             )
 
+        residual_topup_nodes = (
+            self._max_ppr_nodes if self._enable_residual_topup else 0
+        )
         return self._extract_ppr_state_top_k(
             ppr_state,
             device,
             max_ppr_nodes=self._max_ppr_nodes,
-            residual_topup_nodes=self._max_ppr_nodes,
+            residual_topup_nodes=residual_topup_nodes,
             max_total_nodes=self._max_ppr_nodes,
         )
 

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -293,6 +293,19 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         Union[torch.Tensor, dict[NodeType, torch.Tensor]],
         Union[torch.Tensor, dict[NodeType, torch.Tensor]],
     ]:
+        """Extract PPR neighbors from a completed C++ Forward Push state.
+
+        The C++ kernel indexes node types by compact integer IDs for speed.
+        This helper translates those IDs back to GiGL node-type keys and
+        preserves the homogeneous return shape expected by the rest of the
+        sampler.
+
+        ``residual_topup_nodes`` controls how many discovered residual
+        candidates may be considered after finalized PPR scores.  ``max_total_nodes``
+        is a combined per-seed cap across finalized and residual candidates.
+        When both are set, the cap is passed into C++ so residual candidates are
+        not materialized only to be discarded later in Python.
+        """
         # Translate ntype_id integer keys back to NodeType strings for the rest
         # of the pipeline, and move tensors to the correct device.
         ntype_to_flat_ids: dict[NodeType, torch.Tensor] = {}
@@ -302,13 +315,22 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         ppr_node_quota = (
             max_ppr_nodes if max_ppr_nodes is not None else self._max_ppr_nodes
         )
+        extraction_is_total_capped = False
         if residual_topup_nodes > 0:
+            max_total_nodes_for_extraction = (
+                max_total_nodes if max_total_nodes is not None else -1
+            )
             extracted_results = ppr_state.extract_top_k_with_residual_top_up(
                 ppr_node_quota,
                 residual_topup_nodes,
+                max_total_nodes_for_extraction,
             )
+            extraction_is_total_capped = max_total_nodes is not None
         else:
             extracted_results = ppr_state.extract_top_k(ppr_node_quota)
+            extraction_is_total_capped = (
+                max_total_nodes is None or ppr_node_quota <= max_total_nodes
+            )
 
         for ntype_id, (
             flat_ids,
@@ -320,7 +342,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             ntype_to_flat_weights[ntype] = flat_weights.to(device)
             ntype_to_valid_counts[ntype] = valid_counts.to(device)
 
-        if max_total_nodes is not None:
+        if max_total_nodes is not None and not extraction_is_total_capped:
             for ntype in ntype_to_flat_ids:
                 (
                     ntype_to_flat_ids[ntype],
@@ -357,7 +379,13 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         valid_counts: torch.Tensor,
         max_nodes: int,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Cap each seed's flat PPR result after residual top-up."""
+        """Cap each seed's flat PPR result while preserving flat tensor layout.
+
+        ``flat_ids`` and ``flat_weights`` concatenate variable-length per-seed
+        candidate lists.  ``valid_counts`` stores the segment length for each
+        seed.  This fallback trims each segment independently and rebuilds the
+        same flat representation.
+        """
         if max_nodes < 0:
             raise ValueError(f"max_nodes must be non-negative, got {max_nodes}.")
 

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -37,20 +37,6 @@ _PPR_HOMOGENEOUS_EDGE_TYPE = (
 )
 
 
-def _extract_top_k_from_ppr_state(
-    ppr_state,
-    max_ppr_nodes: int,
-    residual_topup_nodes: int,
-    max_total_nodes: int,
-) -> dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]:
-    """Call the shared C++ extraction path for the configured quotas."""
-    return ppr_state.extract_top_k_with_residual_top_up(
-        max_ppr_nodes,
-        residual_topup_nodes,
-        max_total_nodes,
-    )
-
-
 class DistPPRNeighborSampler(BaseDistNeighborSampler):
     """Personalized PageRank (PPR) based distributed neighbor sampler.
 
@@ -310,7 +296,6 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         device: torch.device,
         max_ppr_nodes: int,
         residual_topup_nodes: int,
-        max_total_nodes: int,
     ) -> tuple[
         Union[torch.Tensor, dict[NodeType, torch.Tensor]],
         Union[torch.Tensor, dict[NodeType, torch.Tensor]],
@@ -326,8 +311,14 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         The quota arguments are passed in explicitly by the caller so this
         helper only translates the C++ output shape.  ``residual_topup_nodes``
         controls how many discovered residual candidates may be considered
-        after finalized PPR scores.  ``max_total_nodes`` is a combined per-seed
-        cap across finalized and residual candidates.
+        after finalized PPR scores.  Regular PPR uses ``max_ppr_nodes`` as the
+        combined per-seed cap across finalized and residual candidates.
+
+        Returns:
+            ``(flat_ids, flat_weights, valid_counts)`` for homogeneous graphs,
+            or three dictionaries keyed by node type for heterogeneous graphs.
+            ``flat_ids`` and ``flat_weights`` are concatenated across seeds;
+            ``valid_counts`` stores how many selected nodes belong to each seed.
         """
         # Translate ntype_id integer keys back to NodeType strings for the rest
         # of the pipeline, and move tensors to the correct device.
@@ -335,11 +326,10 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         ntype_to_flat_weights: dict[NodeType, torch.Tensor] = {}
         ntype_to_valid_counts: dict[NodeType, torch.Tensor] = {}
 
-        extracted_results = _extract_top_k_from_ppr_state(
-            ppr_state,
+        extracted_results = ppr_state.extract_top_k_with_residual_top_up(
             max_ppr_nodes,
             residual_topup_nodes,
-            max_total_nodes,
+            max_ppr_nodes,
         )
 
         for ntype_id, (
@@ -479,7 +469,6 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             device,
             max_ppr_nodes=self._max_ppr_nodes,
             residual_topup_nodes=residual_topup_nodes,
-            max_total_nodes=self._max_ppr_nodes,
         )
 
     async def _sample_from_nodes(

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -51,10 +51,11 @@ class PPRSamplerOptions:
             values give more accurate PPR scores but require more computation.
             Typical values: 1e-4 to 1e-6.
         max_ppr_nodes: Maximum number of nodes to return per seed based on PPR
-            scores. If finalized PPR scores produce fewer than this cap, the
-            sampler appends discovered-but-unpushed residual candidates from
-            the completed Forward Push state. Residual top-up candidates are
-            scored on the same mass scale as PPR scores: ``ppr_score + residual``.
+            scores.
+        enable_residual_topup: Whether to append discovered-but-unpushed
+            residual candidates when finalized PPR scores produce fewer than
+            ``max_ppr_nodes`` results. Residual top-up candidates are scored on
+            the same mass scale as PPR scores: ``ppr_score + residual``.
         num_neighbors_per_hop: Maximum number of neighbors fetched per node per edge
             type during PPR traversal. 1000 is sufficient in practice — high-degree
             hub nodes receive diminishing residual per neighbor, so capping the fetch
@@ -71,6 +72,7 @@ class PPRSamplerOptions:
     alpha: float = 0.5
     eps: float = 1e-4
     max_ppr_nodes: int = 50
+    enable_residual_topup: bool = True
     num_neighbors_per_hop: int = 1_000
     max_fetch_iterations: Optional[int] = None
 

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -51,7 +51,10 @@ class PPRSamplerOptions:
             values give more accurate PPR scores but require more computation.
             Typical values: 1e-4 to 1e-6.
         max_ppr_nodes: Maximum number of nodes to return per seed based on PPR
-            scores.
+            scores. If finalized PPR scores produce fewer than this cap, the
+            sampler appends discovered-but-unpushed residual candidates from
+            the completed Forward Push state. Residual top-up candidates are
+            scored on the same mass scale as PPR scores: ``ppr_score + residual``.
         num_neighbors_per_hop: Maximum number of neighbors fetched per node per edge
             type during PPR traversal. 1000 is sufficient in practice — high-degree
             hub nodes receive diminishing residual per neighbor, so capping the fetch

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -44,6 +44,12 @@ class PPRSamplerOptions:
 
     For homogeneous graphs these live directly on ``data.edge_index`` / ``data.edge_attr``.
 
+    Residual top-up is a sequence-length knob that avoids lowering ``eps`` just
+    to get more returned nodes.  Lowering ``eps`` re-enqueues more low-residual
+    nodes but increases push iterations and neighbor-fetch work; top-up instead
+    fills unused output slots with already-discovered positive-residual nodes
+    that were closest to crossing the requeue threshold.
+
     Attributes:
         alpha: Restart probability (teleport probability back to seed). Higher
             values keep samples closer to seeds. Typical values: 0.15-0.25.
@@ -55,7 +61,9 @@ class PPRSamplerOptions:
         enable_residual_topup: Whether to append discovered-but-unpushed
             residual candidates when finalized PPR scores produce fewer than
             ``max_ppr_nodes`` results. Residual top-up candidates are scored on
-            the same mass scale as PPR scores: ``ppr_score + residual``.
+            the same mass scale as PPR scores: ``ppr_score + residual``. They
+            fill only unused output slots and do not displace finalized PPR nodes
+            when those already fill ``max_ppr_nodes``.
         num_neighbors_per_hop: Maximum number of neighbors fetched per node per edge
             type during PPR traversal. 1000 is sufficient in practice — high-degree
             hub nodes receive diminishing residual per neighbor, so capping the fetch

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -44,11 +44,11 @@ class PPRSamplerOptions:
 
     For homogeneous graphs these live directly on ``data.edge_index`` / ``data.edge_attr``.
 
-    Residual top-up is a sequence-length knob that avoids lowering ``eps`` just
-    to get more returned nodes.  Lowering ``eps`` re-enqueues more low-residual
-    nodes but increases push iterations and neighbor-fetch work; top-up instead
-    fills unused output slots with already-discovered positive-residual nodes
-    that were closest to crossing the requeue threshold.
+    Enable residual top-up when you want longer returned sequences without
+    paying the throughput cost of lowering ``eps``.  Lowering ``eps``
+    re-enqueues more low-residual nodes but increases push iterations and
+    neighbor-fetch work; top-up instead uses positive-residual nodes already
+    discovered during Forward Push.
 
     Attributes:
         alpha: Restart probability (teleport probability back to seed). Higher

--- a/gigl/distributed/utils/dist_sampler.py
+++ b/gigl/distributed/utils/dist_sampler.py
@@ -82,6 +82,7 @@ def create_dist_sampler(
             alpha=sampler_options.alpha,
             eps=sampler_options.eps,
             max_ppr_nodes=sampler_options.max_ppr_nodes,
+            enable_residual_topup=sampler_options.enable_residual_topup,
             max_fetch_iterations=sampler_options.max_fetch_iterations,
             num_neighbors_per_hop=sampler_options.num_neighbors_per_hop,
             degree_tensors=degree_tensors,

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -26,6 +26,7 @@ graph (add dst→src instead of src→dst).  When ``edge_dir="out"``, no
 reversal is needed since both follow the original edge direction.
 """
 
+import asyncio
 import heapq
 from collections import defaultdict
 from typing import Literal
@@ -38,7 +39,9 @@ from graphlearn_torch.distributed import shutdown_rpc
 from parameterized import param, parameterized
 from torch_geometric.data import Data, HeteroData
 
+import gigl.distributed.dist_ppr_sampler as dist_ppr_sampler_module
 from gigl.distributed.dist_ablp_neighborloader import DistABLPLoader
+from gigl.distributed.dist_ppr_sampler import DistPPRNeighborSampler
 from gigl.distributed.distributed_neighborloader import DistNeighborLoader
 from gigl.distributed.sampler_options import PPRSamplerOptions
 from gigl.types.graph import (
@@ -814,6 +817,65 @@ class DistPPRSamplerTest(TestCase):
     def test_ppr_sampler_homogeneous_ablp(self) -> None:
         """Verify PPR handles homogeneous ABLP seed dictionaries."""
         mp.spawn(fn=_run_ppr_labeled_homogeneous_ablp_loader_check, args=())
+
+    def test_regular_ppr_uses_residual_topup_and_caps_results(self) -> None:
+        """Verify non-typed PPR uses residual top-up without exceeding max_ppr_nodes."""
+
+        class FakePPRForwardPush:
+            def __init__(self, *_, **__):
+                self.extract_topup_args = None
+
+            def drain_queue(self):
+                return None
+
+            def extract_top_k(self, *_):
+                raise AssertionError("regular PPR should use residual top-up extraction")
+
+            def extract_top_k_with_residual_top_up(
+                self,
+                max_ppr_nodes: int,
+                max_residual_nodes: int,
+            ):
+                self.extract_topup_args = (max_ppr_nodes, max_residual_nodes)
+                return {
+                    0: (
+                        torch.tensor([10, 11, 12], dtype=torch.long),
+                        torch.tensor([0.7, 0.2, 0.1], dtype=torch.double),
+                        torch.tensor([3], dtype=torch.long),
+                    )
+                }
+
+        sampler = object.__new__(DistPPRNeighborSampler)
+        sampler._alpha = _TEST_ALPHA
+        sampler._requeue_threshold_factor = _TEST_ALPHA * _TEST_EPS
+        sampler._max_ppr_nodes = 2
+        sampler._max_fetch_iterations = None
+        sampler._is_homogeneous = True
+        sampler._node_type_to_id = {DEFAULT_HOMOGENEOUS_NODE_TYPE: 0}
+        sampler._ntype_id_to_ntype = [DEFAULT_HOMOGENEOUS_NODE_TYPE]
+        sampler._node_type_id_to_edge_type_ids = [[]]
+        sampler._edge_type_id_to_dst_ntype_id = []
+        sampler._degree_tensors_for_cpp = [torch.zeros(0, dtype=torch.int32)]
+
+        fake_state = FakePPRForwardPush()
+        original_ppr_forward_push = dist_ppr_sampler_module.PPRForwardPush
+        dist_ppr_sampler_module.PPRForwardPush = lambda *args, **kwargs: fake_state
+        try:
+            flat_ids, flat_weights, valid_counts = asyncio.run(
+                sampler._compute_ppr_scores(
+                    seed_nodes=torch.tensor([0], dtype=torch.long),
+                    seed_node_type=None,
+                )
+            )
+        finally:
+            dist_ppr_sampler_module.PPRForwardPush = original_ppr_forward_push
+
+        self.assertEqual(fake_state.extract_topup_args, (2, 2))
+        self.assertTrue(torch.equal(flat_ids, torch.tensor([10, 11])))
+        self.assertTrue(
+            torch.equal(flat_weights, torch.tensor([0.7, 0.2], dtype=torch.double))
+        )
+        self.assertTrue(torch.equal(valid_counts, torch.tensor([2])))
 
 
 if __name__ == "__main__":

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -818,6 +818,26 @@ class DistPPRSamplerTest(TestCase):
         """Verify PPR handles homogeneous ABLP seed dictionaries."""
         mp.spawn(fn=_run_ppr_labeled_homogeneous_ablp_loader_check, args=())
 
+    @staticmethod
+    def _build_minimal_homogeneous_sampler(
+        *,
+        max_ppr_nodes: int,
+        enable_residual_topup: bool,
+    ) -> DistPPRNeighborSampler:
+        sampler = object.__new__(DistPPRNeighborSampler)
+        sampler._alpha = _TEST_ALPHA
+        sampler._requeue_threshold_factor = _TEST_ALPHA * _TEST_EPS
+        sampler._max_ppr_nodes = max_ppr_nodes
+        sampler._enable_residual_topup = enable_residual_topup
+        sampler._max_fetch_iterations = None
+        sampler._is_homogeneous = True
+        sampler._node_type_to_id = {DEFAULT_HOMOGENEOUS_NODE_TYPE: 0}
+        sampler._ntype_id_to_ntype = [DEFAULT_HOMOGENEOUS_NODE_TYPE]
+        sampler._node_type_id_to_edge_type_ids = [[]]
+        sampler._edge_type_id_to_dst_ntype_id = []
+        sampler._degree_tensors_for_cpp = [torch.zeros(0, dtype=torch.int32)]
+        return sampler
+
     def test_regular_ppr_uses_residual_topup_and_caps_results(self) -> None:
         """Verify non-typed PPR uses residual top-up without exceeding max_ppr_nodes."""
 
@@ -845,17 +865,10 @@ class DistPPRSamplerTest(TestCase):
                     )
                 }
 
-        sampler = object.__new__(DistPPRNeighborSampler)
-        sampler._alpha = _TEST_ALPHA
-        sampler._requeue_threshold_factor = _TEST_ALPHA * _TEST_EPS
-        sampler._max_ppr_nodes = 2
-        sampler._max_fetch_iterations = None
-        sampler._is_homogeneous = True
-        sampler._node_type_to_id = {DEFAULT_HOMOGENEOUS_NODE_TYPE: 0}
-        sampler._ntype_id_to_ntype = [DEFAULT_HOMOGENEOUS_NODE_TYPE]
-        sampler._node_type_id_to_edge_type_ids = [[]]
-        sampler._edge_type_id_to_dst_ntype_id = []
-        sampler._degree_tensors_for_cpp = [torch.zeros(0, dtype=torch.int32)]
+        sampler = self._build_minimal_homogeneous_sampler(
+            max_ppr_nodes=2,
+            enable_residual_topup=True,
+        )
 
         fake_state = FakePPRForwardPush()
         original_ppr_forward_push = dist_ppr_sampler_module.PPRForwardPush
@@ -876,6 +889,54 @@ class DistPPRSamplerTest(TestCase):
             torch.equal(flat_weights, torch.tensor([0.7, 0.2], dtype=torch.double))
         )
         self.assertTrue(torch.equal(valid_counts, torch.tensor([2])))
+
+    def test_regular_ppr_can_disable_residual_topup(self) -> None:
+        """Verify non-typed PPR can keep the pre-top-up extraction behavior."""
+
+        class FakePPRForwardPush:
+            def __init__(self, *_, **__):
+                self.extract_top_k_args = None
+
+            def drain_queue(self):
+                return None
+
+            def extract_top_k(self, max_ppr_nodes: int):
+                self.extract_top_k_args = max_ppr_nodes
+                return {
+                    0: (
+                        torch.tensor([20], dtype=torch.long),
+                        torch.tensor([0.8], dtype=torch.double),
+                        torch.tensor([1], dtype=torch.long),
+                    )
+                }
+
+            def extract_top_k_with_residual_top_up(self, *_):
+                raise AssertionError("residual top-up should be disabled")
+
+        sampler = self._build_minimal_homogeneous_sampler(
+            max_ppr_nodes=2,
+            enable_residual_topup=False,
+        )
+
+        fake_state = FakePPRForwardPush()
+        original_ppr_forward_push = dist_ppr_sampler_module.PPRForwardPush
+        dist_ppr_sampler_module.PPRForwardPush = lambda *args, **kwargs: fake_state
+        try:
+            flat_ids, flat_weights, valid_counts = asyncio.run(
+                sampler._compute_ppr_scores(
+                    seed_nodes=torch.tensor([0], dtype=torch.long),
+                    seed_node_type=None,
+                )
+            )
+        finally:
+            dist_ppr_sampler_module.PPRForwardPush = original_ppr_forward_push
+
+        self.assertEqual(fake_state.extract_top_k_args, 2)
+        self.assertTrue(torch.equal(flat_ids, torch.tensor([20])))
+        self.assertTrue(
+            torch.equal(flat_weights, torch.tensor([0.8], dtype=torch.double))
+        )
+        self.assertTrue(torch.equal(valid_counts, torch.tensor([1])))
 
 
 if __name__ == "__main__":

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -26,11 +26,9 @@ graph (add dst→src instead of src→dst).  When ``edge_dir="out"``, no
 reversal is needed since both follow the original edge direction.
 """
 
-import asyncio
 import heapq
 from collections import defaultdict
 from typing import Literal
-from unittest.mock import patch
 
 import networkx as nx
 import torch
@@ -42,7 +40,6 @@ from torch_geometric.data import Data, HeteroData
 
 import gigl.distributed.dist_ppr_sampler as dist_ppr_sampler_module
 from gigl.distributed.dist_ablp_neighborloader import DistABLPLoader
-from gigl.distributed.dist_ppr_sampler import DistPPRNeighborSampler
 from gigl.distributed.distributed_neighborloader import DistNeighborLoader
 from gigl.distributed.sampler_options import PPRSamplerOptions
 from gigl.types.graph import (
@@ -819,41 +816,12 @@ class DistPPRSamplerTest(TestCase):
         """Verify PPR handles homogeneous ABLP seed dictionaries."""
         mp.spawn(fn=_run_ppr_labeled_homogeneous_ablp_loader_check, args=())
 
-    @staticmethod
-    def _build_minimal_homogeneous_sampler(
-        *,
-        max_ppr_nodes: int,
-        enable_residual_topup: bool,
-    ) -> DistPPRNeighborSampler:
-        """Build only the sampler fields needed by extraction-focused tests."""
-        sampler = object.__new__(DistPPRNeighborSampler)
-        sampler._alpha = _TEST_ALPHA
-        sampler._requeue_threshold_factor = _TEST_ALPHA * _TEST_EPS
-        sampler._max_ppr_nodes = max_ppr_nodes
-        sampler._enable_residual_topup = enable_residual_topup
-        sampler._max_fetch_iterations = None
-        sampler._is_homogeneous = True
-        sampler._node_type_to_id = {DEFAULT_HOMOGENEOUS_NODE_TYPE: 0}
-        sampler._ntype_id_to_ntype = [DEFAULT_HOMOGENEOUS_NODE_TYPE]
-        sampler._node_type_id_to_edge_type_ids = [[]]
-        sampler._edge_type_id_to_dst_ntype_id = []
-        sampler._degree_tensors_for_cpp = [torch.zeros(0, dtype=torch.int32)]
-        return sampler
-
-    def test_regular_ppr_uses_residual_topup_and_caps_results(self) -> None:
-        """Verify non-typed PPR uses residual top-up without exceeding max_ppr_nodes."""
+    def test_ppr_extraction_uses_residual_topup_and_caps_results(self) -> None:
+        """Verify extraction uses residual top-up without exceeding max_ppr_nodes."""
 
         class FakePPRForwardPush:
             def __init__(self, *_, **__):
                 self.extract_topup_args = None
-
-            def drain_queue(self):
-                return None
-
-            def extract_top_k(self, *_):
-                raise AssertionError(
-                    "regular PPR should use residual top-up extraction"
-                )
 
             def extract_top_k_with_residual_top_up(
                 self,
@@ -874,44 +842,40 @@ class DistPPRSamplerTest(TestCase):
                     )
                 }
 
-        sampler = self._build_minimal_homogeneous_sampler(
+        fake_state = FakePPRForwardPush()
+        extracted_results = dist_ppr_sampler_module._extract_top_k_from_ppr_state(
+            fake_state,
             max_ppr_nodes=2,
-            enable_residual_topup=True,
+            residual_topup_nodes=2,
+            max_total_nodes=2,
         )
 
-        fake_state = FakePPRForwardPush()
-        with patch.object(
-            dist_ppr_sampler_module, "PPRForwardPush", return_value=fake_state
-        ):
-            flat_ids, flat_weights, valid_counts = asyncio.run(
-                sampler._compute_ppr_scores(
-                    seed_nodes=torch.tensor([0], dtype=torch.long),
-                    seed_node_type=None,
-                )
-            )
-
         self.assertEqual(fake_state.extract_topup_args, (2, 2, 2))
-        assert isinstance(flat_ids, torch.Tensor)
-        assert isinstance(flat_weights, torch.Tensor)
-        assert isinstance(valid_counts, torch.Tensor)
+        flat_ids, flat_weights, valid_counts = extracted_results[0]
         self.assertTrue(torch.equal(flat_ids, torch.tensor([10, 11])))
         self.assertTrue(
             torch.equal(flat_weights, torch.tensor([0.7, 0.2], dtype=torch.double))
         )
         self.assertTrue(torch.equal(valid_counts, torch.tensor([2])))
 
-    def test_regular_ppr_can_disable_residual_topup(self) -> None:
-        """Verify non-typed PPR can keep the pre-top-up extraction behavior."""
+    def test_ppr_extraction_can_disable_residual_topup(self) -> None:
+        """Verify extraction can keep the pre-top-up behavior."""
 
         class FakePPRForwardPush:
             def __init__(self, *_, **__):
-                self.extract_top_k_args = None
+                self.extract_topup_args = None
 
-            def drain_queue(self):
-                return None
-
-            def extract_top_k(self, max_ppr_nodes: int):
-                self.extract_top_k_args = max_ppr_nodes
+            def extract_top_k_with_residual_top_up(
+                self,
+                max_ppr_nodes: int,
+                max_residual_nodes: int,
+                max_total_nodes: int,
+            ):
+                self.extract_topup_args = (
+                    max_ppr_nodes,
+                    max_residual_nodes,
+                    max_total_nodes,
+                )
                 return {
                     0: (
                         torch.tensor([20], dtype=torch.long),
@@ -920,29 +884,16 @@ class DistPPRSamplerTest(TestCase):
                     )
                 }
 
-            def extract_top_k_with_residual_top_up(self, *_):
-                raise AssertionError("residual top-up should be disabled")
-
-        sampler = self._build_minimal_homogeneous_sampler(
+        fake_state = FakePPRForwardPush()
+        extracted_results = dist_ppr_sampler_module._extract_top_k_from_ppr_state(
+            fake_state,
             max_ppr_nodes=2,
-            enable_residual_topup=False,
+            residual_topup_nodes=0,
+            max_total_nodes=2,
         )
 
-        fake_state = FakePPRForwardPush()
-        with patch.object(
-            dist_ppr_sampler_module, "PPRForwardPush", return_value=fake_state
-        ):
-            flat_ids, flat_weights, valid_counts = asyncio.run(
-                sampler._compute_ppr_scores(
-                    seed_nodes=torch.tensor([0], dtype=torch.long),
-                    seed_node_type=None,
-                )
-            )
-
-        self.assertEqual(fake_state.extract_top_k_args, 2)
-        assert isinstance(flat_ids, torch.Tensor)
-        assert isinstance(flat_weights, torch.Tensor)
-        assert isinstance(valid_counts, torch.Tensor)
+        self.assertEqual(fake_state.extract_topup_args, (2, 0, 2))
+        flat_ids, flat_weights, valid_counts = extracted_results[0]
         self.assertTrue(torch.equal(flat_ids, torch.tensor([20])))
         self.assertTrue(
             torch.equal(flat_weights, torch.tensor([0.8], dtype=torch.double))

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -824,6 +824,7 @@ class DistPPRSamplerTest(TestCase):
         max_ppr_nodes: int,
         enable_residual_topup: bool,
     ) -> DistPPRNeighborSampler:
+        """Build only the sampler fields needed by extraction-focused tests."""
         sampler = object.__new__(DistPPRNeighborSampler)
         sampler._alpha = _TEST_ALPHA
         sampler._requeue_threshold_factor = _TEST_ALPHA * _TEST_EPS
@@ -855,13 +856,18 @@ class DistPPRSamplerTest(TestCase):
                 self,
                 max_ppr_nodes: int,
                 max_residual_nodes: int,
+                max_total_nodes: int,
             ):
-                self.extract_topup_args = (max_ppr_nodes, max_residual_nodes)
+                self.extract_topup_args = (
+                    max_ppr_nodes,
+                    max_residual_nodes,
+                    max_total_nodes,
+                )
                 return {
                     0: (
-                        torch.tensor([10, 11, 12], dtype=torch.long),
-                        torch.tensor([0.7, 0.2, 0.1], dtype=torch.double),
-                        torch.tensor([3], dtype=torch.long),
+                        torch.tensor([10, 11], dtype=torch.long),
+                        torch.tensor([0.7, 0.2], dtype=torch.double),
+                        torch.tensor([2], dtype=torch.long),
                     )
                 }
 
@@ -883,7 +889,7 @@ class DistPPRSamplerTest(TestCase):
         finally:
             dist_ppr_sampler_module.PPRForwardPush = original_ppr_forward_push
 
-        self.assertEqual(fake_state.extract_topup_args, (2, 2))
+        self.assertEqual(fake_state.extract_topup_args, (2, 2, 2))
         self.assertTrue(torch.equal(flat_ids, torch.tensor([10, 11])))
         self.assertTrue(
             torch.equal(flat_weights, torch.tensor([0.7, 0.2], dtype=torch.double))

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -30,6 +30,7 @@ import asyncio
 import heapq
 from collections import defaultdict
 from typing import Literal
+from unittest.mock import patch
 
 import networkx as nx
 import torch
@@ -850,7 +851,9 @@ class DistPPRSamplerTest(TestCase):
                 return None
 
             def extract_top_k(self, *_):
-                raise AssertionError("regular PPR should use residual top-up extraction")
+                raise AssertionError(
+                    "regular PPR should use residual top-up extraction"
+                )
 
             def extract_top_k_with_residual_top_up(
                 self,
@@ -877,19 +880,20 @@ class DistPPRSamplerTest(TestCase):
         )
 
         fake_state = FakePPRForwardPush()
-        original_ppr_forward_push = dist_ppr_sampler_module.PPRForwardPush
-        dist_ppr_sampler_module.PPRForwardPush = lambda *args, **kwargs: fake_state
-        try:
+        with patch.object(
+            dist_ppr_sampler_module, "PPRForwardPush", return_value=fake_state
+        ):
             flat_ids, flat_weights, valid_counts = asyncio.run(
                 sampler._compute_ppr_scores(
                     seed_nodes=torch.tensor([0], dtype=torch.long),
                     seed_node_type=None,
                 )
             )
-        finally:
-            dist_ppr_sampler_module.PPRForwardPush = original_ppr_forward_push
 
         self.assertEqual(fake_state.extract_topup_args, (2, 2, 2))
+        assert isinstance(flat_ids, torch.Tensor)
+        assert isinstance(flat_weights, torch.Tensor)
+        assert isinstance(valid_counts, torch.Tensor)
         self.assertTrue(torch.equal(flat_ids, torch.tensor([10, 11])))
         self.assertTrue(
             torch.equal(flat_weights, torch.tensor([0.7, 0.2], dtype=torch.double))
@@ -925,19 +929,20 @@ class DistPPRSamplerTest(TestCase):
         )
 
         fake_state = FakePPRForwardPush()
-        original_ppr_forward_push = dist_ppr_sampler_module.PPRForwardPush
-        dist_ppr_sampler_module.PPRForwardPush = lambda *args, **kwargs: fake_state
-        try:
+        with patch.object(
+            dist_ppr_sampler_module, "PPRForwardPush", return_value=fake_state
+        ):
             flat_ids, flat_weights, valid_counts = asyncio.run(
                 sampler._compute_ppr_scores(
                     seed_nodes=torch.tensor([0], dtype=torch.long),
                     seed_node_type=None,
                 )
             )
-        finally:
-            dist_ppr_sampler_module.PPRForwardPush = original_ppr_forward_push
 
         self.assertEqual(fake_state.extract_top_k_args, 2)
+        assert isinstance(flat_ids, torch.Tensor)
+        assert isinstance(flat_weights, torch.Tensor)
+        assert isinstance(valid_counts, torch.Tensor)
         self.assertTrue(torch.equal(flat_ids, torch.tensor([20])))
         self.assertTrue(
             torch.equal(flat_weights, torch.tensor([0.8], dtype=torch.double))

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -38,7 +38,6 @@ from graphlearn_torch.distributed import shutdown_rpc
 from parameterized import param, parameterized
 from torch_geometric.data import Data, HeteroData
 
-import gigl.distributed.dist_ppr_sampler as dist_ppr_sampler_module
 from gigl.distributed.dist_ablp_neighborloader import DistABLPLoader
 from gigl.distributed.distributed_neighborloader import DistNeighborLoader
 from gigl.distributed.sampler_options import PPRSamplerOptions
@@ -815,90 +814,6 @@ class DistPPRSamplerTest(TestCase):
     def test_ppr_sampler_homogeneous_ablp(self) -> None:
         """Verify PPR handles homogeneous ABLP seed dictionaries."""
         mp.spawn(fn=_run_ppr_labeled_homogeneous_ablp_loader_check, args=())
-
-    def test_ppr_extraction_uses_residual_topup_and_caps_results(self) -> None:
-        """Verify extraction uses residual top-up without exceeding max_ppr_nodes."""
-
-        class FakePPRForwardPush:
-            def __init__(self, *_, **__):
-                self.extract_topup_args = None
-
-            def extract_top_k_with_residual_top_up(
-                self,
-                max_ppr_nodes: int,
-                max_residual_nodes: int,
-                max_total_nodes: int,
-            ):
-                self.extract_topup_args = (
-                    max_ppr_nodes,
-                    max_residual_nodes,
-                    max_total_nodes,
-                )
-                return {
-                    0: (
-                        torch.tensor([10, 11], dtype=torch.long),
-                        torch.tensor([0.7, 0.2], dtype=torch.double),
-                        torch.tensor([2], dtype=torch.long),
-                    )
-                }
-
-        fake_state = FakePPRForwardPush()
-        extracted_results = dist_ppr_sampler_module._extract_top_k_from_ppr_state(
-            fake_state,
-            max_ppr_nodes=2,
-            residual_topup_nodes=2,
-            max_total_nodes=2,
-        )
-
-        self.assertEqual(fake_state.extract_topup_args, (2, 2, 2))
-        flat_ids, flat_weights, valid_counts = extracted_results[0]
-        self.assertTrue(torch.equal(flat_ids, torch.tensor([10, 11])))
-        self.assertTrue(
-            torch.equal(flat_weights, torch.tensor([0.7, 0.2], dtype=torch.double))
-        )
-        self.assertTrue(torch.equal(valid_counts, torch.tensor([2])))
-
-    def test_ppr_extraction_can_disable_residual_topup(self) -> None:
-        """Verify extraction can keep the pre-top-up behavior."""
-
-        class FakePPRForwardPush:
-            def __init__(self, *_, **__):
-                self.extract_topup_args = None
-
-            def extract_top_k_with_residual_top_up(
-                self,
-                max_ppr_nodes: int,
-                max_residual_nodes: int,
-                max_total_nodes: int,
-            ):
-                self.extract_topup_args = (
-                    max_ppr_nodes,
-                    max_residual_nodes,
-                    max_total_nodes,
-                )
-                return {
-                    0: (
-                        torch.tensor([20], dtype=torch.long),
-                        torch.tensor([0.8], dtype=torch.double),
-                        torch.tensor([1], dtype=torch.long),
-                    )
-                }
-
-        fake_state = FakePPRForwardPush()
-        extracted_results = dist_ppr_sampler_module._extract_top_k_from_ppr_state(
-            fake_state,
-            max_ppr_nodes=2,
-            residual_topup_nodes=0,
-            max_total_nodes=2,
-        )
-
-        self.assertEqual(fake_state.extract_topup_args, (2, 0, 2))
-        flat_ids, flat_weights, valid_counts = extracted_results[0]
-        self.assertTrue(torch.equal(flat_ids, torch.tensor([20])))
-        self.assertTrue(
-            torch.equal(flat_weights, torch.tensor([0.8], dtype=torch.double))
-        )
-        self.assertTrue(torch.equal(valid_counts, torch.tensor([1])))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

# Reasoning for Change

Previously, the PPR forward push would return all neighbors re-enqueued during forward push. This is how the base PPR forward push algorithm works, but results in small sequences volumes that could be more meaningful if they were larger. Decreasing epsilon previously provided a knob to get these larger sequence lengths, but came at heavy throughput costs. Instead of relying on epsilon for this behavior, this change exposes a way to allow us to "top-off" the existing PPR sequence with nodes that were found during forward-push but didn't meet the threshold for re-enqueue. The logic here is that these are the nodes that would have been re-enqueued next by decreasing epsilon, so this gives us a clean way to get these nodes and their ppr scores without having to pay heavy throughput costs.

On internal benchmarking, we have seen sequences toped off this way perform as good as the sequences with lower epsilon at a much faster runtime.


# Changes Summary

Adds an configurable but opt-in residual top-up extraction API to `PPRForwardPush`.

The existing `extractTopK` behavior is unchanged. The new API returns the normal top-k finalized PPR nodes first, then appends additional candidates from residual mass that was discovered during forward push but did not necessarily cross the requeue threshold. This gives downstream samplers a way to fill more sequence slots without issuing extra neighbor fetches.

## Changes

- Adds `extractTopKWithResidualTopUp(maxPprNodes, maxResidualNodes)` in C++.
- Exposes the new method through pybind and the Python stub.
- Scores residual top-up candidates on the same scale as finalized candidates via `ppr_score + residual`.

## Validation

- Ran focused ruff check on the updated Python stub.
- Full `uv run` validation in the temp worktree was blocked by local environment setup because `gigl-core` attempted to rebuild and could not find Torch CMake config.
