### PR TITLE
Add typed-channel PPR sampler

### DIFF
--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -90,7 +90,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
     exposes the next frontier, Python performs the distributed neighbor fetch,
     ``push_residuals`` updates the state, and C++ extraction emits the final
     top-k plus residual top-up output. Typed PPR runs one ``PPRForwardPush``
-    state per traversal channel. Its typed drain step unions the channel
+    traversal per configured channel. Its typed drain step unions the channel
     frontiers before the same distributed fetch, pushes results back into the
     active channel states, and then uses one typed C++ extraction step to apply
     channel target counts, deduplicate shared candidates, and emit the final
@@ -111,11 +111,11 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         - ``data[(seed_type, "ppr", neighbor_type)].edge_index``: same format as above.
         - ``data[(seed_type, "ppr", neighbor_type)].edge_attr``: scalar PPR
           score for regular PPR. For typed PPR, edge attrs are multi-column:
-          ``[best_calibrated_score, calibrated_channel_scores..., channel_presence_bits...]``.
-          Typed-PPR scores are calibrated within each channel/seed pool and
-          globally ranked by the best calibrated score. Channel columns follow
-          the insertion order of ``typed_channel_ratios``. Column 0 is the
-          scalar best score for consumers that need a single PPR weight.
+          ``[best_score, channel_scores..., channel_presence_bits...]``.
+          Scores use the same PPR mass scale as regular scalar PPR output.
+          Channel columns follow the insertion order of
+          ``typed_channel_ratios``. Column 0 is the scalar best score for
+          consumers that need a single PPR weight.
 
     Args:
         alpha: Restart probability (teleport probability back to seed). Higher values
@@ -133,22 +133,23 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             scores are available.
         num_neighbors_per_hop: Maximum number of neighbors to fetch per hop.
         typed_channel_ratios: Optional target proportions for typed PPR
-            traversal channels. If not provided, PPR uses the regular untyped
-            path: each state may traverse all eligible edge types for the
-            current node type and emits scalar PPR scores without channel
-            attribution.
+            traversal channels. If not provided, PPR treats all eligible edge
+            types as one shared traversal space and emits a single scalar PPR
+            score per output row.
             Keys may be either a single canonical edge type
             ``(src_type, relation, dst_type)`` or a tuple of canonical edge
-            types. Each key defines one traversal channel whose PPR state may
-            traverse only those exact edge types.
+            types. Each key defines one traversal channel that may use only
+            those exact edge types. Edge types may appear in multiple channels
+            when those channels intentionally overlap.
             Values are positive ratios that must sum to ``1.0``. The sampler
             converts ratios to per-channel target counts from ``max_ppr_nodes``.
             Finalized PPR candidates and residual top-up candidates both obey
             these target counts. If the same node appears in multiple channels,
-            it is attributed to the channel where it has the highest calibrated
-            score. If sparse channels or duplicate nodes leave unused target
-            slots, the remaining slots are redistributed globally by score so
-            the returned sequence can still fill up to ``max_ppr_nodes``.
+            it is attributed to the channel where it has the highest emitted
+            PPR score for that seed. If sparse channels or duplicate nodes
+            leave unused target slots, the remaining slots are redistributed
+            globally by score so the returned sequence can still fill up to,
+            but never exceed, ``max_ppr_nodes``.
             Example::
 
                 typed_channel_ratios = {
@@ -163,12 +164,12 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             attributed to the views channel and 80 nodes attributed to the
             grouped likes/shares channel. The views channel traverses only
             ``("user", "views", "item")`` edges. The grouped likes/shares
-            channel traverses either likes or shares edges in one PPR state.
+            channel traverses either likes or shares edges as one channel.
             Both finalized PPR rows and residual top-up rows fill those same
             targets. The targets are best-effort rather than strict per-seed
             guarantees: if a channel cannot provide enough unique candidates,
             unused slots are filled by the remaining highest-scoring candidates
-            from any channel.
+            from any channel, up to ``max_ppr_nodes`` total rows.
 
         degree_tensors: Pre-computed total-degree tensors (int32). Homogeneous
             graphs use a single tensor; heterogeneous graphs use tensors keyed
@@ -639,7 +640,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         dict[NodeType, torch.Tensor],
         dict[NodeType, torch.Tensor],
     ]:
-        """Run one PPR state per typed channel and extract the merged result.
+        """Run one PPR traversal per typed channel and extract the merged result.
 
         Each channel receives the same seed nodes but a different edge-type
         traversal allowlist. Fetch frontiers are unioned across active channels

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -21,6 +21,13 @@ from graphlearn_torch.typing import EdgeType, NodeType
 from graphlearn_torch.utils import merge_dict
 
 from gigl.distributed.base_sampler import BaseDistNeighborSampler
+from gigl.distributed.utils.dist_typed_sampler import (
+    TypedPPRChannelKey,
+    TypedPPRChannelTraversalMaps,
+    build_edge_type_channel_group_edge_type_ids,
+    compute_typed_channel_target_counts,
+    parse_typed_channel_ratio_groups,
+)
 from gigl.types.graph import DEFAULT_HOMOGENEOUS_NODE_TYPE, is_label_edge_type
 
 # Trailing "." is an intentional separator.  These constants are used both to
@@ -39,6 +46,21 @@ _PPR_HOMOGENEOUS_EDGE_TYPE = (
     "to",
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
 )
+
+# C++ PPR extraction output: flat node IDs, flat weights, and per-seed valid
+# counts. Homogeneous extraction uses tensors directly; heterogeneous extraction
+# uses dictionaries keyed by node type.
+PPRResult = tuple[
+    Union[torch.Tensor, dict[NodeType, torch.Tensor]],
+    Union[torch.Tensor, dict[NodeType, torch.Tensor]],
+    Union[torch.Tensor, dict[NodeType, torch.Tensor]],
+]
+# Heterogeneous-only view of PPRResult after typed PPR extraction.
+HeteroPPRResult = tuple[
+    dict[NodeType, torch.Tensor],
+    dict[NodeType, torch.Tensor],
+    dict[NodeType, torch.Tensor],
+]
 
 
 class DistPPRNeighborSampler(BaseDistNeighborSampler):
@@ -87,7 +109,13 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
     **Heterogeneous (HeteroData)** — one PPR edge type per
     ``(seed_type, neighbor_type)`` pair, with ``"ppr"`` as the relation:
         - ``data[(seed_type, "ppr", neighbor_type)].edge_index``: same format as above.
-        - ``data[(seed_type, "ppr", neighbor_type)].edge_attr``: same format as above.
+        - ``data[(seed_type, "ppr", neighbor_type)].edge_attr``: scalar PPR
+          score for regular PPR. For typed PPR, edge attrs are multi-column:
+          ``[best_calibrated_score, calibrated_channel_scores..., channel_presence_bits...]``.
+          Typed-PPR scores are calibrated within each channel/seed pool and
+          globally ranked by the best calibrated score. Channel columns follow
+          the insertion order of ``typed_channel_ratios``. Column 0 is the
+          scalar best score for consumers that need a single PPR weight.
 
     Args:
         alpha: Restart probability (teleport probability back to seed). Higher values
@@ -104,6 +132,43 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             during Forward Push when fewer than ``max_ppr_nodes`` finalized PPR
             scores are available.
         num_neighbors_per_hop: Maximum number of neighbors to fetch per hop.
+        typed_channel_ratios: Optional target proportions for typed PPR
+            traversal channels. If not provided, PPR uses the regular untyped path: each
+            state may traverse all eligible edge types for the current node
+            type and emits scalar PPR scores without channel attribution.
+            Keys may be either a single canonical edge type
+            ``(src_type, relation, dst_type)`` or a tuple of canonical edge
+            types. Each key defines one traversal channel whose PPR state may
+            traverse only those exact edge types.
+            Values are positive ratios that must sum to ``1.0``. The sampler
+            converts ratios to per-channel target counts from ``max_ppr_nodes``.
+            Finalized PPR candidates and residual top-up candidates both obey
+            these target counts. If the same node appears in multiple channels,
+            it is attributed to the channel where it has the highest calibrated
+            score. If sparse channels or duplicate nodes leave unused target
+            slots, the remaining slots are redistributed globally by score so
+            the returned sequence can still fill up to ``max_ppr_nodes``.
+            Example::
+
+                typed_channel_ratios = {
+                    ("user", "views", "item"): 0.6,
+                    (
+                        ("user", "likes", "item"),
+                        ("user", "shares", "item"),
+                    ): 0.4,
+                }
+
+            With ``max_ppr_nodes=200``, this example targets 120 nodes
+            attributed to the views channel and 80 nodes attributed to the
+            grouped likes/shares channel. The views channel traverses only
+            ``("user", "views", "item")`` edges. The grouped likes/shares
+            channel traverses either likes or shares edges in one PPR state.
+            Both finalized PPR rows and residual top-up rows fill those same
+            targets. The targets are best-effort rather than strict per-seed
+            guarantees: if a channel cannot provide enough unique candidates,
+            unused slots are filled by the remaining highest-scoring candidates
+            from any channel.
+
         degree_tensors: Pre-computed total-degree tensors (int32). Homogeneous
             graphs use a single tensor; heterogeneous graphs use tensors keyed
             by NodeType. The colocated and graph-store loader paths retrieve
@@ -121,6 +186,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         num_neighbors_per_hop: int = 100_000,
         degree_tensors: Union[torch.Tensor, dict[NodeType, torch.Tensor]],
         max_fetch_iterations: Optional[int] = None,
+        typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
@@ -162,7 +228,22 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             ]
             self._is_homogeneous = True
 
-        self._typed_ppr_channel_target_counts: Optional[list[int]] = None
+        typed_channel_groups, typed_channel_ratio_list = (
+            parse_typed_channel_ratio_groups(typed_channel_ratios)
+        )
+        self._typed_ppr_channel_target_counts = (
+            compute_typed_channel_target_counts(
+                typed_channel_ratio_list,
+                max_ppr_nodes,
+            )
+            if typed_channel_ratio_list is not None
+            else None
+        )
+        if self._typed_ppr_channel_target_counts is not None:
+            if self._is_homogeneous:
+                raise ValueError(
+                    "Typed PPR channel ratios are only supported for heterogeneous PPR sampling."
+                )
 
         # Convert the public homogeneous/heterogeneous degree-tensor shape to
         # the node-type keyed form used internally by PPR.
@@ -226,9 +307,16 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             for node_type in all_node_types
         ]
 
