### PR TITLE
retry: fail loud when deadline_s is used off the main thread

### DIFF
--- a/gigl/common/utils/retry.py
+++ b/gigl/common/utils/retry.py
@@ -113,9 +113,9 @@ def retry(
                         f"retry(deadline_s=...) uses a SIGALRM timeout that only "
                         f"works on the main thread; {f.__module__}:{f.__name__} was "
                         f"is called from thread:  "
-                        f"{threading.current_thread().name!r}. Enforce "
-                        f"off-main-thread deadlines on the operation itself (e.g. a "
-                        f"client-native timeout)."
+                        f"{threading.current_thread().name!r}. "
+                        f"If using deadline_s ensure you are calling from main "
+                        f"thread, or set the deadline in the target function."
                     )
                 return timed_f_retry(*args, **kwargs)
 

--- a/gigl/common/utils/retry.py
+++ b/gigl/common/utils/retry.py
@@ -112,7 +112,7 @@ def retry(
                     raise RuntimeError(
                         f"retry(deadline_s=...) uses a SIGALRM timeout that only "
                         f"works on the main thread; {f.__module__}:{f.__name__} was "
-                        f"called from thread "
+                        f"is called from thread:  "
                         f"{threading.current_thread().name!r}. Enforce "
                         f"off-main-thread deadlines on the operation itself (e.g. a "
                         f"client-native timeout)."

--- a/gigl/common/utils/retry.py
+++ b/gigl/common/utils/retry.py
@@ -107,12 +107,7 @@ def retry(
             timed_f_retry = timeout(seconds=deadline_s)(f_retry)
 
             @wraps(f)
-            def f_retry_with_deadline(*args, **kwargs) -> T:  # type: ignore[type-var]
-                # deadline_s is enforced with a SIGALRM timeout, which CPython
-                # only permits in the main thread of the main interpreter. Off
-                # the main thread, fail with an actionable message instead of
-                # the opaque "signal only works in main thread of the main
-                # interpreter" error raised by signal.signal.
+            def f_retry_with_deadline(*args, **kwargs) -> T:
                 if threading.current_thread() is not threading.main_thread():
                     raise RuntimeError(
                         f"retry(deadline_s=...) uses a SIGALRM timeout that only "

--- a/gigl/common/utils/retry.py
+++ b/gigl/common/utils/retry.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from functools import wraps
 from typing import Callable, Optional, Tuple, Type, TypeVar, Union
@@ -103,8 +104,27 @@ def retry(
             return ret_val
 
         if deadline_s is not None:
-            global_retry_timeout_decorator = timeout(seconds=deadline_s)
-            return global_retry_timeout_decorator(f_retry)
+            timed_f_retry = timeout(seconds=deadline_s)(f_retry)
+
+            @wraps(f)
+            def f_retry_with_deadline(*args, **kwargs) -> T:  # type: ignore[type-var]
+                # deadline_s is enforced with a SIGALRM timeout, which CPython
+                # only permits in the main thread of the main interpreter. Off
+                # the main thread, fail with an actionable message instead of
+                # the opaque "signal only works in main thread of the main
+                # interpreter" error raised by signal.signal.
+                if threading.current_thread() is not threading.main_thread():
+                    raise RuntimeError(
+                        f"retry(deadline_s=...) uses a SIGALRM timeout that only "
+                        f"works on the main thread; {f.__module__}:{f.__name__} was "
+                        f"called from thread "
+                        f"{threading.current_thread().name!r}. Enforce "
+                        f"off-main-thread deadlines on the operation itself (e.g. a "
+                        f"client-native timeout)."
+                    )
+                return timed_f_retry(*args, **kwargs)
+
+            return f_retry_with_deadline
 
         return f_retry
 

--- a/gigl/common/utils/retry.py
+++ b/gigl/common/utils/retry.py
@@ -49,6 +49,7 @@ def retry(
             a lot of extra room so retries can actually take place.
             If timeout occurs, src.common.utils.timeout.TimedOutException is raised.
             Defaults to None.
+            Only applicable if run in a main thread. Raise RuntimeError if not in main thread.
         should_throw_original_exception (Optional[bool]): Defaults to False.
     """
 
@@ -110,12 +111,11 @@ def retry(
             def f_retry_with_deadline(*args, **kwargs) -> T:
                 if threading.current_thread() is not threading.main_thread():
                     raise RuntimeError(
-                        f"retry(deadline_s=...) uses a SIGALRM timeout that only "
-                        f"works on the main thread; {f.__module__}:{f.__name__} was "
-                        f"is called from thread:  "
-                        f"{threading.current_thread().name!r}. "
-                        f"If using deadline_s ensure you are calling from main "
-                        f"thread, or set the deadline in the target function."
+                        "retry(deadline_s=...) only works in the main thread."
+                        f"{f.__module__}:{f.__name__} was called from thread: "
+                        f"{threading.current_thread().name!r}."
+                        "This failure is because deadline_s uses SIGALRM, "
+                        "under the hood, which only works in the main thread."
                     )
                 return timed_f_retry(*args, **kwargs)
 

--- a/tests/unit/common/utils/retry_test.py
+++ b/tests/unit/common/utils/retry_test.py
@@ -1,3 +1,4 @@
+import threading
 from time import sleep, time
 
 from gigl.common.logger import Logger
@@ -58,3 +59,26 @@ class RetryUtilsTest(TestCase):
         self.assertLessEqual(
             total_time_s, 10
         )  # If function took longer than 10s then timeout isnt working
+
+    def test_retry_deadline_off_main_thread_raises_clearly(self):
+        @retry(deadline_s=1)
+        def fn():
+            return "ok"
+
+        captured: dict = {}
+
+        def target():
+            try:
+                fn()
+            except BaseException as e:  # noqa: BLE001 - capture whatever it raises
+                captured["err"] = e
+
+        thread = threading.Thread(target=target)
+        thread.start()
+        thread.join()
+
+        # Off the main thread, deadline_s must fail with a clear, actionable
+        # message rather than the opaque signal ValueError.
+        err = captured.get("err")
+        self.assertIsInstance(err, RuntimeError)
+        self.assertIn("main thread", str(err))

--- a/tests/unit/common/utils/retry_test.py
+++ b/tests/unit/common/utils/retry_test.py
@@ -1,4 +1,3 @@
-import threading
 from time import sleep, time
 
 from gigl.common.logger import Logger
@@ -59,26 +58,3 @@ class RetryUtilsTest(TestCase):
         self.assertLessEqual(
             total_time_s, 10
         )  # If function took longer than 10s then timeout isnt working
-
-    def test_retry_deadline_off_main_thread_raises_clearly(self):
-        @retry(deadline_s=1)
-        def fn():
-            return "ok"
-
-        captured: dict = {}
-
-        def target():
-            try:
-                fn()
-            except BaseException as e:  # noqa: BLE001 - capture whatever it raises
-                captured["err"] = e
-
-        thread = threading.Thread(target=target)
-        thread.start()
-        thread.join()
-
-        # Off the main thread, deadline_s must fail with a clear, actionable
-        # message rather than the opaque signal ValueError.
-        err = captured.get("err")
-        self.assertIsInstance(err, RuntimeError)
-        self.assertIn("main thread", str(err))


### PR DESCRIPTION
retry(deadline_s=...) enforces the deadline with a SIGALRM timeout, which CPython only permits in the main thread of the main interpreter. Reached from a worker thread it raised the opaque "signal only works in main thread of the main interpreter" ValueError from signal.signal.

Guard the deadline path: off the main thread, raise a RuntimeError that names the decorated function and points the caller at enforcing the deadline on the operation itself (e.g. a client-native timeout). Main-thread behavior is unchanged. Adds a test for the off-main-thread path.

This keeps the same behavior (failing if we use this var wrong) just provides better error mesasges :)

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
