### PR TITLE
Remove deprecated RESOURCE_CONFIG_PATH env var fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Removed
+
+- Remove the deprecated `RESOURCE_CONFIG_PATH` environment variable; use `GIGL_RESOURCE_CONFIG_URI` instead by
+  @kmontemayor2-sc in https://github.com/Snapchat/GiGL/pull/PENDING
+
 ## [0.3.1] - Jun 4, 2026
 
 ### Fixed

--- a/gigl/env/constants.py
+++ b/gigl/env/constants.py
@@ -10,14 +10,11 @@ and ``gigl.src.common.vertex_ai_launcher`` so that receiving CLIs can
 ``gigl.env.pipelines_config.get_resource_config`` so that downstream readers
 (e.g. ``GiglResourceConfigWrapper.get_resource_config_uri``) can recover the
 value within the same process. Use :func:`read_resource_config_uri_from_env`
-to read it; that helper also falls back to the deprecated
-``RESOURCE_CONFIG_PATH`` with a one-time warning.
+to read it.
 """
 
 import os
 from typing import Final, Optional
-
-from gigl.common.logger import Logger
 
 GIGL_APPLIED_TASK_IDENTIFIER_ENV_KEY: Final[str] = "GIGL_APPLIED_TASK_IDENTIFIER"
 GIGL_TASK_CONFIG_URI_ENV_KEY: Final[str] = "GIGL_TASK_CONFIG_URI"
@@ -26,31 +23,11 @@ GIGL_CPU_DOCKER_URI_ENV_KEY: Final[str] = "GIGL_CPU_DOCKER_URI"
 GIGL_CUDA_DOCKER_URI_ENV_KEY: Final[str] = "GIGL_CUDA_DOCKER_URI"
 GIGL_COMPONENT_ENV_KEY: Final[str] = "GIGL_COMPONENT"
 
-_LEGACY_RESOURCE_CONFIG_ENV_KEY: Final[str] = "RESOURCE_CONFIG_PATH"
-_legacy_resource_config_env_warned: bool = False
-_logger = Logger()
-
 
 def read_resource_config_uri_from_env() -> Optional[str]:
-    """Read the resource-config URI from the environment.
-
-    Prefers ``GIGL_RESOURCE_CONFIG_URI``. Falls back to the deprecated
-    ``RESOURCE_CONFIG_PATH`` and emits a one-time warning if that path is taken.
+    """Read the resource-config URI from ``GIGL_RESOURCE_CONFIG_URI``.
 
     Returns:
-        The URI string if set under either name, else ``None``.
+        The URI string if the variable is set, else ``None``.
     """
-    global _legacy_resource_config_env_warned
-    value = os.environ.get(GIGL_RESOURCE_CONFIG_URI_ENV_KEY)
-    if value is not None:
-        return value
-
-    legacy_value = os.environ.get(_LEGACY_RESOURCE_CONFIG_ENV_KEY)
-    if legacy_value is not None and not _legacy_resource_config_env_warned:
-        _logger.warning(
-            f"Environment variable {_LEGACY_RESOURCE_CONFIG_ENV_KEY!r} is deprecated; "
-            f"use {GIGL_RESOURCE_CONFIG_URI_ENV_KEY!r} instead. "
-            "Support for the legacy name will be removed in a future release."
-        )
-        _legacy_resource_config_env_warned = True
-    return legacy_value
+    return os.environ.get(GIGL_RESOURCE_CONFIG_URI_ENV_KEY)

--- a/gigl/env/pipelines_config.py
+++ b/gigl/env/pipelines_config.py
@@ -59,9 +59,8 @@ def get_resource_config(
     Args:
         resource_config_uri: Optional[Uri] = None
             The URI of the resource config file. If None, the function will try to load the resource config from the
-            command-line argument --resource_config_uri or the environment variable GIGL_RESOURCE_CONFIG_URI (the
-            deprecated RESOURCE_CONFIG_PATH is still read as a fallback, with a one-time warning). If these are not
-            set, the function will try to load the resource config from the pipeline options.
+            command-line argument --resource_config_uri or the environment variable GIGL_RESOURCE_CONFIG_URI. If these
+            are not set, the function will try to load the resource config from the pipeline options.
 
     Returns:
         resource_config: GiglResourceConfigWrapper


### PR DESCRIPTION
RESOURCE_CONFIG_PATH was deprecated in 0.3.0 in favor of GIGL_RESOURCE_CONFIG_URI. Drop the fallback branch and one-time warning so read_resource_config_uri_from_env reads only GIGL_RESOURCE_CONFIG_URI, and update the related docstrings.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