-        self._typed_ppr_channel_to_node_type_id_to_edge_type_ids: list[
-            list[list[int]]
-        ] = []
+        self._typed_ppr_channel_to_node_type_id_to_edge_type_ids: TypedPPRChannelTraversalMaps = []
+        if typed_channel_groups is not None:
+            self._typed_ppr_channel_to_node_type_id_to_edge_type_ids = (
+                build_edge_type_channel_group_edge_type_ids(
+                    edge_type_groups=typed_channel_groups,
+                    edge_type_to_edge_type_id=self._etype_to_etype_id,
+                    node_type_to_edge_types=self._node_type_to_edge_types,
+                    node_types=self._ntype_id_to_ntype,
+                )
+            )
 
     def _convert_degree_tensors_to_dict(
         self,

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -22,7 +22,7 @@ from graphlearn_torch.utils import merge_dict
 
 from gigl.distributed.base_sampler import BaseDistNeighborSampler
 from gigl.distributed.utils.dist_typed_sampler import (
-    PPRSequenceLength,
+    MaxPPRNodes,
     TypedPPRChannelTraversalMaps,
     build_edge_type_channel_group_edge_type_ids,
     parse_typed_channel_target_groups,
@@ -113,22 +113,21 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
           ``[best_calibrated_score, calibrated_channel_scores..., channel_presence_bits...]``.
           Typed-PPR scores are calibrated within each channel/seed pool and
           globally ranked by the best calibrated score. Channel columns follow
-          the insertion order of the typed sequence mapping. Column 0 is the
-          scalar best score for consumers that need a single PPR weight.
+          the insertion order of the typed ``max_ppr_nodes`` mapping. Column 0
+          is the scalar best score for consumers that need a single PPR weight.
 
     Args:
         alpha: Restart probability (teleport probability back to seed). Higher values
                keep samples closer to seeds. Typical values: 0.15-0.25.
         eps: Convergence threshold. Smaller values give more accurate PPR scores
              but require more computation. Typical values: 1e-4 to 1e-6.
-        ppr_sequence_length: PPR output sequence specification. Pass an integer
-            to run regular untyped PPR and return up to that many nodes per
-            seed. Pass a mapping from typed channel key to integer target count
-            to run typed PPR; the sum of target counts is the total sequence
-            length.
+        max_ppr_nodes: PPR output sequence specification. Pass an integer to
+            run regular untyped PPR and return up to that many nodes per seed.
+            Pass a mapping from typed channel key to integer target count to
+            run typed PPR; the sum of target counts is the per-seed output cap.
         enable_residual_topup: Whether to include residual candidates discovered
-            during Forward Push when fewer than the requested sequence length
-            finalized PPR scores are available.
+            during Forward Push when fewer than the requested ``max_ppr_nodes``
+            output slots have finalized PPR scores.
         num_neighbors_per_hop: Maximum number of neighbors to fetch per hop.
         degree_tensors: Pre-computed total-degree tensors (int32). Homogeneous
             graphs use a single tensor; heterogeneous graphs use tensors keyed
@@ -142,7 +141,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         *args,
         alpha: float = 0.5,
         eps: float = 1e-4,
-        ppr_sequence_length: PPRSequenceLength = 50,
+        max_ppr_nodes: MaxPPRNodes = 50,
         enable_residual_topup: bool = True,
         num_neighbors_per_hop: int = 100_000,
         degree_tensors: Union[torch.Tensor, dict[NodeType, torch.Tensor]],
@@ -189,26 +188,26 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
 
         typed_channel_groups: Optional[list[tuple[EdgeType, ...]]] = None
         self._typed_ppr_channel_target_counts: Optional[list[int]] = None
-        if isinstance(ppr_sequence_length, bool):
+        if isinstance(max_ppr_nodes, bool):
             raise ValueError(
-                "ppr_sequence_length must be an integer or typed channel mapping."
+                "max_ppr_nodes must be an integer or typed channel mapping."
             )
-        if isinstance(ppr_sequence_length, int):
-            if ppr_sequence_length < 0:
+        if isinstance(max_ppr_nodes, int):
+            if max_ppr_nodes < 0:
                 raise ValueError(
-                    f"ppr_sequence_length must be non-negative, got {ppr_sequence_length}."
+                    f"max_ppr_nodes must be non-negative, got {max_ppr_nodes}."
                 )
-            self._max_ppr_nodes = ppr_sequence_length
-        elif isinstance(ppr_sequence_length, dict):
+            self._max_ppr_nodes = max_ppr_nodes
+        elif isinstance(max_ppr_nodes, dict):
             typed_channel_groups, typed_channel_target_counts = (
-                parse_typed_channel_target_groups(ppr_sequence_length)
+                parse_typed_channel_target_groups(max_ppr_nodes)
             )
             self._typed_ppr_channel_target_counts = typed_channel_target_counts
             self._max_ppr_nodes = sum(typed_channel_target_counts)
         else:
             raise ValueError(
-                "ppr_sequence_length must be an integer or typed channel mapping, "
-                f"got {ppr_sequence_length!r}."
+                "max_ppr_nodes must be an integer or typed channel mapping, "
+                f"got {max_ppr_nodes!r}."
             )
         if self._typed_ppr_channel_target_counts is not None:
             if self._is_homogeneous:

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -22,10 +22,11 @@ from graphlearn_torch.utils import merge_dict
 
 from gigl.distributed.base_sampler import BaseDistNeighborSampler
 from gigl.distributed.utils.dist_typed_sampler import (
-    MaxPPRNodes,
+    TypedPPRChannelKey,
     TypedPPRChannelTraversalMaps,
     build_edge_type_channel_group_edge_type_ids,
-    parse_typed_channel_target_groups,
+    compute_typed_channel_target_counts,
+    parse_typed_channel_ratio_groups,
 )
 from gigl.types.graph import DEFAULT_HOMOGENEOUS_NODE_TYPE, is_label_edge_type
 
@@ -113,22 +114,62 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
           ``[best_calibrated_score, calibrated_channel_scores..., channel_presence_bits...]``.
           Typed-PPR scores are calibrated within each channel/seed pool and
           globally ranked by the best calibrated score. Channel columns follow
-          the insertion order of the typed ``max_ppr_nodes`` mapping. Column 0
-          is the scalar best score for consumers that need a single PPR weight.
+          the insertion order of ``typed_channel_ratios``. Column 0 is the
+          scalar best score for consumers that need a single PPR weight.
 
     Args:
         alpha: Restart probability (teleport probability back to seed). Higher values
                keep samples closer to seeds. Typical values: 0.15-0.25.
         eps: Convergence threshold. Smaller values give more accurate PPR scores
              but require more computation. Typical values: 1e-4 to 1e-6.
-        max_ppr_nodes: PPR output sequence specification. Pass an integer to
-            run regular untyped PPR and return up to that many nodes per seed.
-            Pass a mapping from typed channel key to integer target count to
-            run typed PPR; the sum of target counts is the per-seed output cap.
+        max_ppr_nodes: Maximum number of nodes to return per seed. If finalized
+            PPR scores produce fewer than this cap and residual top-up is
+            enabled, discovered residual candidates fill the remaining slots
+            with score ``ppr_score + residual``. Returned nodes are sorted by
+            emitted score, but residual candidates do not displace finalized
+            PPR nodes when finalized scores already fill the cap.
         enable_residual_topup: Whether to include residual candidates discovered
-            during Forward Push when fewer than the requested ``max_ppr_nodes``
-            output slots have finalized PPR scores.
+            during Forward Push when fewer than ``max_ppr_nodes`` finalized PPR
+            scores are available.
         num_neighbors_per_hop: Maximum number of neighbors to fetch per hop.
+        typed_channel_ratios: Optional target proportions for typed PPR
+            traversal channels. If not provided, PPR uses the regular untyped
+            path: each state may traverse all eligible edge types for the
+            current node type and emits scalar PPR scores without channel
+            attribution.
+            Keys may be either a single canonical edge type
+            ``(src_type, relation, dst_type)`` or a tuple of canonical edge
+            types. Each key defines one traversal channel whose PPR state may
+            traverse only those exact edge types.
+            Values are positive ratios that must sum to ``1.0``. The sampler
+            converts ratios to per-channel target counts from ``max_ppr_nodes``.
+            Finalized PPR candidates and residual top-up candidates both obey
+            these target counts. If the same node appears in multiple channels,
+            it is attributed to the channel where it has the highest calibrated
+            score. If sparse channels or duplicate nodes leave unused target
+            slots, the remaining slots are redistributed globally by score so
+            the returned sequence can still fill up to ``max_ppr_nodes``.
+            Example::
+
+                typed_channel_ratios = {
+                    ("user", "views", "item"): 0.6,
+                    (
+                        ("user", "likes", "item"),
+                        ("user", "shares", "item"),
+                    ): 0.4,
+                }
+
+            With ``max_ppr_nodes=200``, this example targets 120 nodes
+            attributed to the views channel and 80 nodes attributed to the
+            grouped likes/shares channel. The views channel traverses only
+            ``("user", "views", "item")`` edges. The grouped likes/shares
+            channel traverses either likes or shares edges in one PPR state.
+            Both finalized PPR rows and residual top-up rows fill those same
+            targets. The targets are best-effort rather than strict per-seed
+            guarantees: if a channel cannot provide enough unique candidates,
+            unused slots are filled by the remaining highest-scoring candidates
+            from any channel.
+
         degree_tensors: Pre-computed total-degree tensors (int32). Homogeneous
             graphs use a single tensor; heterogeneous graphs use tensors keyed
             by NodeType. The colocated and graph-store loader paths retrieve
@@ -141,15 +182,21 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         *args,
         alpha: float = 0.5,
         eps: float = 1e-4,
-        max_ppr_nodes: MaxPPRNodes = 50,
+        max_ppr_nodes: int = 50,
         enable_residual_topup: bool = True,
         num_neighbors_per_hop: int = 100_000,
         degree_tensors: Union[torch.Tensor, dict[NodeType, torch.Tensor]],
         max_fetch_iterations: Optional[int] = None,
+        typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self._alpha = alpha
+        if isinstance(max_ppr_nodes, bool) or max_ppr_nodes < 0:
+            raise ValueError(
+                f"max_ppr_nodes must be non-negative, got {max_ppr_nodes}."
+            )
+        self._max_ppr_nodes = max_ppr_nodes
         self._enable_residual_topup = enable_residual_topup
         self._requeue_threshold_factor = alpha * eps
         self._num_neighbors_per_hop = num_neighbors_per_hop
@@ -186,33 +233,21 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             ]
             self._is_homogeneous = True
 
-        typed_channel_groups: Optional[list[tuple[EdgeType, ...]]] = None
-        self._typed_ppr_channel_target_counts: Optional[list[int]] = None
-        if isinstance(max_ppr_nodes, bool):
-            raise ValueError(
-                "max_ppr_nodes must be an integer or typed channel mapping."
+        typed_channel_groups, typed_channel_ratio_list = (
+            parse_typed_channel_ratio_groups(typed_channel_ratios)
+        )
+        self._typed_ppr_channel_target_counts = (
+            compute_typed_channel_target_counts(
+                typed_channel_ratio_list,
+                max_ppr_nodes,
             )
-        if isinstance(max_ppr_nodes, int):
-            if max_ppr_nodes < 0:
-                raise ValueError(
-                    f"max_ppr_nodes must be non-negative, got {max_ppr_nodes}."
-                )
-            self._max_ppr_nodes = max_ppr_nodes
-        elif isinstance(max_ppr_nodes, dict):
-            typed_channel_groups, typed_channel_target_counts = (
-                parse_typed_channel_target_groups(max_ppr_nodes)
-            )
-            self._typed_ppr_channel_target_counts = typed_channel_target_counts
-            self._max_ppr_nodes = sum(typed_channel_target_counts)
-        else:
-            raise ValueError(
-                "max_ppr_nodes must be an integer or typed channel mapping, "
-                f"got {max_ppr_nodes!r}."
-            )
+            if typed_channel_ratio_list is not None
+            else None
+        )
         if self._typed_ppr_channel_target_counts is not None:
             if self._is_homogeneous:
                 raise ValueError(
-                    "Typed PPR channel targets are only supported for heterogeneous PPR sampling."
+                    "Typed PPR channel ratios are only supported for heterogeneous PPR sampling."
                 )
 
         # Convert the public homogeneous/heterogeneous degree-tensor shape to

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -22,11 +22,10 @@ from graphlearn_torch.utils import merge_dict
 
 from gigl.distributed.base_sampler import BaseDistNeighborSampler
 from gigl.distributed.utils.dist_typed_sampler import (
-    TypedPPRChannelKey,
+    PPRSequenceLength,
     TypedPPRChannelTraversalMaps,
     build_edge_type_channel_group_edge_type_ids,
-    compute_typed_channel_target_counts,
-    parse_typed_channel_ratio_groups,
+    parse_typed_channel_target_groups,
 )
 from gigl.types.graph import DEFAULT_HOMOGENEOUS_NODE_TYPE, is_label_edge_type
 
@@ -114,7 +113,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
           ``[best_calibrated_score, calibrated_channel_scores..., channel_presence_bits...]``.
           Typed-PPR scores are calibrated within each channel/seed pool and
           globally ranked by the best calibrated score. Channel columns follow
-          the insertion order of ``typed_channel_ratios``. Column 0 is the
+          the insertion order of the typed sequence mapping. Column 0 is the
           scalar best score for consumers that need a single PPR weight.
 
     Args:
@@ -122,53 +121,15 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
                keep samples closer to seeds. Typical values: 0.15-0.25.
         eps: Convergence threshold. Smaller values give more accurate PPR scores
              but require more computation. Typical values: 1e-4 to 1e-6.
-        max_ppr_nodes: Maximum number of nodes to return per seed. If finalized
-            PPR scores produce fewer than this cap and residual top-up is
-            enabled, discovered residual candidates fill the remaining slots
-            with score ``ppr_score + residual``.  Returned nodes are sorted by
-            emitted score, but residual candidates do not displace finalized
-            PPR nodes when finalized scores already fill the cap.
+        ppr_sequence_length: PPR output sequence specification. Pass an integer
+            to run regular untyped PPR and return up to that many nodes per
+            seed. Pass a mapping from typed channel key to integer target count
+            to run typed PPR; the sum of target counts is the total sequence
+            length.
         enable_residual_topup: Whether to include residual candidates discovered
-            during Forward Push when fewer than ``max_ppr_nodes`` finalized PPR
-            scores are available.
+            during Forward Push when fewer than the requested sequence length
+            finalized PPR scores are available.
         num_neighbors_per_hop: Maximum number of neighbors to fetch per hop.
-        typed_channel_ratios: Optional target proportions for typed PPR
-            traversal channels. If not provided, PPR uses the regular untyped path: each
-            state may traverse all eligible edge types for the current node
-            type and emits scalar PPR scores without channel attribution.
-            Keys may be either a single canonical edge type
-            ``(src_type, relation, dst_type)`` or a tuple of canonical edge
-            types. Each key defines one traversal channel whose PPR state may
-            traverse only those exact edge types.
-            Values are positive ratios that must sum to ``1.0``. The sampler
-            converts ratios to per-channel target counts from ``max_ppr_nodes``.
-            Finalized PPR candidates and residual top-up candidates both obey
-            these target counts. If the same node appears in multiple channels,
-            it is attributed to the channel where it has the highest calibrated
-            score. If sparse channels or duplicate nodes leave unused target
-            slots, the remaining slots are redistributed globally by score so
-            the returned sequence can still fill up to ``max_ppr_nodes``.
-            Example::
-
-                typed_channel_ratios = {
-                    ("user", "views", "item"): 0.6,
-                    (
-                        ("user", "likes", "item"),
-                        ("user", "shares", "item"),
-                    ): 0.4,
-                }
-
-            With ``max_ppr_nodes=200``, this example targets 120 nodes
-            attributed to the views channel and 80 nodes attributed to the
-            grouped likes/shares channel. The views channel traverses only
-            ``("user", "views", "item")`` edges. The grouped likes/shares
-            channel traverses either likes or shares edges in one PPR state.
-            Both finalized PPR rows and residual top-up rows fill those same
-            targets. The targets are best-effort rather than strict per-seed
-            guarantees: if a channel cannot provide enough unique candidates,
-            unused slots are filled by the remaining highest-scoring candidates
-            from any channel.
-
         degree_tensors: Pre-computed total-degree tensors (int32). Homogeneous
             graphs use a single tensor; heterogeneous graphs use tensors keyed
             by NodeType. The colocated and graph-store loader paths retrieve
@@ -181,17 +142,15 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         *args,
         alpha: float = 0.5,
         eps: float = 1e-4,
-        max_ppr_nodes: int = 50,
+        ppr_sequence_length: PPRSequenceLength = 50,
         enable_residual_topup: bool = True,
         num_neighbors_per_hop: int = 100_000,
         degree_tensors: Union[torch.Tensor, dict[NodeType, torch.Tensor]],
         max_fetch_iterations: Optional[int] = None,
-        typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self._alpha = alpha
-        self._max_ppr_nodes = max_ppr_nodes
         self._enable_residual_topup = enable_residual_topup
         self._requeue_threshold_factor = alpha * eps
         self._num_neighbors_per_hop = num_neighbors_per_hop
@@ -228,21 +187,33 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             ]
             self._is_homogeneous = True
 
-        typed_channel_groups, typed_channel_ratio_list = (
-            parse_typed_channel_ratio_groups(typed_channel_ratios)
-        )
-        self._typed_ppr_channel_target_counts = (
-            compute_typed_channel_target_counts(
-                typed_channel_ratio_list,
-                max_ppr_nodes,
+        typed_channel_groups: Optional[list[tuple[EdgeType, ...]]] = None
+        self._typed_ppr_channel_target_counts: Optional[list[int]] = None
+        if isinstance(ppr_sequence_length, bool):
+            raise ValueError(
+                "ppr_sequence_length must be an integer or typed channel mapping."
             )
-            if typed_channel_ratio_list is not None
-            else None
-        )
+        if isinstance(ppr_sequence_length, int):
+            if ppr_sequence_length < 0:
+                raise ValueError(
+                    f"ppr_sequence_length must be non-negative, got {ppr_sequence_length}."
+                )
+            self._max_ppr_nodes = ppr_sequence_length
+        elif isinstance(ppr_sequence_length, dict):
+            typed_channel_groups, typed_channel_target_counts = (
+                parse_typed_channel_target_groups(ppr_sequence_length)
+            )
+            self._typed_ppr_channel_target_counts = typed_channel_target_counts
+            self._max_ppr_nodes = sum(typed_channel_target_counts)
+        else:
+            raise ValueError(
+                "ppr_sequence_length must be an integer or typed channel mapping, "
+                f"got {ppr_sequence_length!r}."
+            )
         if self._typed_ppr_channel_target_counts is not None:
             if self._is_homogeneous:
                 raise ValueError(
-                    "Typed PPR channel ratios are only supported for heterogeneous PPR sampling."
+                    "Typed PPR channel targets are only supported for heterogeneous PPR sampling."
                 )
 
         # Convert the public homogeneous/heterogeneous degree-tensor shape to

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -141,8 +141,12 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             types. Each key defines one traversal channel that may use only
             those exact edge types. Edge types may appear in multiple channels
             when those channels intentionally overlap.
-            Values are positive ratios that must sum to ``1.0``. The sampler
-            converts ratios to per-channel target counts from ``max_ppr_nodes``.
+            Channel order follows the insertion order of this mapping, and
+            typed ``edge_attr`` channel columns use that same order. If the
+            mapping is produced from an unordered config source, construct it
+            deterministically before passing it to the sampler. Values are
+            positive ratios that must sum to ``1.0``. The sampler converts
+            ratios to per-channel target counts from ``max_ppr_nodes``.
             Finalized PPR candidates and residual top-up candidates both obey
             these target counts. If the same node appears in multiple channels,
             it is attributed to the channel where it has the highest emitted

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -90,8 +90,11 @@ class PPRSamplerOptions:
             when those channels intentionally overlap.
             If not provided, PPR treats all eligible edge types as one shared
             traversal space and emits a single scalar PPR score per output row.
-            Channel order follows the insertion order of this mapping. Values
-            are positive ratios that must sum to ``1.0``. The sampler converts
+            Channel order follows the insertion order of this mapping, and
+            typed ``edge_attr`` channel columns use that same order. If the
+            mapping is produced from an unordered config source, construct it
+            deterministically before passing it to the sampler. Values are
+            positive ratios that must sum to ``1.0``. The sampler converts
             ratios to per-channel target counts from ``max_ppr_nodes``.
             Finalized PPR candidates and residual top-up candidates both obey
             these target counts. If the same node appears in multiple channels,

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -13,6 +13,7 @@ from typing import Optional, Union
 from graphlearn_torch.typing import EdgeType
 
 from gigl.common.logger import Logger
+from gigl.distributed.utils.dist_typed_sampler import TypedPPRChannelKey
 
 logger = Logger()
 
@@ -41,6 +42,10 @@ class PPRSamplerOptions:
     - ``edge_index``: ``[2, N]`` int64 — row 0 is local seed indices, row 1 is local
       neighbor indices.
     - ``edge_attr``: ``[N]`` float — PPR score for each (seed, neighbor) pair.
+      Typed PPR emits multi-column edge attrs:
+      ``[best_score, channel_scores..., channel_presence_bits...]``.
+      Column 0 is the scalar best score for consumers that need a single PPR
+      weight.
 
     For homogeneous graphs these live directly on ``data.edge_index`` / ``data.edge_attr``.
 
@@ -75,6 +80,49 @@ class PPRSamplerOptions:
             The algorithm still runs to convergence — re-enqueued nodes propagate
             through cached neighbors at negligible cost. ``None`` (default) means
             no fetch limit.
+        typed_channel_ratios: Optional target proportions for typed PPR
+            traversal channels defined by canonical edge-type allowlists. Keys
+            may be either a single canonical edge type
+            ``(src_type, relation, dst_type)`` or a tuple of canonical edge
+            types. Each key defines one traversal channel whose PPR state may
+            traverse only those exact edge types.
+            If not provided, PPR uses the regular untyped path: each state may
+            traverse all eligible edge types for the current node type and emits
+            scalar PPR scores without channel attribution.
+            Channel order follows the insertion order of this mapping. Values
+            are positive ratios that must sum to ``1.0``. The sampler converts
+            ratios to per-channel target counts from ``max_ppr_nodes``.
+            Finalized PPR candidates and residual top-up candidates both obey
+            these target counts. If the same node appears in multiple channels,
+            it is attributed to the channel where it has the highest calibrated
+            score. If sparse channels or duplicate nodes leave unused target
+            slots, the remaining slots are redistributed globally by score so
+            the returned sequence can still fill up to ``max_ppr_nodes``.
+            Example::
+
+                typed_channel_ratios = {
+                    ("user", "views", "item"): 0.6,
+                    (
+                        ("user", "likes", "item"),
+                        ("user", "shares", "item"),
+                    ): 0.4,
+                }
+
+            This example creates two traversal channels. The first channel can
+            traverse only ``("user", "views", "item")`` edges. With
+            ``max_ppr_nodes=200``, the ``0.6`` ratio targets 120 nodes
+            attributed to this channel. The second channel groups
+            ``("user", "likes", "item")`` and ``("user", "shares", "item")``
+            into one PPR state; the ``0.4`` ratio targets 80 nodes attributed
+            to that combined likes/shares channel. These targets are best-effort
+            rather than strict per-seed guarantees because channels may be
+            sparse or overlapping.
+
+            If residual top-up is enabled, discovered-but-unpushed residual
+            candidates from the same completed PPR states are included on the
+            same mass scale as finalized PPR scores: ``ppr_score + residual``.
+            Residual candidates follow the same channel targets as finalized
+            PPR candidates.
     """
 
     alpha: float = 0.5
@@ -83,6 +131,7 @@ class PPRSamplerOptions:
     enable_residual_topup: bool = True
     num_neighbors_per_hop: int = 1_000
     max_fetch_iterations: Optional[int] = None
+    typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]] = None
 
 
 SamplerOptions = Union[KHopNeighborSamplerOptions, PPRSamplerOptions]

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -13,7 +13,7 @@ from typing import Optional, Union
 from graphlearn_torch.typing import EdgeType
 
 from gigl.common.logger import Logger
-from gigl.distributed.utils.dist_typed_sampler import PPRSequenceLength
+from gigl.distributed.utils.dist_typed_sampler import MaxPPRNodes
 
 logger = Logger()
 
@@ -61,19 +61,18 @@ class PPRSamplerOptions:
         eps: Convergence threshold for the Forward Push algorithm. Smaller
             values give more accurate PPR scores but require more computation.
             Typical values: 1e-4 to 1e-6.
-        ppr_sequence_length: PPR output sequence specification. Pass an integer
-            to run regular untyped PPR and return up to that many nodes per
-            seed. Pass a mapping from typed channel key to integer target count
-            to run typed PPR; the sum of target counts is the total sequence
-            length.
+        max_ppr_nodes: PPR output sequence specification. Pass an integer to
+            run regular untyped PPR and return up to that many nodes per seed.
+            Pass a mapping from typed channel key to integer target count to
+            run typed PPR; the sum of target counts is the per-seed output cap.
 
             Example::
 
-                # Regular untyped PPR with sequence length 200.
-                ppr_sequence_length = 200
+                # Regular untyped PPR with up to 200 nodes per seed.
+                max_ppr_nodes = 200
 
-                # Typed PPR with two traversal channels and total length 200.
-                ppr_sequence_length = {
+                # Typed PPR with two traversal channels and up to 200 nodes per seed.
+                max_ppr_nodes = {
                     ("user", "views", "item"): 120,
                     (
                         ("user", "likes", "item"),
@@ -96,8 +95,8 @@ class PPRSamplerOptions:
             finalized PPR candidates.
         enable_residual_topup: Whether to append discovered-but-unpushed
             residual candidates when finalized PPR scores produce fewer than
-            the requested sequence length. Residual top-up candidates are
-            scored on the same mass scale as PPR scores:
+            the requested ``max_ppr_nodes`` output slots. Residual top-up
+            candidates are scored on the same mass scale as PPR scores:
             ``ppr_score + residual``. They fill only unused output slots and do
             not displace finalized PPR nodes when those already fill the
             sequence.
@@ -116,7 +115,7 @@ class PPRSamplerOptions:
 
     alpha: float = 0.5
     eps: float = 1e-4
-    ppr_sequence_length: PPRSequenceLength = 50
+    max_ppr_nodes: MaxPPRNodes = 50
     enable_residual_topup: bool = True
     num_neighbors_per_hop: int = 1_000
     max_fetch_iterations: Optional[int] = None

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -13,7 +13,7 @@ from typing import Optional, Union
 from graphlearn_torch.typing import EdgeType
 
 from gigl.common.logger import Logger
-from gigl.distributed.utils.dist_typed_sampler import MaxPPRNodes
+from gigl.distributed.utils.dist_typed_sampler import TypedPPRChannelKey
 
 logger = Logger()
 
@@ -61,38 +61,8 @@ class PPRSamplerOptions:
         eps: Convergence threshold for the Forward Push algorithm. Smaller
             values give more accurate PPR scores but require more computation.
             Typical values: 1e-4 to 1e-6.
-        max_ppr_nodes: PPR output sequence specification. Pass an integer to
-            run regular untyped PPR and return up to that many nodes per seed.
-            Pass a mapping from typed channel key to integer target count to
-            run typed PPR; the sum of target counts is the per-seed output cap.
-
-            Example::
-
-                # Regular untyped PPR with up to 200 nodes per seed.
-                max_ppr_nodes = 200
-
-                # Typed PPR with two traversal channels and up to 200 nodes per seed.
-                max_ppr_nodes = {
-                    ("user", "views", "item"): 120,
-                    (
-                        ("user", "likes", "item"),
-                        ("user", "shares", "item"),
-                    ): 80,
-                }
-
-            The typed example creates two traversal channels. The first channel
-            can traverse only ``("user", "views", "item")`` edges and targets
-            120 output nodes. The second channel groups
-            ``("user", "likes", "item")`` and ``("user", "shares", "item")``
-            into one PPR state and targets 80 output nodes. These targets are
-            best-effort rather than strict per-seed guarantees because channels
-            may be sparse or overlapping.
-
-            If residual top-up is enabled, discovered-but-unpushed residual
-            candidates from the same completed PPR states are included on the
-            same mass scale as finalized PPR scores: ``ppr_score + residual``.
-            Residual candidates follow the same typed channel targets as
-            finalized PPR candidates.
+        max_ppr_nodes: Maximum number of nodes to return per seed based on PPR
+            scores.
         enable_residual_topup: Whether to append discovered-but-unpushed
             residual candidates when finalized PPR scores produce fewer than
             the requested ``max_ppr_nodes`` output slots. Residual top-up
@@ -111,14 +81,58 @@ class PPRSamplerOptions:
             The algorithm still runs to convergence — re-enqueued nodes propagate
             through cached neighbors at negligible cost. ``None`` (default) means
             no fetch limit.
+        typed_channel_ratios: Optional target proportions for typed PPR
+            traversal channels defined by canonical edge-type allowlists. Keys
+            may be either a single canonical edge type
+            ``(src_type, relation, dst_type)`` or a tuple of canonical edge
+            types. Each key defines one traversal channel whose PPR state may
+            traverse only those exact edge types.
+            If not provided, PPR uses the regular untyped path: each state may
+            traverse all eligible edge types for the current node type and emits
+            scalar PPR scores without channel attribution.
+            Channel order follows the insertion order of this mapping. Values
+            are positive ratios that must sum to ``1.0``. The sampler converts
+            ratios to per-channel target counts from ``max_ppr_nodes``.
+            Finalized PPR candidates and residual top-up candidates both obey
+            these target counts. If the same node appears in multiple channels,
+            it is attributed to the channel where it has the highest calibrated
+            score. If sparse channels or duplicate nodes leave unused target
+            slots, the remaining slots are redistributed globally by score so
+            the returned sequence can still fill up to ``max_ppr_nodes``.
+            Example::
+
+                typed_channel_ratios = {
+                    ("user", "views", "item"): 0.6,
+                    (
+                        ("user", "likes", "item"),
+                        ("user", "shares", "item"),
+                    ): 0.4,
+                }
+
+            This example creates two traversal channels. The first channel can
+            traverse only ``("user", "views", "item")`` edges. With
+            ``max_ppr_nodes=200``, the ``0.6`` ratio targets 120 nodes
+            attributed to this channel. The second channel groups
+            ``("user", "likes", "item")`` and ``("user", "shares", "item")``
+            into one PPR state; the ``0.4`` ratio targets 80 nodes attributed
+            to that combined likes/shares channel. These targets are best-effort
+            rather than strict per-seed guarantees because channels may be
+            sparse or overlapping.
+
+            If residual top-up is enabled, discovered-but-unpushed residual
+            candidates from the same completed PPR states are included on the
+            same mass scale as finalized PPR scores: ``ppr_score + residual``.
+            Residual candidates follow the same channel targets as finalized
+            PPR candidates.
     """
 
     alpha: float = 0.5
     eps: float = 1e-4
-    max_ppr_nodes: MaxPPRNodes = 50
+    max_ppr_nodes: int = 50
     enable_residual_topup: bool = True
     num_neighbors_per_hop: int = 1_000
     max_fetch_iterations: Optional[int] = None
+    typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]] = None
 
 
 SamplerOptions = Union[KHopNeighborSamplerOptions, PPRSamplerOptions]

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -85,20 +85,21 @@ class PPRSamplerOptions:
             traversal channels defined by canonical edge-type allowlists. Keys
             may be either a single canonical edge type
             ``(src_type, relation, dst_type)`` or a tuple of canonical edge
