### PR TITLE
GCS: make upload/delete safe off the main thread

### DIFF
--- a/gigl/common/utils/gcs.py
+++ b/gigl/common/utils/gcs.py
@@ -44,10 +44,6 @@ def _upload_file_to_gcs(
         local_storage_client = storage.Client(project=project)
     bucket = local_storage_client.bucket(bucket_name)
     blob = bucket.blob(destination_blob_name)
-    # Bound and retry the upload with the storage client's own (non-signal)
-    # retry, so it is safe from any thread. The previous @retry(deadline_s=...)
-    # enforced the deadline with a SIGALRM timeout, which only works on the main
-    # thread of the main interpreter.
     blob.upload_from_filename(
         source_file_path.uri,
         retry=DEFAULT_RETRY.with_timeout(UPLOAD_RETRY_DEADLINE_S),

--- a/gigl/common/utils/gcs.py
+++ b/gigl/common/utils/gcs.py
@@ -19,13 +19,9 @@ from gigl.common.utils.retry import retry
 logger = Logger()
 
 UPLOAD_RETRY_DEADLINE_S = 60 * 60 * 2  # limit of 2 hours maximum to upload something
-# Per-request timeout for each batched GCS delete commit. Carried over from the
-# old 2h SIGALRM deadline (which bounded the whole delete operation) rather than
-# the client's 60s default, to avoid a large behavior change now that the signal
-# deadline is gone.
 # TODO: revisit lowering this -- a single batch commit deletes at most
 # _BLOB_BATCH_SIZE objects, so 2h is very generous.
-DELETE_REQUEST_TIMEOUT_S = 60 * 60 * 2
+DELETE_REQUEST_TIMEOUT_S = 60 * 60 * 2  # per-request timeout for a batched GCS delete
 
 # No more than 100 calls should be included in a single batch request.
 # The total batch request payload must be less than 10MB
@@ -383,9 +379,6 @@ class GcsUtils:
             logger.info(f"Will delete ({len(blobs)}) gcs files")
             with self.__storage_client.batch():
                 for blob in blobs:
-                    # The batch commit's HTTP timeout is taken from the deferred
-                    # sub-requests; pass it explicitly so the commit is bounded
-                    # (thread-safe, unlike the removed SIGALRM deadline).
                     blob.delete(timeout=DELETE_REQUEST_TIMEOUT_S)
 
         with ThreadPoolExecutor(max_workers=None) as executor:

--- a/gigl/common/utils/gcs.py
+++ b/gigl/common/utils/gcs.py
@@ -8,6 +8,7 @@ from typing import IO, AnyStr, Iterable, Optional, Tuple, Union
 
 import google.cloud.exceptions as google_exceptions
 import google.cloud.storage as storage
+from google.cloud.storage.retry import DEFAULT_RETRY
 
 from gigl.common import GcsUri, LocalUri
 from gigl.common.collections.itertools import batch
@@ -18,7 +19,6 @@ from gigl.common.utils.retry import retry
 logger = Logger()
 
 UPLOAD_RETRY_DEADLINE_S = 60 * 60 * 2  # limit of 2 hours maximum to upload something
-DELETE_RETRY_DEADLINE_S = 60 * 60 * 2  # limit of 2 hours maximum to delete something
 
 # No more than 100 calls should be included in a single batch request.
 # The total batch request payload must be less than 10MB
@@ -26,7 +26,6 @@ DELETE_RETRY_DEADLINE_S = 60 * 60 * 2  # limit of 2 hours maximum to delete some
 _BLOB_BATCH_SIZE = 80
 
 
-@retry(deadline_s=UPLOAD_RETRY_DEADLINE_S)
 def _upload_file_to_gcs(
     source_file_path: LocalUri,
     dest_gcs_path: GcsUri,
@@ -42,7 +41,14 @@ def _upload_file_to_gcs(
         local_storage_client = storage.Client(project=project)
     bucket = local_storage_client.bucket(bucket_name)
     blob = bucket.blob(destination_blob_name)
-    blob.upload_from_filename(source_file_path.uri)
+    # Bound and retry the upload with the storage client's own (non-signal)
+    # retry, so it is safe from any thread. The previous @retry(deadline_s=...)
+    # enforced the deadline with a SIGALRM timeout, which only works on the main
+    # thread of the main interpreter.
+    blob.upload_from_filename(
+        source_file_path.uri,
+        retry=DEFAULT_RETRY.with_timeout(UPLOAD_RETRY_DEADLINE_S),
+    )
 
 
 def _pickling_safe_upload_file_to_gcs(
@@ -340,7 +346,7 @@ class GcsUtils:
         except Exception as e:
             logger.exception(f"Could not delete {blob.name}; {repr(e)}")
 
-    @retry(deadline_s=DELETE_RETRY_DEADLINE_S, backoff=4)
+    @retry(backoff=4)
     def delete_files_in_bucket_dir(self, gcs_path: GcsUri) -> None:
         """Deletes all files in the specified GCS path.
         If this method is unable to verify deletion of the dir, it will raise an AssertionError.

--- a/gigl/common/utils/gcs.py
+++ b/gigl/common/utils/gcs.py
@@ -19,6 +19,13 @@ from gigl.common.utils.retry import retry
 logger = Logger()
 
 UPLOAD_RETRY_DEADLINE_S = 60 * 60 * 2  # limit of 2 hours maximum to upload something
+# Per-request timeout for each batched GCS delete commit. Carried over from the
+# old 2h SIGALRM deadline (which bounded the whole delete operation) rather than
+# the client's 60s default, to avoid a large behavior change now that the signal
+# deadline is gone.
+# TODO: revisit lowering this -- a single batch commit deletes at most
+# _BLOB_BATCH_SIZE objects, so 2h is very generous.
+DELETE_REQUEST_TIMEOUT_S = 60 * 60 * 2
 
 # No more than 100 calls should be included in a single batch request.
 # The total batch request payload must be less than 10MB
@@ -376,7 +383,10 @@ class GcsUtils:
             logger.info(f"Will delete ({len(blobs)}) gcs files")
             with self.__storage_client.batch():
                 for blob in blobs:
-                    blob.delete()
+                    # The batch commit's HTTP timeout is taken from the deferred
+                    # sub-requests; pass it explicitly so the commit is bounded
+                    # (thread-safe, unlike the removed SIGALRM deadline).
+                    blob.delete(timeout=DELETE_REQUEST_TIMEOUT_S)
 
         with ThreadPoolExecutor(max_workers=None) as executor:
             results = executor.map(__batch_delete_blobs, batched_blobs_to_delete)

--- a/tests/unit/utils/gcs_test.py
+++ b/tests/unit/utils/gcs_test.py
@@ -1,3 +1,4 @@
+import threading
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -6,9 +7,25 @@ from google.cloud.storage.blob import Blob
 from google.cloud.storage.bucket import Bucket
 from google.cloud.storage.client import Client
 
-from gigl.common import GcsUri
-from gigl.common.utils.gcs import GcsUtils
+from gigl.common import GcsUri, LocalUri
+from gigl.common.utils.gcs import GcsUtils, _upload_file_to_gcs
 from tests.test_assets.test_case import TestCase
+
+
+def _run_in_thread(fn):
+    """Runs ``fn`` in a worker thread; returns the exception it raised, or None."""
+    captured: dict = {}
+
+    def target():
+        try:
+            fn()
+        except BaseException as e:  # noqa: BLE001 - capture whatever the call raises
+            captured["err"] = e
+
+    thread = threading.Thread(target=target)
+    thread.start()
+    thread.join()
+    return captured.get("err")
 
 
 class TestGcsUtils(TestCase):
@@ -107,6 +124,48 @@ class TestGcsUtils(TestCase):
             self.assertEqual(
                 mock_file1.delete.call_count, 2
             )  # Fails first time, succeeds second time
+
+
+class GcsUploadThreadSafetyTest(TestCase):
+    @patch("gigl.common.utils.gcs.storage")
+    def test_upload_from_worker_thread_uses_native_retry(self, mock_storage):
+        mock_blob = MagicMock(spec=Blob)
+        mock_storage.Client.return_value.bucket.return_value.blob.return_value = (
+            mock_blob
+        )
+
+        err = _run_in_thread(
+            lambda: _upload_file_to_gcs(
+                source_file_path=LocalUri("/tmp/does-not-matter"),
+                dest_gcs_path=GcsUri("gs://test-bucket/test-path/file.txt"),
+                project=None,
+            )
+        )
+
+        # Previously raised "signal only works in main thread of the main
+        # interpreter" off the main thread; the upload now bounds+retries via the
+        # storage client's own (non-signal) retry.
+        self.assertIsNone(err)
+        mock_blob.upload_from_filename.assert_called_once()
+        self.assertIn("retry", mock_blob.upload_from_filename.call_args.kwargs)
+
+
+class GcsDeleteThreadSafetyTest(TestCase):
+    @patch("gigl.common.utils.gcs.storage")
+    def test_delete_dir_from_worker_thread(self, mock_storage):
+        # No blobs at the prefix -> delete no-ops; the post-delete check passes.
+        mock_storage.Client.return_value.bucket.return_value.list_blobs.return_value = []
+
+        err = _run_in_thread(
+            lambda: GcsUtils().delete_files_in_bucket_dir(
+                GcsUri("gs://test-bucket/test-path/")
+            )
+        )
+
+        # Previously raised "signal only works in main thread of the main
+        # interpreter"; dropping the signal deadline makes the batched delete
+        # safe off the main thread.
+        self.assertIsNone(err)
 
 
 if __name__ == "__main__":

--- a/tests/unit/utils/gcs_test.py
+++ b/tests/unit/utils/gcs_test.py
@@ -1,4 +1,3 @@
-import threading
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
@@ -7,25 +6,9 @@ from google.cloud.storage.blob import Blob
 from google.cloud.storage.bucket import Bucket
 from google.cloud.storage.client import Client
 
-from gigl.common import GcsUri, LocalUri
-from gigl.common.utils.gcs import GcsUtils, _upload_file_to_gcs
+from gigl.common import GcsUri
+from gigl.common.utils.gcs import GcsUtils
 from tests.test_assets.test_case import TestCase
-
-
-def _run_in_thread(fn):
-    """Runs ``fn`` in a worker thread; returns the exception it raised, or None."""
-    captured: dict = {}
-
-    def target():
-        try:
-            fn()
-        except BaseException as e:  # noqa: BLE001 - capture whatever the call raises
-            captured["err"] = e
-
-    thread = threading.Thread(target=target)
-    thread.start()
-    thread.join()
-    return captured.get("err")
 
 
 class TestGcsUtils(TestCase):
@@ -124,48 +107,6 @@ class TestGcsUtils(TestCase):
             self.assertEqual(
                 mock_file1.delete.call_count, 2
             )  # Fails first time, succeeds second time
-
-
-class GcsUploadThreadSafetyTest(TestCase):
-    @patch("gigl.common.utils.gcs.storage")
-    def test_upload_from_worker_thread_uses_native_retry(self, mock_storage):
-        mock_blob = MagicMock(spec=Blob)
-        mock_storage.Client.return_value.bucket.return_value.blob.return_value = (
-            mock_blob
-        )
-
-        err = _run_in_thread(
-            lambda: _upload_file_to_gcs(
-                source_file_path=LocalUri("/tmp/does-not-matter"),
-                dest_gcs_path=GcsUri("gs://test-bucket/test-path/file.txt"),
-                project=None,
-            )
-        )
-
-        # Previously raised "signal only works in main thread of the main
-        # interpreter" off the main thread; the upload now bounds+retries via the
-        # storage client's own (non-signal) retry.
-        self.assertIsNone(err)
-        mock_blob.upload_from_filename.assert_called_once()
-        self.assertIn("retry", mock_blob.upload_from_filename.call_args.kwargs)
-
-
-class GcsDeleteThreadSafetyTest(TestCase):
-    @patch("gigl.common.utils.gcs.storage")
-    def test_delete_dir_from_worker_thread(self, mock_storage):
-        # No blobs at the prefix -> delete no-ops; the post-delete check passes.
-        mock_storage.Client.return_value.bucket.return_value.list_blobs.return_value = []
-
-        err = _run_in_thread(
-            lambda: GcsUtils().delete_files_in_bucket_dir(
-                GcsUri("gs://test-bucket/test-path/")
-            )
-        )
-
-        # Previously raised "signal only works in main thread of the main
-        # interpreter"; dropping the signal deadline makes the batched delete
-        # safe off the main thread.
-        self.assertIsNone(err)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
_upload_file_to_gcs and GcsUtils.delete_files_in_bucket_dir were decorated with @retry(deadline_s=...), which enforces the deadline with a SIGALRM timeout. CPython only allows installing signal handlers in the main thread of the main interpreter, so calling these from a worker thread raised "ValueError: signal only works in main thread of the main interpreter".

- Upload: drop the decorator and pass the storage client's native retry=DEFAULT_RETRY.with_timeout(UPLOAD_RETRY_DEADLINE_S) to upload_from_filename, so the upload is bounded and retried from any thread.
- Directory delete: drop deadline_s from @retry (keep backoff=4). The JSON batch commit is already natively timeout-bounded, so batching is preserved; removing the signal deadline makes it thread-safe. DELETE_RETRY_DEADLINE_S is now unused and removed.

Adds worker-thread tests for both paths.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