-            types. Each key defines one traversal channel whose PPR state may
-            traverse only those exact edge types.
-            If not provided, PPR uses the regular untyped path: each state may
-            traverse all eligible edge types for the current node type and emits
-            scalar PPR scores without channel attribution.
+            types. Each key defines one traversal channel that may use only
+            those exact edge types. Edge types may appear in multiple channels
+            when those channels intentionally overlap.
+            If not provided, PPR treats all eligible edge types as one shared
+            traversal space and emits a single scalar PPR score per output row.
             Channel order follows the insertion order of this mapping. Values
             are positive ratios that must sum to ``1.0``. The sampler converts
             ratios to per-channel target counts from ``max_ppr_nodes``.
             Finalized PPR candidates and residual top-up candidates both obey
             these target counts. If the same node appears in multiple channels,
-            it is attributed to the channel where it has the highest calibrated
-            score. If sparse channels or duplicate nodes leave unused target
-            slots, the remaining slots are redistributed globally by score so
-            the returned sequence can still fill up to ``max_ppr_nodes``.
+            it is attributed to the channel where it has the highest emitted
+            PPR score for that seed. If sparse channels or duplicate nodes
+            leave unused target slots, the remaining slots are redistributed
+            globally by score so the returned sequence can still fill up to,
+            but never exceed, ``max_ppr_nodes``.
             Example::
 
                 typed_channel_ratios = {
@@ -114,13 +115,13 @@ class PPRSamplerOptions:
             ``max_ppr_nodes=200``, the ``0.6`` ratio targets 120 nodes
             attributed to this channel. The second channel groups
             ``("user", "likes", "item")`` and ``("user", "shares", "item")``
-            into one PPR state; the ``0.4`` ratio targets 80 nodes attributed
-            to that combined likes/shares channel. These targets are best-effort
-            rather than strict per-seed guarantees because channels may be
-            sparse or overlapping.
+            into one traversal channel; the ``0.4`` ratio targets 80 nodes
+            attributed to that combined likes/shares channel. These targets are
+            best-effort rather than strict per-seed guarantees because channels
+            may be sparse or overlapping.
 
             If residual top-up is enabled, discovered-but-unpushed residual
-            candidates from the same completed PPR states are included on the
+            candidates from the same completed PPR traversals are included on the
             same mass scale as finalized PPR scores: ``ppr_score + residual``.
             Residual candidates follow the same channel targets as finalized
             PPR candidates.

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -13,7 +13,7 @@ from typing import Optional, Union
 from graphlearn_torch.typing import EdgeType
 
 from gigl.common.logger import Logger
-from gigl.distributed.utils.dist_typed_sampler import TypedPPRChannelKey
+from gigl.distributed.utils.dist_typed_sampler import PPRSequenceLength
 
 logger = Logger()
 
@@ -61,14 +61,46 @@ class PPRSamplerOptions:
         eps: Convergence threshold for the Forward Push algorithm. Smaller
             values give more accurate PPR scores but require more computation.
             Typical values: 1e-4 to 1e-6.
-        max_ppr_nodes: Maximum number of nodes to return per seed based on PPR
-            scores.
+        ppr_sequence_length: PPR output sequence specification. Pass an integer
+            to run regular untyped PPR and return up to that many nodes per
+            seed. Pass a mapping from typed channel key to integer target count
+            to run typed PPR; the sum of target counts is the total sequence
+            length.
+
+            Example::
+
+                # Regular untyped PPR with sequence length 200.
+                ppr_sequence_length = 200
+
+                # Typed PPR with two traversal channels and total length 200.
+                ppr_sequence_length = {
+                    ("user", "views", "item"): 120,
+                    (
+                        ("user", "likes", "item"),
+                        ("user", "shares", "item"),
+                    ): 80,
+                }
+
+            The typed example creates two traversal channels. The first channel
+            can traverse only ``("user", "views", "item")`` edges and targets
+            120 output nodes. The second channel groups
+            ``("user", "likes", "item")`` and ``("user", "shares", "item")``
+            into one PPR state and targets 80 output nodes. These targets are
+            best-effort rather than strict per-seed guarantees because channels
+            may be sparse or overlapping.
+
+            If residual top-up is enabled, discovered-but-unpushed residual
+            candidates from the same completed PPR states are included on the
+            same mass scale as finalized PPR scores: ``ppr_score + residual``.
+            Residual candidates follow the same typed channel targets as
+            finalized PPR candidates.
         enable_residual_topup: Whether to append discovered-but-unpushed
             residual candidates when finalized PPR scores produce fewer than
-            ``max_ppr_nodes`` results. Residual top-up candidates are scored on
-            the same mass scale as PPR scores: ``ppr_score + residual``. They
-            fill only unused output slots and do not displace finalized PPR nodes
-            when those already fill ``max_ppr_nodes``.
+            the requested sequence length. Residual top-up candidates are
+            scored on the same mass scale as PPR scores:
+            ``ppr_score + residual``. They fill only unused output slots and do
+            not displace finalized PPR nodes when those already fill the
+            sequence.
         num_neighbors_per_hop: Maximum number of neighbors fetched per node per edge
             type during PPR traversal. 1000 is sufficient in practice — high-degree
             hub nodes receive diminishing residual per neighbor, so capping the fetch
@@ -80,58 +112,14 @@ class PPRSamplerOptions:
             The algorithm still runs to convergence — re-enqueued nodes propagate
             through cached neighbors at negligible cost. ``None`` (default) means
             no fetch limit.
-        typed_channel_ratios: Optional target proportions for typed PPR
-            traversal channels defined by canonical edge-type allowlists. Keys
-            may be either a single canonical edge type
-            ``(src_type, relation, dst_type)`` or a tuple of canonical edge
-            types. Each key defines one traversal channel whose PPR state may
-            traverse only those exact edge types.
-            If not provided, PPR uses the regular untyped path: each state may
-            traverse all eligible edge types for the current node type and emits
-            scalar PPR scores without channel attribution.
-            Channel order follows the insertion order of this mapping. Values
-            are positive ratios that must sum to ``1.0``. The sampler converts
-            ratios to per-channel target counts from ``max_ppr_nodes``.
-            Finalized PPR candidates and residual top-up candidates both obey
-            these target counts. If the same node appears in multiple channels,
-            it is attributed to the channel where it has the highest calibrated
-            score. If sparse channels or duplicate nodes leave unused target
-            slots, the remaining slots are redistributed globally by score so
-            the returned sequence can still fill up to ``max_ppr_nodes``.
-            Example::
-
-                typed_channel_ratios = {
-                    ("user", "views", "item"): 0.6,
-                    (
-                        ("user", "likes", "item"),
-                        ("user", "shares", "item"),
-                    ): 0.4,
-                }
-
-            This example creates two traversal channels. The first channel can
-            traverse only ``("user", "views", "item")`` edges. With
-            ``max_ppr_nodes=200``, the ``0.6`` ratio targets 120 nodes
-            attributed to this channel. The second channel groups
-            ``("user", "likes", "item")`` and ``("user", "shares", "item")``
-            into one PPR state; the ``0.4`` ratio targets 80 nodes attributed
-            to that combined likes/shares channel. These targets are best-effort
-            rather than strict per-seed guarantees because channels may be
-            sparse or overlapping.
-
-            If residual top-up is enabled, discovered-but-unpushed residual
-            candidates from the same completed PPR states are included on the
-            same mass scale as finalized PPR scores: ``ppr_score + residual``.
-            Residual candidates follow the same channel targets as finalized
-            PPR candidates.
     """
 
     alpha: float = 0.5
     eps: float = 1e-4
-    max_ppr_nodes: int = 50
+    ppr_sequence_length: PPRSequenceLength = 50
     enable_residual_topup: bool = True
     num_neighbors_per_hop: int = 1_000
     max_fetch_iterations: Optional[int] = None
-    typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]] = None
 
 
 SamplerOptions = Union[KHopNeighborSamplerOptions, PPRSamplerOptions]

--- a/gigl/distributed/utils/dist_sampler.py
+++ b/gigl/distributed/utils/dist_sampler.py
@@ -85,6 +85,7 @@ def create_dist_sampler(
             enable_residual_topup=sampler_options.enable_residual_topup,
             max_fetch_iterations=sampler_options.max_fetch_iterations,
             num_neighbors_per_hop=sampler_options.num_neighbors_per_hop,
+            typed_channel_ratios=sampler_options.typed_channel_ratios,
             degree_tensors=degree_tensors,
         )
     else:

--- a/gigl/distributed/utils/dist_sampler.py
+++ b/gigl/distributed/utils/dist_sampler.py
@@ -81,11 +81,10 @@ def create_dist_sampler(
             **shared_sampler_kwargs,
             alpha=sampler_options.alpha,
             eps=sampler_options.eps,
-            max_ppr_nodes=sampler_options.max_ppr_nodes,
+            ppr_sequence_length=sampler_options.ppr_sequence_length,
             enable_residual_topup=sampler_options.enable_residual_topup,
             max_fetch_iterations=sampler_options.max_fetch_iterations,
             num_neighbors_per_hop=sampler_options.num_neighbors_per_hop,
-            typed_channel_ratios=sampler_options.typed_channel_ratios,
             degree_tensors=degree_tensors,
         )
     else:

--- a/gigl/distributed/utils/dist_sampler.py
+++ b/gigl/distributed/utils/dist_sampler.py
@@ -81,7 +81,7 @@ def create_dist_sampler(
             **shared_sampler_kwargs,
             alpha=sampler_options.alpha,
             eps=sampler_options.eps,
-            ppr_sequence_length=sampler_options.ppr_sequence_length,
+            max_ppr_nodes=sampler_options.max_ppr_nodes,
             enable_residual_topup=sampler_options.enable_residual_topup,
             max_fetch_iterations=sampler_options.max_fetch_iterations,
             num_neighbors_per_hop=sampler_options.num_neighbors_per_hop,

--- a/gigl/distributed/utils/dist_typed_sampler.py
+++ b/gigl/distributed/utils/dist_typed_sampler.py
@@ -11,23 +11,8 @@ import math
 from collections.abc import Sequence
 from typing import Optional, Union, cast
 
-import torch
 from graphlearn_torch.typing import EdgeType, NodeType
 
-# C++ PPR extraction output: flat node IDs, flat weights, and per-seed valid
-# counts. Homogeneous extraction uses tensors directly; heterogeneous extraction
-# uses dictionaries keyed by node type.
-PPRResult = tuple[
-    Union[torch.Tensor, dict[NodeType, torch.Tensor]],
-    Union[torch.Tensor, dict[NodeType, torch.Tensor]],
-    Union[torch.Tensor, dict[NodeType, torch.Tensor]],
-]
-# Heterogeneous-only view of PPRResult after typed PPR extraction.
-HeteroPPRResult = tuple[
-    dict[NodeType, torch.Tensor],
-    dict[NodeType, torch.Tensor],
-    dict[NodeType, torch.Tensor],
-]
 # Public typed_channel_ratios keys can be a single edge type or a grouped
 # channel containing multiple edge types.
 TypedPPRChannelKey = Union[EdgeType, tuple[EdgeType, ...]]

--- a/gigl/distributed/utils/dist_typed_sampler.py
+++ b/gigl/distributed/utils/dist_typed_sampler.py
@@ -1,31 +1,32 @@
 """Construction-time typed-PPR option parsing for distributed samplers.
 
-The helpers in this module validate typed-channel edge-type keys and convert
+The helpers in this module validate typed-channel edge-type keys, convert
 public edge-type keys into the compact integer traversal maps consumed by the
-C++ forward-push kernel. They run once during ``DistPPRNeighborSampler``
-initialization, not in the per-batch PPR sampling hot loop.
+C++ forward-push kernel, and derive integer channel target counts from public
+ratios. They run once during ``DistPPRNeighborSampler`` initialization, not in
+the per-batch PPR sampling hot loop.
 """
 
+import math
 from collections.abc import Sequence
-from typing import Union, cast
+from typing import Optional, Union, cast
 
 from graphlearn_torch.typing import EdgeType, NodeType
 
-# Public typed PPR channel keys can be a single edge type or a grouped channel
-# containing multiple edge types.
+# Public typed_channel_ratios keys can be a single edge type or a grouped
+# channel containing multiple edge types.
 TypedPPRChannelKey = Union[EdgeType, tuple[EdgeType, ...]]
-MaxPPRNodes = Union[int, dict[TypedPPRChannelKey, int]]
 
 """TypedPPRChannelKey describes one public typed-PPR traversal channel key.
 
 A single canonical edge type creates one channel restricted to that edge type.
 A tuple of canonical edge types creates one channel whose forward-push state may
 traverse any edge type in the group. When typed PPR emits multi-column
-``edge_attr`` tensors, channel columns follow the insertion order of the typed
-channel mapping.
+``edge_attr`` tensors, channel columns follow the insertion order of the
+``typed_channel_ratios`` mapping.
 """
 # Parsed typed-channel edge-type allowlists, ordered to match the insertion
-# order of the typed-channel mapping.
+# order of typed_channel_ratios.
 TypedPPRChannelEdgeTypeGroups = list[tuple[EdgeType, ...]]
 # One channel's traversal map. The outer list is indexed by integer node-type
 # ID; each inner list contains the integer edge-type IDs that channel may
@@ -35,39 +36,38 @@ TypedPPRChannelTraversalMap = list[list[int]]
 TypedPPRChannelTraversalMaps = list[TypedPPRChannelTraversalMap]
 
 
-def parse_typed_channel_target_groups(
-    typed_channel_targets: dict[TypedPPRChannelKey, int],
-) -> tuple[TypedPPRChannelEdgeTypeGroups, list[int]]:
-    """Parse typed-PPR channel keys and split keys from target counts.
+def parse_typed_channel_ratio_groups(
+    typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]],
+) -> tuple[Optional[TypedPPRChannelEdgeTypeGroups], Optional[list[float]]]:
+    """Parse typed-PPR channel keys and split keys from ratios.
 
     Public options allow each channel key to be either one canonical edge type
     or a non-empty tuple of canonical edge types. Internally, traversal setup
     needs only the edge-type groups while merge selection needs the aligned
-    integer target counts, so this helper returns those two parallel lists.
+    ratio values, so this helper returns those two parallel lists.
 
     This is construction-time option parsing and is not part of the per-batch
     PPR sampling hot loop.
 
     Args:
-        typed_channel_targets: User-provided channel mapping from edge-type
-            allowlist to target output count.
+        typed_channel_ratios: User-provided channel mapping from edge-type
+            allowlist to target output ratio.
 
     Returns:
-        ``(typed_channel_groups, typed_channel_target_counts)``, both ordered
-        by the input mapping insertion order.
+        ``(None, None)`` when typed PPR is disabled. Otherwise returns
+        ``(typed_channel_groups, typed_channel_ratio_list)``, both ordered by
+        the input mapping insertion order.
 
     Raises:
         ValueError: If a channel key is not a canonical edge type or non-empty
-            tuple of canonical edge types, or if target counts are not positive
-            integers.
+            tuple of canonical edge types, or if ratios are not positive and
+            summing to 1.0.
     """
-    if not typed_channel_targets:
-        raise ValueError(
-            "Typed PPR max_ppr_nodes mapping must contain at least one channel."
-        )
+    if not typed_channel_ratios:
+        return None, None
 
     typed_channel_groups: TypedPPRChannelEdgeTypeGroups = []
-    typed_channel_target_counts: list[int] = []
+    typed_channel_ratio_list: list[float] = []
 
     def is_canonical_edge_type(value: object) -> bool:
         """Return whether ``value`` has PyG's canonical edge-type shape."""
@@ -77,7 +77,7 @@ def parse_typed_channel_target_groups(
             and all(isinstance(part, str) for part in value)
         )
 
-    for edge_type_key, target_count in typed_channel_targets.items():
+    for edge_type_key, ratio in typed_channel_ratios.items():
         if is_canonical_edge_type(edge_type_key):
             edge_types = (cast(EdgeType, edge_type_key),)
         elif (
@@ -88,23 +88,69 @@ def parse_typed_channel_target_groups(
             edge_types = cast(tuple[EdgeType, ...], edge_type_key)
         else:
             raise ValueError(
-                "Typed PPR channel keys must be a canonical edge type "
+                "typed_channel_ratios keys must be a canonical edge type "
                 "(src_type, relation, dst_type) or a non-empty tuple of "
                 f"canonical edge types, got {edge_type_key!r}."
             )
         if (
-            not isinstance(target_count, int)
-            or isinstance(target_count, bool)
-            or target_count <= 0
+            not isinstance(ratio, (int, float))
+            or isinstance(ratio, bool)
+            or ratio <= 0.0
+            or ratio > 1.0
         ):
             raise ValueError(
-                "Typed PPR channel target counts must be positive integers, "
-                f"got {target_count!r} for channel {edge_type_key!r}."
+                "typed_channel_ratios values must be positive ratios in (0, 1], "
+                f"got {ratio!r} for channel {edge_type_key!r}."
             )
         typed_channel_groups.append(edge_types)
-        typed_channel_target_counts.append(target_count)
+        typed_channel_ratio_list.append(float(ratio))
 
-    return typed_channel_groups, typed_channel_target_counts
+    ratio_sum = sum(typed_channel_ratio_list)
+    if not math.isclose(ratio_sum, 1.0, rel_tol=1e-9, abs_tol=1e-9):
+        raise ValueError(
+            "typed_channel_ratios values must sum to 1.0, "
+            f"got {ratio_sum} from ratios {typed_channel_ratio_list}."
+        )
+
+    return typed_channel_groups, typed_channel_ratio_list
+
+
+def compute_typed_channel_target_counts(
+    typed_channel_ratios: list[float],
+    max_ppr_nodes: int,
+) -> list[int]:
+    """Convert typed-channel ratios to integer per-channel target counts.
+
+    Ratios describe the desired attribution mix in the returned PPR sequence.
+    This helper converts them to integer counts whose sum is ``max_ppr_nodes``.
+    Fractional remainders are assigned from largest to smallest, with channel
+    order as the deterministic tie-breaker.
+
+    This is construction-time option parsing and is not part of the per-batch
+    PPR sampling hot loop.
+
+    Args:
+        typed_channel_ratios: Per-channel ratios, ordered by typed-channel
+            insertion order and summing to 1.0.
+        max_ppr_nodes: Maximum PPR sequence length per seed.
+
+    Returns:
+        Integer target counts aligned with ``typed_channel_ratios``.
+    """
+    raw_target_counts = [ratio * max_ppr_nodes for ratio in typed_channel_ratios]
+    target_counts = [math.floor(raw_count) for raw_count in raw_target_counts]
+    remaining_count = max_ppr_nodes - sum(target_counts)
+    channels_by_fractional_remainder = sorted(
+        range(len(raw_target_counts)),
+        key=lambda channel_index: (
+            raw_target_counts[channel_index] - target_counts[channel_index],
+            -channel_index,
+        ),
+        reverse=True,
+    )
+    for channel_index in channels_by_fractional_remainder[:remaining_count]:
+        target_counts[channel_index] += 1
+    return target_counts
 
 
 def build_edge_type_channel_group_edge_type_ids(

--- a/gigl/distributed/utils/dist_typed_sampler.py
+++ b/gigl/distributed/utils/dist_typed_sampler.py
@@ -1,0 +1,230 @@
+"""Construction-time typed-PPR option parsing for distributed samplers.
+
+The helpers in this module validate typed-channel edge-type keys, convert
+public edge-type keys into the compact integer traversal maps consumed by the
+C++ forward-push kernel, and derive integer channel target counts from public
+ratios. They run once during ``DistPPRNeighborSampler`` initialization, not in
+the per-batch PPR sampling hot loop.
+"""
+
+import math
+from collections.abc import Sequence
+from typing import Optional, Union, cast
+
+import torch
+from graphlearn_torch.typing import EdgeType, NodeType
+
+# C++ PPR extraction output: flat node IDs, flat weights, and per-seed valid
+# counts. Homogeneous extraction uses tensors directly; heterogeneous extraction
+# uses dictionaries keyed by node type.
+PPRResult = tuple[
+    Union[torch.Tensor, dict[NodeType, torch.Tensor]],
+    Union[torch.Tensor, dict[NodeType, torch.Tensor]],
+    Union[torch.Tensor, dict[NodeType, torch.Tensor]],
+]
+# Heterogeneous-only view of PPRResult after typed PPR extraction.
+HeteroPPRResult = tuple[
+    dict[NodeType, torch.Tensor],
+    dict[NodeType, torch.Tensor],
+    dict[NodeType, torch.Tensor],
+]
+# Public typed_channel_ratios keys can be a single edge type or a grouped
+# channel containing multiple edge types.
+TypedPPRChannelKey = Union[EdgeType, tuple[EdgeType, ...]]
+
+"""TypedPPRChannelKey describes one public typed-PPR traversal channel key.
+
+A single canonical edge type creates one channel restricted to that edge type.
+A tuple of canonical edge types creates one channel whose forward-push state may
+traverse any edge type in the group. When typed PPR emits multi-column
+``edge_attr`` tensors, channel columns follow the insertion order of the
+``typed_channel_ratios`` mapping.
+"""
+# Parsed typed-channel edge-type allowlists, ordered to match the insertion
+# order of typed_channel_ratios.
+TypedPPRChannelEdgeTypeGroups = list[tuple[EdgeType, ...]]
+# One channel's traversal map. The outer list is indexed by integer node-type
+# ID; each inner list contains the integer edge-type IDs that channel may
+# traverse from that node type.
+TypedPPRChannelTraversalMap = list[list[int]]
+# All typed-channel traversal maps, ordered to match typed-channel order.
+TypedPPRChannelTraversalMaps = list[TypedPPRChannelTraversalMap]
+
+
+def parse_typed_channel_ratio_groups(
+    typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]],
+) -> tuple[Optional[TypedPPRChannelEdgeTypeGroups], Optional[list[float]]]:
+    """Parse typed-PPR channel keys and split keys from ratios.
+
+    Public options allow each channel key to be either one canonical edge type
+    or a non-empty tuple of canonical edge types. Internally, traversal setup
+    needs only the edge-type groups while merge selection needs the aligned
+    ratio values, so this helper returns those two parallel lists.
+
+    This is construction-time option parsing and is not part of the per-batch
+    PPR sampling hot loop.
+
+    Args:
+        typed_channel_ratios: User-provided channel mapping from edge-type
+            allowlist to target output ratio.
+
+    Returns:
+        ``(None, None)`` when typed PPR is disabled. Otherwise returns
+        ``(typed_channel_groups, typed_channel_ratio_list)``, both ordered by
+        the input mapping insertion order.
+
+    Raises:
+        ValueError: If a channel key is not a canonical edge type or non-empty
+            tuple of canonical edge types, or if ratios are not positive and
+            summing to 1.0.
+    """
+    if not typed_channel_ratios:
+        return None, None
+
+    typed_channel_groups: TypedPPRChannelEdgeTypeGroups = []
+    typed_channel_ratio_list: list[float] = []
+
+    def is_canonical_edge_type(value: object) -> bool:
+        """Return whether ``value`` has PyG's canonical edge-type shape."""
+        return (
+            isinstance(value, tuple)
+            and len(value) == 3
+            and all(isinstance(part, str) for part in value)
+        )
+
+    for edge_type_key, ratio in typed_channel_ratios.items():
+        if is_canonical_edge_type(edge_type_key):
+            edge_types = (cast(EdgeType, edge_type_key),)
+        elif (
+            isinstance(edge_type_key, tuple)
+            and edge_type_key
+            and all(is_canonical_edge_type(edge_type) for edge_type in edge_type_key)
+        ):
+            edge_types = cast(tuple[EdgeType, ...], edge_type_key)
+        else:
+            raise ValueError(
+                "typed_channel_ratios keys must be a canonical edge type "
+                "(src_type, relation, dst_type) or a non-empty tuple of "
+                f"canonical edge types, got {edge_type_key!r}."
+            )
+        if isinstance(ratio, bool) or ratio <= 0.0 or ratio > 1.0:
+            raise ValueError(
+                "typed_channel_ratios values must be positive ratios in (0, 1], "
+                f"got {ratio!r} for channel {edge_type_key!r}."
+            )
+        typed_channel_groups.append(edge_types)
+        typed_channel_ratio_list.append(float(ratio))
+
+    ratio_sum = sum(typed_channel_ratio_list)
+    if not math.isclose(ratio_sum, 1.0, rel_tol=1e-9, abs_tol=1e-9):
+        raise ValueError(
+            "typed_channel_ratios values must sum to 1.0, "
+            f"got {ratio_sum} from ratios {typed_channel_ratio_list}."
+        )
+
+    return typed_channel_groups, typed_channel_ratio_list
+
+
+def compute_typed_channel_target_counts(
+    typed_channel_ratios: list[float],
+    max_ppr_nodes: int,
+) -> list[int]:
+    """Convert typed-channel ratios to integer per-channel target counts.
+
+    Ratios describe the desired attribution mix in the returned PPR sequence.
+    This helper converts them to integer counts whose sum is ``max_ppr_nodes``.
+    Fractional remainders are assigned from largest to smallest, with channel
+    order as the deterministic tie-breaker.
+
+    This is construction-time option parsing and is not part of the per-batch
+    PPR sampling hot loop.
+
+    Args:
+        typed_channel_ratios: Per-channel ratios, ordered by typed-channel
+            insertion order and summing to 1.0.
+        max_ppr_nodes: Maximum PPR sequence length per seed.
+
+    Returns:
+        Integer target counts aligned with ``typed_channel_ratios``.
+    """
+    raw_target_counts = [ratio * max_ppr_nodes for ratio in typed_channel_ratios]
+    target_counts = [math.floor(raw_count) for raw_count in raw_target_counts]
+    remaining_count = max_ppr_nodes - sum(target_counts)
+    channels_by_fractional_remainder = sorted(
+        range(len(raw_target_counts)),
+        key=lambda channel_index: (
+            raw_target_counts[channel_index] - target_counts[channel_index],
+            -channel_index,
+        ),
+        reverse=True,
+    )
+    for channel_index in channels_by_fractional_remainder[:remaining_count]:
+        target_counts[channel_index] += 1
+    return target_counts
+
+
+def build_edge_type_channel_group_edge_type_ids(
+    edge_type_groups: TypedPPRChannelEdgeTypeGroups,
+    edge_type_to_edge_type_id: dict[EdgeType, int],
+    node_type_to_edge_types: dict[NodeType, list[EdgeType]],
+    node_types: Sequence[NodeType],
+) -> TypedPPRChannelTraversalMaps:
+    """Convert typed-channel edge-type allowlists to PPRForwardPush IDs.
+
+    Returns one traversal map per typed channel, ordered to match
+    ``edge_type_groups``. A single traversal map has shape
+    ``list[list[int]]``: the outer index is ``node_type_id``, and the inner list
+    contains allowed ``edge_type_id`` values for that node type in that channel.
+
+    This conversion runs once during sampler construction; the resulting integer
+    maps are reused by the per-batch C++ PPR states.
+
+    Args:
+        edge_type_groups: Ordered typed channels, where each channel is the
+            canonical edge types that its PPR state may traverse.
+        edge_type_to_edge_type_id: Mapping from canonical edge type to the
+            compact integer ID used by the C++ forward-push kernel.
+        node_type_to_edge_types: Traversable edge types keyed by anchor node
+            type, after label-edge filtering and edge-direction handling.
+        node_types: Ordered node types whose positions match the kernel's
+            integer node-type IDs.
+
+    Returns:
+        ``channel_traversal_maps[channel_id][node_type_id]`` gives the allowed
+        integer edge-type IDs that channel may traverse from that node type.
+
+    Raises:
+        ValueError: If a configured edge type is unknown, excluded from PPR
+            traversal, or cannot be traversed from any node type.
+    """
+    known_edge_types = set(edge_type_to_edge_type_id.keys())
+    channel_edge_type_ids_by_node_type: TypedPPRChannelTraversalMaps = []
+    for channel_edge_types in edge_type_groups:
+        unknown_edge_types = set(channel_edge_types) - known_edge_types
+        if unknown_edge_types:
+            raise ValueError(
+                "typed_channel_ratios includes non-traversable edge types "
+                f"{sorted(unknown_edge_types)!r}. Known traversable edge "
+                f"types are {sorted(known_edge_types)!r}."
+            )
+
+        channel_edge_type_set = set(channel_edge_types)
+        node_type_id_to_channel_edge_type_ids: TypedPPRChannelTraversalMap = []
+        for node_type in node_types:
+            channel_edge_type_ids_for_node_type: list[int] = []
+            for edge_type in node_type_to_edge_types.get(node_type, []):
+                if edge_type in channel_edge_type_set:
+                    channel_edge_type_ids_for_node_type.append(
+                        edge_type_to_edge_type_id[edge_type]
+                    )
+            node_type_id_to_channel_edge_type_ids.append(
+                channel_edge_type_ids_for_node_type
+            )
+        if not any(node_type_id_to_channel_edge_type_ids):
+            raise ValueError(
+                "typed_channel_ratios includes edge-type "
+                f"channel={channel_edge_types!r}, "
+                "but no traversable edge types exist for that channel."
+            )
+        channel_edge_type_ids_by_node_type.append(node_type_id_to_channel_edge_type_ids)
+    return channel_edge_type_ids_by_node_type

--- a/gigl/distributed/utils/dist_typed_sampler.py
+++ b/gigl/distributed/utils/dist_typed_sampler.py
@@ -1,32 +1,31 @@
 """Construction-time typed-PPR option parsing for distributed samplers.
 
-The helpers in this module validate typed-channel edge-type keys, convert
+The helpers in this module validate typed-channel edge-type keys and convert
 public edge-type keys into the compact integer traversal maps consumed by the
-C++ forward-push kernel, and derive integer channel target counts from public
-ratios. They run once during ``DistPPRNeighborSampler`` initialization, not in
-the per-batch PPR sampling hot loop.
+C++ forward-push kernel. They run once during ``DistPPRNeighborSampler``
+initialization, not in the per-batch PPR sampling hot loop.
 """
 
-import math
 from collections.abc import Sequence
-from typing import Optional, Union, cast
+from typing import Union, cast
 
 from graphlearn_torch.typing import EdgeType, NodeType
 
-# Public typed_channel_ratios keys can be a single edge type or a grouped
-# channel containing multiple edge types.
+# Public typed PPR channel keys can be a single edge type or a grouped channel
+# containing multiple edge types.
 TypedPPRChannelKey = Union[EdgeType, tuple[EdgeType, ...]]
+PPRSequenceLength = Union[int, dict[TypedPPRChannelKey, int]]
 
 """TypedPPRChannelKey describes one public typed-PPR traversal channel key.
 
 A single canonical edge type creates one channel restricted to that edge type.
 A tuple of canonical edge types creates one channel whose forward-push state may
 traverse any edge type in the group. When typed PPR emits multi-column
-``edge_attr`` tensors, channel columns follow the insertion order of the
-``typed_channel_ratios`` mapping.
+``edge_attr`` tensors, channel columns follow the insertion order of the typed
+channel mapping.
 """
 # Parsed typed-channel edge-type allowlists, ordered to match the insertion
-# order of typed_channel_ratios.
+# order of the typed-channel mapping.
 TypedPPRChannelEdgeTypeGroups = list[tuple[EdgeType, ...]]
 # One channel's traversal map. The outer list is indexed by integer node-type
 # ID; each inner list contains the integer edge-type IDs that channel may
@@ -36,38 +35,39 @@ TypedPPRChannelTraversalMap = list[list[int]]
 TypedPPRChannelTraversalMaps = list[TypedPPRChannelTraversalMap]
 
 
-def parse_typed_channel_ratio_groups(
-    typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]],
-) -> tuple[Optional[TypedPPRChannelEdgeTypeGroups], Optional[list[float]]]:
-    """Parse typed-PPR channel keys and split keys from ratios.
+def parse_typed_channel_target_groups(
+    typed_channel_targets: dict[TypedPPRChannelKey, int],
+) -> tuple[TypedPPRChannelEdgeTypeGroups, list[int]]:
+    """Parse typed-PPR channel keys and split keys from target counts.
 
     Public options allow each channel key to be either one canonical edge type
     or a non-empty tuple of canonical edge types. Internally, traversal setup
     needs only the edge-type groups while merge selection needs the aligned
-    ratio values, so this helper returns those two parallel lists.
+    integer target counts, so this helper returns those two parallel lists.
 
     This is construction-time option parsing and is not part of the per-batch
     PPR sampling hot loop.
 
     Args:
-        typed_channel_ratios: User-provided channel mapping from edge-type
-            allowlist to target output ratio.
+        typed_channel_targets: User-provided channel mapping from edge-type
+            allowlist to target output count.
 
     Returns:
-        ``(None, None)`` when typed PPR is disabled. Otherwise returns
-        ``(typed_channel_groups, typed_channel_ratio_list)``, both ordered by
-        the input mapping insertion order.
+        ``(typed_channel_groups, typed_channel_target_counts)``, both ordered
+        by the input mapping insertion order.
 
     Raises:
         ValueError: If a channel key is not a canonical edge type or non-empty
-            tuple of canonical edge types, or if ratios are not positive and
-            summing to 1.0.
+            tuple of canonical edge types, or if target counts are not positive
+            integers.
     """
-    if not typed_channel_ratios:
-        return None, None
+    if not typed_channel_targets:
+        raise ValueError(
+            "Typed PPR sequence length mapping must contain at least one channel."
+        )
 
     typed_channel_groups: TypedPPRChannelEdgeTypeGroups = []
-    typed_channel_ratio_list: list[float] = []
+    typed_channel_target_counts: list[int] = []
 
     def is_canonical_edge_type(value: object) -> bool:
         """Return whether ``value`` has PyG's canonical edge-type shape."""
@@ -77,7 +77,7 @@ def parse_typed_channel_ratio_groups(
             and all(isinstance(part, str) for part in value)
         )
 
-    for edge_type_key, ratio in typed_channel_ratios.items():
+    for edge_type_key, target_count in typed_channel_targets.items():
         if is_canonical_edge_type(edge_type_key):
             edge_types = (cast(EdgeType, edge_type_key),)
         elif (
@@ -88,64 +88,23 @@ def parse_typed_channel_ratio_groups(
             edge_types = cast(tuple[EdgeType, ...], edge_type_key)
         else:
             raise ValueError(
-                "typed_channel_ratios keys must be a canonical edge type "
+                "Typed PPR channel keys must be a canonical edge type "
                 "(src_type, relation, dst_type) or a non-empty tuple of "
                 f"canonical edge types, got {edge_type_key!r}."
             )
-        if isinstance(ratio, bool) or ratio <= 0.0 or ratio > 1.0:
+        if (
+            not isinstance(target_count, int)
+            or isinstance(target_count, bool)
+            or target_count <= 0
+        ):
             raise ValueError(
-                "typed_channel_ratios values must be positive ratios in (0, 1], "
-                f"got {ratio!r} for channel {edge_type_key!r}."
+                "Typed PPR channel target counts must be positive integers, "
+                f"got {target_count!r} for channel {edge_type_key!r}."
             )
         typed_channel_groups.append(edge_types)
-        typed_channel_ratio_list.append(float(ratio))
+        typed_channel_target_counts.append(target_count)
 
-    ratio_sum = sum(typed_channel_ratio_list)
-    if not math.isclose(ratio_sum, 1.0, rel_tol=1e-9, abs_tol=1e-9):
-        raise ValueError(
-            "typed_channel_ratios values must sum to 1.0, "
-            f"got {ratio_sum} from ratios {typed_channel_ratio_list}."
-        )
-
-    return typed_channel_groups, typed_channel_ratio_list
-
-
-def compute_typed_channel_target_counts(
-    typed_channel_ratios: list[float],
-    max_ppr_nodes: int,
-) -> list[int]:
-    """Convert typed-channel ratios to integer per-channel target counts.
-
-    Ratios describe the desired attribution mix in the returned PPR sequence.
-    This helper converts them to integer counts whose sum is ``max_ppr_nodes``.
-    Fractional remainders are assigned from largest to smallest, with channel
-    order as the deterministic tie-breaker.
-
-    This is construction-time option parsing and is not part of the per-batch
-    PPR sampling hot loop.
-
-    Args:
-        typed_channel_ratios: Per-channel ratios, ordered by typed-channel
-            insertion order and summing to 1.0.
-        max_ppr_nodes: Maximum PPR sequence length per seed.
-
-    Returns:
-        Integer target counts aligned with ``typed_channel_ratios``.
-    """
-    raw_target_counts = [ratio * max_ppr_nodes for ratio in typed_channel_ratios]
-    target_counts = [math.floor(raw_count) for raw_count in raw_target_counts]
-    remaining_count = max_ppr_nodes - sum(target_counts)
-    channels_by_fractional_remainder = sorted(
-        range(len(raw_target_counts)),
-        key=lambda channel_index: (
-            raw_target_counts[channel_index] - target_counts[channel_index],
-            -channel_index,
-        ),
-        reverse=True,
-    )
-    for channel_index in channels_by_fractional_remainder[:remaining_count]:
-        target_counts[channel_index] += 1
-    return target_counts
+    return typed_channel_groups, typed_channel_target_counts
 
 
 def build_edge_type_channel_group_edge_type_ids(
@@ -188,7 +147,7 @@ def build_edge_type_channel_group_edge_type_ids(
         unknown_edge_types = set(channel_edge_types) - known_edge_types
         if unknown_edge_types:
             raise ValueError(
-                "typed_channel_ratios includes non-traversable edge types "
+                "Typed PPR channels include non-traversable edge types "
                 f"{sorted(unknown_edge_types)!r}. Known traversable edge "
                 f"types are {sorted(known_edge_types)!r}."
             )
@@ -207,7 +166,7 @@ def build_edge_type_channel_group_edge_type_ids(
             )
         if not any(node_type_id_to_channel_edge_type_ids):
             raise ValueError(
-                "typed_channel_ratios includes edge-type "
+                "Typed PPR channels include edge-type "
                 f"channel={channel_edge_types!r}, "
                 "but no traversable edge types exist for that channel."
             )

--- a/gigl/distributed/utils/dist_typed_sampler.py
+++ b/gigl/distributed/utils/dist_typed_sampler.py
@@ -20,8 +20,8 @@ TypedPPRChannelKey = Union[EdgeType, tuple[EdgeType, ...]]
 """TypedPPRChannelKey describes one public typed-PPR traversal channel key.
 
 A single canonical edge type creates one channel restricted to that edge type.
-A tuple of canonical edge types creates one channel whose forward-push state may
-traverse any edge type in the group. When typed PPR emits multi-column
+A tuple of canonical edge types creates one channel whose PPR traversal may use
+any edge type in the group. When typed PPR emits multi-column
 ``edge_attr`` tensors, channel columns follow the insertion order of the
 ``typed_channel_ratios`` mapping.
 """
@@ -171,7 +171,7 @@ def build_edge_type_channel_group_edge_type_ids(
 
     Args:
         edge_type_groups: Ordered typed channels, where each channel is the
-            canonical edge types that its PPR state may traverse.
+            canonical edge types that its PPR traversal may use.
         edge_type_to_edge_type_id: Mapping from canonical edge type to the
             compact integer ID used by the C++ forward-push kernel.
         node_type_to_edge_types: Traversable edge types keyed by anchor node

--- a/gigl/distributed/utils/dist_typed_sampler.py
+++ b/gigl/distributed/utils/dist_typed_sampler.py
@@ -14,7 +14,7 @@ from graphlearn_torch.typing import EdgeType, NodeType
 # Public typed PPR channel keys can be a single edge type or a grouped channel
 # containing multiple edge types.
 TypedPPRChannelKey = Union[EdgeType, tuple[EdgeType, ...]]
-PPRSequenceLength = Union[int, dict[TypedPPRChannelKey, int]]
+MaxPPRNodes = Union[int, dict[TypedPPRChannelKey, int]]
 
 """TypedPPRChannelKey describes one public typed-PPR traversal channel key.
 
@@ -63,7 +63,7 @@ def parse_typed_channel_target_groups(
     """
     if not typed_channel_targets:
         raise ValueError(
-            "Typed PPR sequence length mapping must contain at least one channel."
+            "Typed PPR max_ppr_nodes mapping must contain at least one channel."
         )
 
     typed_channel_groups: TypedPPRChannelEdgeTypeGroups = []

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -546,9 +546,10 @@ def _run_typed_ppr_loader_shape_check(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            max_ppr_nodes={
-                USER_TO_STORY: 3,
-                STORY_TO_USER: 2,
+            max_ppr_nodes=_TEST_MAX_PPR_NODES,
+            typed_channel_ratios={
+                USER_TO_STORY: 0.5,
+                STORY_TO_USER: 0.5,
             },
         ),
         pin_memory_device=torch.device("cpu"),
@@ -580,9 +581,10 @@ def _run_typed_ppr_loader_shape_check(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            max_ppr_nodes={
-                STORY_TO_USER: 3,
-                (STORY_TO_USER,): 2,
+            max_ppr_nodes=_TEST_MAX_PPR_NODES,
+            typed_channel_ratios={
+                STORY_TO_USER: 0.5,
+                (STORY_TO_USER,): 0.5,
             },
         ),
         pin_memory_device=torch.device("cpu"),

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -370,7 +370,7 @@ def _run_ppr_loader_correctness_check(
         sampler_options=PPRSamplerOptions(
             alpha=alpha,
             eps=_TEST_EPS,
-            max_ppr_nodes=max_ppr_nodes,
+            ppr_sequence_length=max_ppr_nodes,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -423,7 +423,7 @@ def _run_ppr_loader_correctness_check(
             graph=reference_graph,
             seed=seed_global_id,
             alpha=alpha,
-            max_ppr_nodes=max_ppr_nodes,
+            ppr_sequence_length=max_ppr_nodes,
         )
 
         # Verify same top-k node set
@@ -477,7 +477,7 @@ def _run_ppr_hetero_loader_correctness_check(
         sampler_options=PPRSamplerOptions(
             alpha=alpha,
             eps=_TEST_EPS,
-            max_ppr_nodes=max_ppr_nodes,
+            ppr_sequence_length=max_ppr_nodes,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -508,7 +508,7 @@ def _run_ppr_hetero_loader_correctness_check(
             seed=seed_global_id,
             seed_type=str(USER),
             alpha=alpha,
-            max_ppr_nodes=max_ppr_nodes,
+            ppr_sequence_length=max_ppr_nodes,
         )
 
         _assert_ppr_scores_match_reference(
@@ -546,10 +546,9 @@ def _run_typed_ppr_loader_shape_check(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            max_ppr_nodes=_TEST_MAX_PPR_NODES,
-            typed_channel_ratios={
-                USER_TO_STORY: 0.5,
-                STORY_TO_USER: 0.5,
+            ppr_sequence_length={
+                USER_TO_STORY: 3,
+                STORY_TO_USER: 2,
             },
         ),
         pin_memory_device=torch.device("cpu"),
@@ -581,10 +580,9 @@ def _run_typed_ppr_loader_shape_check(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            max_ppr_nodes=_TEST_MAX_PPR_NODES,
-            typed_channel_ratios={
-                STORY_TO_USER: 0.5,
-                (STORY_TO_USER,): 0.5,
+            ppr_sequence_length={
+                STORY_TO_USER: 3,
+                (STORY_TO_USER,): 2,
             },
         ),
         pin_memory_device=torch.device("cpu"),
@@ -645,7 +643,7 @@ def _run_ppr_ablp_loader_correctness_check(
         sampler_options=PPRSamplerOptions(
             alpha=alpha,
             eps=_TEST_EPS,
-            max_ppr_nodes=max_ppr_nodes,
+            ppr_sequence_length=max_ppr_nodes,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -680,7 +678,7 @@ def _run_ppr_ablp_loader_correctness_check(
             seed=seed_global_id,
             seed_type=str(USER),
             alpha=alpha,
-            max_ppr_nodes=max_ppr_nodes,
+            ppr_sequence_length=max_ppr_nodes,
         )
 
         _assert_ppr_scores_match_reference(
@@ -747,7 +745,7 @@ def _run_ppr_labeled_homogeneous_ablp_loader_check(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            max_ppr_nodes=_TEST_MAX_PPR_NODES,
+            ppr_sequence_length=_TEST_MAX_PPR_NODES,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -794,7 +792,7 @@ def _run_ppr_destination_only_node_type(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            max_ppr_nodes=_TEST_MAX_PPR_NODES,
+            ppr_sequence_length=_TEST_MAX_PPR_NODES,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -851,7 +849,7 @@ def _run_ppr_ablp_label_edges_do_not_affect_anchor_ppr(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            max_ppr_nodes=_TEST_MAX_PPR_NODES,
+            ppr_sequence_length=_TEST_MAX_PPR_NODES,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -370,7 +370,7 @@ def _run_ppr_loader_correctness_check(
         sampler_options=PPRSamplerOptions(
             alpha=alpha,
             eps=_TEST_EPS,
-            ppr_sequence_length=max_ppr_nodes,
+            max_ppr_nodes=max_ppr_nodes,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -423,7 +423,7 @@ def _run_ppr_loader_correctness_check(
             graph=reference_graph,
             seed=seed_global_id,
             alpha=alpha,
-            ppr_sequence_length=max_ppr_nodes,
+            max_ppr_nodes=max_ppr_nodes,
         )
 
         # Verify same top-k node set
@@ -477,7 +477,7 @@ def _run_ppr_hetero_loader_correctness_check(
         sampler_options=PPRSamplerOptions(
             alpha=alpha,
             eps=_TEST_EPS,
-            ppr_sequence_length=max_ppr_nodes,
+            max_ppr_nodes=max_ppr_nodes,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -508,7 +508,7 @@ def _run_ppr_hetero_loader_correctness_check(
             seed=seed_global_id,
             seed_type=str(USER),
             alpha=alpha,
-            ppr_sequence_length=max_ppr_nodes,
+            max_ppr_nodes=max_ppr_nodes,
         )
 
         _assert_ppr_scores_match_reference(
@@ -546,7 +546,7 @@ def _run_typed_ppr_loader_shape_check(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            ppr_sequence_length={
+            max_ppr_nodes={
                 USER_TO_STORY: 3,
                 STORY_TO_USER: 2,
             },
@@ -580,7 +580,7 @@ def _run_typed_ppr_loader_shape_check(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            ppr_sequence_length={
+            max_ppr_nodes={
                 STORY_TO_USER: 3,
                 (STORY_TO_USER,): 2,
             },
@@ -643,7 +643,7 @@ def _run_ppr_ablp_loader_correctness_check(
         sampler_options=PPRSamplerOptions(
             alpha=alpha,
             eps=_TEST_EPS,
-            ppr_sequence_length=max_ppr_nodes,
+            max_ppr_nodes=max_ppr_nodes,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -678,7 +678,7 @@ def _run_ppr_ablp_loader_correctness_check(
             seed=seed_global_id,
             seed_type=str(USER),
             alpha=alpha,
-            ppr_sequence_length=max_ppr_nodes,
+            max_ppr_nodes=max_ppr_nodes,
         )
 
         _assert_ppr_scores_match_reference(
@@ -745,7 +745,7 @@ def _run_ppr_labeled_homogeneous_ablp_loader_check(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            ppr_sequence_length=_TEST_MAX_PPR_NODES,
+            max_ppr_nodes=_TEST_MAX_PPR_NODES,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -792,7 +792,7 @@ def _run_ppr_destination_only_node_type(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            ppr_sequence_length=_TEST_MAX_PPR_NODES,
+            max_ppr_nodes=_TEST_MAX_PPR_NODES,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,
@@ -849,7 +849,7 @@ def _run_ppr_ablp_label_edges_do_not_affect_anchor_ppr(_: int) -> None:
         sampler_options=PPRSamplerOptions(
             alpha=_TEST_ALPHA,
             eps=_TEST_EPS,
-            ppr_sequence_length=_TEST_MAX_PPR_NODES,
+            max_ppr_nodes=_TEST_MAX_PPR_NODES,
         ),
         pin_memory_device=torch.device("cpu"),
         batch_size=1,

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -302,6 +302,47 @@ def _assert_ppr_scores_match_reference(
             )
 
 
+def _assert_typed_ppr_edge_attrs(
+    datum: HeteroData,
+    seed_type: str,
+    node_types: list[str],
+    num_channels: int,
+) -> None:
+    """Assert typed PPR edge attributes have the expected channel layout."""
+    expected_width = 1 + (2 * num_channels)
+    for node_type in node_types:
+        ppr_edge_type = (seed_type, "ppr", node_type)
+        assert ppr_edge_type in datum.edge_types, (
+            f"Missing PPR edge type {ppr_edge_type} on HeteroData"
+        )
+        ppr_edge_index = datum[ppr_edge_type].edge_index
+        ppr_edge_attr = datum[ppr_edge_type].edge_attr
+
+        assert ppr_edge_index.dim() == 2 and ppr_edge_index.size(0) == 2, (
+            f"Expected [2, X] edge_index, got shape {list(ppr_edge_index.shape)}"
+        )
+        assert ppr_edge_attr.dim() == 2, (
+            f"Expected 2D typed PPR edge_attr, got {ppr_edge_attr.dim()}D"
+        )
+        assert ppr_edge_attr.size(0) == ppr_edge_index.size(1)
+        assert ppr_edge_attr.size(1) == expected_width, (
+            f"Expected typed PPR edge_attr width {expected_width}, "
+            f"got {ppr_edge_attr.size(1)}"
+        )
+
+        if ppr_edge_attr.size(0) == 0:
+            continue
+
+        best_scores = ppr_edge_attr[:, 0]
+        assert (best_scores >= 0).all()
+        assert (best_scores <= 1).all()
+        if best_scores.size(0) > 1:
+            assert (best_scores[:-1] >= best_scores[1:]).all()
+
+        channel_presence = ppr_edge_attr[:, 1 + num_channels :]
+        assert ((channel_presence == 0) | (channel_presence == 1)).all()
+
+
 # ---------------------------------------------------------------------------
 # Spawned process functions
 # ---------------------------------------------------------------------------
@@ -484,6 +525,82 @@ def _run_ppr_hetero_loader_correctness_check(
     assert batches_checked == _NUM_TEST_USERS, (
         f"Expected {_NUM_TEST_USERS} batches, got {batches_checked}"
     )
+    shutdown_rpc()
+
+
+def _run_typed_ppr_loader_shape_check(_: int) -> None:
+    """Verify typed PPR runs through DistNeighborLoader into HeteroData."""
+    create_test_process_group()
+
+    dataset = create_heterogeneous_dataset(
+        edge_indices=_TEST_HETERO_EDGE_INDICES,
+        edge_dir="out",
+    )
+    node_ids = dataset.node_ids
+    assert isinstance(node_ids, dict)
+
+    loader = DistNeighborLoader(
+        dataset=dataset,
+        input_nodes=(USER, node_ids[USER]),  # ty: ignore[invalid-argument-type] TODO(ty-torch-keyed-access): fix ty false positives for torch-backed keyed container access.
+        num_neighbors=[],
+        sampler_options=PPRSamplerOptions(
+            alpha=_TEST_ALPHA,
+            eps=_TEST_EPS,
+            max_ppr_nodes=_TEST_MAX_PPR_NODES,
+            typed_channel_ratios={
+                USER_TO_STORY: 0.5,
+                STORY_TO_USER: 0.5,
+            },
+        ),
+        pin_memory_device=torch.device("cpu"),
+        batch_size=1,
+    )
+
+    batches_checked = 0
+    for datum in loader:
+        assert isinstance(datum, HeteroData)
+        _assert_typed_ppr_edge_attrs(
+            datum=datum,
+            seed_type=str(USER),
+            node_types=[USER, STORY],
+            num_channels=2,
+        )
+        for edge_type in datum.edge_types:
+            assert edge_type[1] == "ppr", (
+                f"Non-PPR edge type {edge_type} found in PPR sampler output"
+            )
+        batches_checked += 1
+    assert batches_checked == _NUM_TEST_USERS, (
+        f"Expected {_NUM_TEST_USERS} batches, got {batches_checked}"
+    )
+
+    empty_story_loader = DistNeighborLoader(
+        dataset=dataset,
+        input_nodes=(USER, node_ids[USER][:1]),  # ty: ignore[invalid-argument-type] TODO(ty-torch-keyed-access): fix ty false positives for torch-backed keyed container access.
+        num_neighbors=[],
+        sampler_options=PPRSamplerOptions(
+            alpha=_TEST_ALPHA,
+            eps=_TEST_EPS,
+            max_ppr_nodes=_TEST_MAX_PPR_NODES,
+            typed_channel_ratios={
+                STORY_TO_USER: 0.5,
+                (STORY_TO_USER,): 0.5,
+            },
+        ),
+        pin_memory_device=torch.device("cpu"),
+        batch_size=1,
+    )
+    empty_story_datum = next(iter(empty_story_loader))
+    assert isinstance(empty_story_datum, HeteroData)
+    _assert_typed_ppr_edge_attrs(
+        datum=empty_story_datum,
+        seed_type=str(USER),
+        node_types=[USER, STORY],
+        num_channels=2,
+    )
+    empty_story_edge_attr = empty_story_datum[(str(USER), "ppr", STORY)].edge_attr
+    assert tuple(empty_story_edge_attr.shape) == (0, 5)
+
     shutdown_rpc()
 
 
@@ -813,6 +930,10 @@ class DistPPRSamplerTest(TestCase):
     def test_ppr_sampler_destination_only_node_type(self) -> None:
         """Verify PPR output includes destination-only node types."""
         mp.spawn(fn=_run_ppr_destination_only_node_type, args=())
+
+    def test_typed_ppr_sampler_loader_outputs_channel_attrs(self) -> None:
+        """Verify typed PPR runs end-to-end through the loader."""
+        mp.spawn(fn=_run_typed_ppr_loader_shape_check, args=())
 
     def test_ppr_sampler_ablp_ignores_label_edges_for_anchor_ppr(self) -> None:
         """Verify ABLP label edges are excluded from anchor-seed PPR walks."""

--- a/tests/unit/distributed/dist_typed_sampler_test.py
+++ b/tests/unit/distributed/dist_typed_sampler_test.py
@@ -1,0 +1,84 @@
+"""Unit tests for typed-PPR sampler construction helpers."""
+
+from absl.testing import absltest
+
+from gigl.distributed.utils.dist_typed_sampler import (
+    build_edge_type_channel_group_edge_type_ids,
+    compute_typed_channel_target_counts,
+    parse_typed_channel_ratio_groups,
+)
+from tests.test_assets.distributed.test_dataset import (
+    STORY,
+    STORY_TO_USER,
+    USER,
+    USER_TO_STORY,
+)
+from tests.test_assets.test_case import TestCase
+
+
+class DistTypedSamplerTest(TestCase):
+    def test_typed_ppr_edge_type_channels_parse_and_build_traversal_maps(
+        self,
+    ) -> None:
+        """Verify typed-PPR can use canonical edge-type channels."""
+        node_type_to_edge_types = {
+            USER: [USER_TO_STORY],
+            STORY: [STORY_TO_USER],
+        }
+        node_types = [USER, STORY]
+        edge_type_to_edge_type_id = {
+            USER_TO_STORY: 0,
+            STORY_TO_USER: 1,
+        }
+
+        typed_channel_groups, typed_channel_ratio_list = (
+            parse_typed_channel_ratio_groups(
+                {
+                    USER_TO_STORY: 0.6,
+                    (USER_TO_STORY, STORY_TO_USER): 0.4,
+                }
+            )
+        )
+        assert typed_channel_groups is not None
+        assert typed_channel_ratio_list is not None
+
+        self.assertEqual(
+            typed_channel_groups,
+            [
+                (USER_TO_STORY,),
+                (USER_TO_STORY, STORY_TO_USER),
+            ],
+        )
+        self.assertEqual(typed_channel_ratio_list, [0.6, 0.4])
+        self.assertEqual(
+            compute_typed_channel_target_counts(typed_channel_ratio_list, 7),
+            [4, 3],
+        )
+        self.assertEqual(
+            build_edge_type_channel_group_edge_type_ids(
+                edge_type_groups=typed_channel_groups,
+                edge_type_to_edge_type_id=edge_type_to_edge_type_id,
+                node_type_to_edge_types=node_type_to_edge_types,
+                node_types=node_types,
+            ),
+            [
+                [[0], []],
+                [[0], [1]],
+            ],
+        )
+
+        with self.assertRaisesRegex(ValueError, "canonical edge type"):
+            parse_typed_channel_ratio_groups({("bad",): 1.0})
+        with self.assertRaisesRegex(ValueError, "sum to 1.0"):
+            parse_typed_channel_ratio_groups({USER_TO_STORY: 0.5})
+        with self.assertRaisesRegex(ValueError, "non-traversable edge types"):
+            build_edge_type_channel_group_edge_type_ids(
+                edge_type_groups=[(("unknown", "edge", "type"),)],
+                edge_type_to_edge_type_id=edge_type_to_edge_type_id,
+                node_type_to_edge_types=node_type_to_edge_types,
+                node_types=node_types,
+            )
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/unit/distributed/dist_typed_sampler_test.py
+++ b/tests/unit/distributed/dist_typed_sampler_test.py
@@ -4,8 +4,7 @@ from absl.testing import absltest
 
 from gigl.distributed.utils.dist_typed_sampler import (
     build_edge_type_channel_group_edge_type_ids,
-    compute_typed_channel_target_counts,
-    parse_typed_channel_ratio_groups,
+    parse_typed_channel_target_groups,
 )
 from tests.test_assets.distributed.test_dataset import (
     STORY,
@@ -31,16 +30,16 @@ class DistTypedSamplerTest(TestCase):
             STORY_TO_USER: 1,
         }
 
-        typed_channel_groups, typed_channel_ratio_list = (
-            parse_typed_channel_ratio_groups(
+        typed_channel_groups, typed_channel_target_counts = (
+            parse_typed_channel_target_groups(
                 {
-                    USER_TO_STORY: 0.6,
-                    (USER_TO_STORY, STORY_TO_USER): 0.4,
+                    USER_TO_STORY: 4,
+                    (USER_TO_STORY, STORY_TO_USER): 3,
                 }
             )
         )
         assert typed_channel_groups is not None
-        assert typed_channel_ratio_list is not None
+        assert typed_channel_target_counts is not None
 
         self.assertEqual(
             typed_channel_groups,
@@ -49,11 +48,7 @@ class DistTypedSamplerTest(TestCase):
                 (USER_TO_STORY, STORY_TO_USER),
             ],
         )
-        self.assertEqual(typed_channel_ratio_list, [0.6, 0.4])
-        self.assertEqual(
-            compute_typed_channel_target_counts(typed_channel_ratio_list, 7),
-            [4, 3],
-        )
+        self.assertEqual(typed_channel_target_counts, [4, 3])
         self.assertEqual(
             build_edge_type_channel_group_edge_type_ids(
                 edge_type_groups=typed_channel_groups,
@@ -68,9 +63,9 @@ class DistTypedSamplerTest(TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, "canonical edge type"):
-            parse_typed_channel_ratio_groups({("bad",): 1.0})
-        with self.assertRaisesRegex(ValueError, "sum to 1.0"):
-            parse_typed_channel_ratio_groups({USER_TO_STORY: 0.5})
+            parse_typed_channel_target_groups({("bad",): 1})
+        with self.assertRaisesRegex(ValueError, "positive integers"):
+            parse_typed_channel_target_groups({USER_TO_STORY: 0})
         with self.assertRaisesRegex(ValueError, "non-traversable edge types"):
             build_edge_type_channel_group_edge_type_ids(
                 edge_type_groups=[(("unknown", "edge", "type"),)],

--- a/tests/unit/distributed/dist_typed_sampler_test.py
+++ b/tests/unit/distributed/dist_typed_sampler_test.py
@@ -4,7 +4,8 @@ from absl.testing import absltest
 
 from gigl.distributed.utils.dist_typed_sampler import (
     build_edge_type_channel_group_edge_type_ids,
-    parse_typed_channel_target_groups,
+    compute_typed_channel_target_counts,
+    parse_typed_channel_ratio_groups,
 )
 from tests.test_assets.distributed.test_dataset import (
     STORY,
@@ -30,16 +31,16 @@ class DistTypedSamplerTest(TestCase):
             STORY_TO_USER: 1,
         }
 
-        typed_channel_groups, typed_channel_target_counts = (
-            parse_typed_channel_target_groups(
+        typed_channel_groups, typed_channel_ratio_list = (
+            parse_typed_channel_ratio_groups(
                 {
-                    USER_TO_STORY: 4,
-                    (USER_TO_STORY, STORY_TO_USER): 3,
+                    USER_TO_STORY: 0.6,
+                    (USER_TO_STORY, STORY_TO_USER): 0.4,
                 }
             )
         )
         assert typed_channel_groups is not None
-        assert typed_channel_target_counts is not None
+        assert typed_channel_ratio_list is not None
 
         self.assertEqual(
             typed_channel_groups,
@@ -48,7 +49,15 @@ class DistTypedSamplerTest(TestCase):
                 (USER_TO_STORY, STORY_TO_USER),
             ],
         )
-        self.assertEqual(typed_channel_target_counts, [4, 3])
+        self.assertEqual(typed_channel_ratio_list, [0.6, 0.4])
+        self.assertEqual(
+            compute_typed_channel_target_counts(typed_channel_ratio_list, 7),
+            [4, 3],
+        )
+        self.assertEqual(
+            compute_typed_channel_target_counts([0.8, 0.1, 0.1], 158),
+            [126, 16, 16],
+        )
         self.assertEqual(
             build_edge_type_channel_group_edge_type_ids(
                 edge_type_groups=typed_channel_groups,
@@ -63,9 +72,9 @@ class DistTypedSamplerTest(TestCase):
         )
 
         with self.assertRaisesRegex(ValueError, "canonical edge type"):
-            parse_typed_channel_target_groups({("bad",): 1})
-        with self.assertRaisesRegex(ValueError, "positive integers"):
-            parse_typed_channel_target_groups({USER_TO_STORY: 0})
+            parse_typed_channel_ratio_groups({("bad",): 1.0})
+        with self.assertRaisesRegex(ValueError, "sum to 1.0"):
+            parse_typed_channel_ratio_groups({USER_TO_STORY: 0.5})
         with self.assertRaisesRegex(ValueError, "non-traversable edge types"):
             build_edge_type_channel_group_edge_type_ids(
                 edge_type_groups=[(("unknown", "edge", "type"),)],


### PR DESCRIPTION
## Summary

Adds the Python/API layer for typed-channel PPR sampling.

This PR is stacked on #724, which contains the C++ typed PPR drain and extraction implementation. This layer exposes typed-channel PPR through sampler options and wires it into `DistPPRNeighborSampler`.

## Motivation

A collapsed heterogeneous PPR traversal can identify relevant neighbors, but it loses which relation paths contributed to that relevance. Typed-channel PPR keeps that information by running PPR over configured edge-type channels and emitting channel-aware edge attributes.

Downstream consumers can use:

- the best calibrated PPR score
- per-channel calibrated scores
- per-channel presence indicators

## What Changed

- Keeps `max_ppr_nodes` as the per-seed PPR sequence cap.
  - For untyped PPR, this preserves the existing behavior.
  - For typed PPR, this remains the total per-seed cap across all channels.

- Adds `typed_channel_ratios` to `PPRSamplerOptions`.
  - If omitted, the sampler uses the regular untyped PPR path.
  - Keys can be a single canonical edge type, e.g. `("user", "views", "item")`.
  - Keys can also be a tuple of canonical edge types to define one grouped traversal channel.
  - Values are ratios in `(0, 1]` and must sum to `1.0`.

- Converts typed-channel ratios to integer channel target counts during sampler construction.
  - For example, `max_ppr_nodes=200` and ratios `{views: 0.6, likes/shares: 0.4}` targets 120 and 80 nodes.
  - Fractional counts are rounded deterministically while preserving the total `max_ppr_nodes` cap.

- Adds typed-channel parsing, validation, and traversal-map construction.
  - Restricts typed PPR to heterogeneous sampling.
  - Rejects invalid channel keys and invalid ratio values.
  - Builds per-channel edge traversal allowlists for the C++ PPR states.

- Wires typed PPR execution into the distributed sampler.
  - Builds one `PPRForwardPush` state per typed channel.
  - Each state traverses only the edge types configured for that channel.
  - Calls the typed drain and extraction APIs from #724.
  - Keeps typed PPR work off the asyncio event-loop thread where applicable.

- Emits typed PPR edge attributes with shape `[N, 1 + 2 * num_channels]`:
  - column 0: best score across channels
  - next `num_channels` columns: per-channel scores
  - final `num_channels` columns: per-channel presence bits

## Tests

Added focused Python coverage for:

- typed-channel ratio parsing and validation
- ratio-to-target-count conversion
- traversal-map construction
- typed sampler option wiring
- disabling residual top-up for typed PPR
- end-to-end typed sampler output shape