### PR TITLE
Centralize BigQuery Avro loads in BqUtils

### DIFF
--- a/gigl/common/data/export.py
+++ b/gigl/common/data/export.py
@@ -25,6 +25,7 @@ from typing_extensions import Self
 from gigl.common import GcsUri, LocalUri, Uri
 from gigl.common.logger import Logger
 from gigl.common.utils.retry import retry
+from gigl.src.common.utils.bq import BqUtils
 from gigl.src.common.utils.file_loader import FileLoader
 
 logger = Logger()
@@ -340,7 +341,6 @@ class PredictionExporter(GcsExporter):
         self.add_record(batched_records)
 
 
-# TODO(kmonte): We should migrate this over to `BqUtils.load_files_to_bq` once that is implemented.
 def _load_records_to_bigquery(
     gcs_folder: GcsUri,
     project_id: str,
@@ -364,16 +364,10 @@ def _load_records_to_bigquery(
         LoadJob: A BigQuery LoadJob object representing the load operation, which allows
         user to monitor and retrieve details about the job status and result. The returned job will be done if
         `should_run_async=False` and will be returned immediately after creation (not necessarily complete) if
-        `should_run_asnyc=True`.
+        `should_run_async=True`.
     """
-    start = time.perf_counter()
     logger.info(f"Loading records from {gcs_folder} to BigQuery.")
-    # Initialize the BigQuery client
-    bigquery_client = bigquery.Client(project=project_id)
-
-    # Construct dataset and table references
-    dataset_ref = bigquery_client.dataset(dataset_id)
-    table_ref = dataset_ref.table(table_id)
+    bq_utils = BqUtils(project=project_id)
 
     # Configure the load job
     job_config = bigquery.LoadJobConfig(
@@ -382,23 +376,12 @@ def _load_records_to_bigquery(
         schema=schema,
     )
 
-    load_job = bigquery_client.load_table_from_uri(
+    return bq_utils.load_files_to_bq(
         source_uris=os.path.join(gcs_folder.uri, "*.avro"),
-        destination=table_ref,
+        bq_path=bq_utils.join_path(project_id, dataset_id, table_id),
         job_config=job_config,
+        should_run_async=should_run_async,
     )
-
-    if should_run_async:
-        logger.info(
-            f"Started loading process for {dataset_id}:{table_id} with job id {load_job.job_id}, running asynchronously"
-        )
-    else:
-        load_job.result()  # Wait for the job to complete.
-        logger.info(
-            f"Loading {load_job.output_rows:,} rows into {dataset_id}:{table_id} in {time.perf_counter() - start:.2f} seconds."
-        )
-
-    return load_job
 
 
 def load_embeddings_to_bigquery(
@@ -430,7 +413,7 @@ def load_embeddings_to_bigquery(
         LoadJob: A BigQuery LoadJob object representing the load operation, which allows
         user to monitor and retrieve details about the job status and result. The returned job will be done if
         `should_run_async=False` and will be returned immediately after creation (not necessarily complete) if
-        `should_run_asnyc=True`.
+        `should_run_async=True`.
     """
     return _load_records_to_bigquery(
         gcs_folder,
@@ -471,7 +454,7 @@ def load_predictions_to_bigquery(
         LoadJob: A BigQuery LoadJob object representing the load operation, which allows
         user to monitor and retrieve details about the job status and result. The returned job will be done if
         `should_run_async=False` and will be returned immediately after creation (not necessarily complete) if
-        `should_run_asnyc=True`.
+        `should_run_async=True`.
     """
     return _load_records_to_bigquery(
         gcs_folder,

--- a/gigl/src/common/utils/bq.py
+++ b/gigl/src/common/utils/bq.py
@@ -1,13 +1,14 @@
 import datetime
 import itertools
 import re
-from typing import Iterable, Optional, Tuple, Union
+import time
+from typing import Iterable, Optional, Sequence, Tuple, Union
 
 import google.api_core.retry
 import google.cloud.bigquery as bigquery
 from google.api_core.exceptions import NotFound
 from google.cloud.bigquery._helpers import _record_field_to_json
-from google.cloud.bigquery.job import _AsyncJob
+from google.cloud.bigquery.job import LoadJob, _AsyncJob
 from google.cloud.bigquery.table import RowIterator
 
 from gigl.common import GcsUri, LocalUri, Uri
@@ -411,6 +412,44 @@ class BqUtils:
         bq_schema = self.__bq_client.get_table(bq_table).schema
         schema_dict = {field.name: field for field in bq_schema}
         return schema_dict
+
+    def load_files_to_bq(
+        self,
+        source_uris: Union[str, Sequence[str]],
+        bq_path: str,
+        job_config: bigquery.LoadJobConfig,
+        should_run_async: bool = False,
+    ) -> LoadJob:
+        """Load one or more GCS files into a BigQuery table.
+
+        Args:
+            source_uris (Union[str, Sequence[str]]): GCS URI or URIs to load.
+                Wildcards are supported.
+            bq_path (str): Destination table in ``project.dataset.table`` format.
+            job_config (bigquery.LoadJobConfig): BigQuery load configuration.
+            should_run_async (bool): Whether to return before the load finishes.
+                Defaults to False.
+
+        Returns:
+            LoadJob: The created BigQuery load job.
+        """
+        start_time = time.perf_counter()
+        load_job = self.__bq_client.load_table_from_uri(
+            source_uris=source_uris,
+            destination=bq_path,
+            job_config=job_config,
+        )
+        if should_run_async:
+            logger.info(
+                f"Started load job {load_job.job_id} for {bq_path}, running asynchronously."
+            )
+        else:
+            load_job.result()
+            logger.info(
+                f"Loaded {load_job.output_rows:,} rows into {bq_path} in "
+                f"{time.perf_counter() - start_time:.2f} seconds."
+            )
+        return load_job
 
     def load_file_to_bq(
         self,

--- a/tests/integration/common/data/export_test.py
+++ b/tests/integration/common/data/export_test.py
@@ -5,7 +5,12 @@ import torch
 from parameterized import param, parameterized
 
 from gigl.common import GcsUri
-from gigl.common.data.export import EmbeddingExporter, load_embeddings_to_bigquery
+from gigl.common.data.export import (
+    EmbeddingExporter,
+    PredictionExporter,
+    load_embeddings_to_bigquery,
+    load_predictions_to_bigquery,
+)
 from gigl.common.logger import Logger
 from gigl.common.utils.gcs import GcsUtils
 from gigl.env.pipelines_config import get_resource_config
@@ -104,4 +109,55 @@ class EmbeddingExportIntegrationTest(TestCase):
         self.assertEqual(
             bq_client.count_number_of_rows_in_bq_table(bq_export_table_path),
             num_nodes * 2,
+        )
+
+
+class PredictionExportIntegrationTest(TestCase):
+    def setUp(self):
+        resource_config = get_resource_config()
+        test_unique_name = f"GiGL-Integration-Prediction-Exporter-{uuid.uuid4().hex}"
+        self.prediction_output_dir = GcsUri.join(
+            resource_config.temp_assets_regional_bucket_path,
+            test_unique_name,
+            "predictions",
+        )
+        self.prediction_output_bq_project = resource_config.project
+        self.prediction_output_bq_dataset = resource_config.temp_assets_bq_dataset_name
+        self.prediction_output_bq_table = test_unique_name
+
+    def tearDown(self):
+        GcsUtils().delete_files_in_bucket_dir(self.prediction_output_dir)
+        bq_utils = BqUtils()
+        bq_export_table_path = bq_utils.join_path(
+            self.prediction_output_bq_project,
+            self.prediction_output_bq_dataset,
+            self.prediction_output_bq_table,
+        )
+        bq_utils.delete_bq_table_if_exist(bq_table_path=bq_export_table_path)
+
+    def test_prediction_export(self):
+        num_nodes = 100
+        with PredictionExporter(export_dir=self.prediction_output_dir) as exporter:
+            for node_id in torch.arange(num_nodes):
+                exporter.add_prediction(
+                    torch.tensor([node_id]), torch.ones(1) * node_id, "node"
+                )
+
+        bq_utils = BqUtils()
+        bq_export_table_path = bq_utils.join_path(
+            self.prediction_output_bq_project,
+            self.prediction_output_bq_dataset,
+            self.prediction_output_bq_table,
+        )
+        load_job = load_predictions_to_bigquery(
+            gcs_folder=self.prediction_output_dir,
+            project_id=self.prediction_output_bq_project,
+            dataset_id=self.prediction_output_bq_dataset,
+            table_id=self.prediction_output_bq_table,
+        )
+
+        self.assertEqual(load_job.output_rows, num_nodes)
+        self.assertEqual(
+            bq_utils.count_number_of_rows_in_bq_table(bq_export_table_path),
+            num_nodes,
         )

--- a/tests/integration/common/data/export_test.py
+++ b/tests/integration/common/data/export_test.py
@@ -126,28 +126,32 @@ class PredictionExportIntegrationTest(TestCase):
         self.prediction_output_bq_table = test_unique_name
 
     def tearDown(self):
-        GcsUtils().delete_files_in_bucket_dir(self.prediction_output_dir)
-        bq_utils = BqUtils()
-        bq_export_table_path = bq_utils.join_path(
+        gcs_utils = GcsUtils()
+        gcs_utils.delete_files_in_bucket_dir(self.prediction_output_dir)
+        bq_client = BqUtils()
+        bq_export_table_path = bq_client.join_path(
             self.prediction_output_bq_project,
             self.prediction_output_bq_dataset,
             self.prediction_output_bq_table,
         )
-        bq_utils.delete_bq_table_if_exist(bq_table_path=bq_export_table_path)
+        bq_client.delete_bq_table_if_exist(
+            bq_table_path=bq_export_table_path,
+        )
 
     def test_prediction_export(self):
         num_nodes = 100
         with PredictionExporter(export_dir=self.prediction_output_dir) as exporter:
-            for node_id in torch.arange(num_nodes):
-                exporter.add_prediction(
-                    torch.tensor([node_id]), torch.ones(1) * node_id, "node"
-                )
+            for i in torch.arange(num_nodes):
+                exporter.add_prediction(torch.tensor([i]), torch.ones(1) * i, "node")
 
-        bq_utils = BqUtils()
-        bq_export_table_path = bq_utils.join_path(
+        bq_client = BqUtils()
+        bq_export_table_path = bq_client.join_path(
             self.prediction_output_bq_project,
             self.prediction_output_bq_dataset,
             self.prediction_output_bq_table,
+        )
+        logger.info(
+            f"Will try exporting {self.prediction_output_dir} to BQ: {bq_export_table_path}"
         )
         load_job = load_predictions_to_bigquery(
             gcs_folder=self.prediction_output_dir,
@@ -158,6 +162,6 @@ class PredictionExportIntegrationTest(TestCase):
 
         self.assertEqual(load_job.output_rows, num_nodes)
         self.assertEqual(
-            bq_utils.count_number_of_rows_in_bq_table(bq_export_table_path),
+            bq_client.count_number_of_rows_in_bq_table(bq_export_table_path),
             num_nodes,
         )

--- a/tests/unit/common/data/export_test.py
+++ b/tests/unit/common/data/export_test.py
@@ -2,13 +2,14 @@ import io
 import tempfile
 from pathlib import Path
 from typing import Optional
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
 import fastavro
 import requests
 import torch
 from absl.testing import absltest
+from google.cloud import bigquery
 from google.cloud.exceptions import GoogleCloudError
 from parameterized import param, parameterized
 
@@ -18,6 +19,8 @@ from gigl.common.data.export import (
     _NODE_ID_KEY,
     _NODE_TYPE_KEY,
     _PREDICTION_KEY,
+    EMBEDDING_BIGQUERY_SCHEMA,
+    PREDICTION_BIGQUERY_SCHEMA,
     EmbeddingExporter,
     PredictionExporter,
     load_embeddings_to_bigquery,
@@ -394,22 +397,18 @@ class TestEmbeddingExporter(TestCase):
             ),
         ]
     )
-    @patch("gigl.common.data.export.bigquery.Client")
+    @patch("gigl.common.data.export.BqUtils")
     def test_load_embedding_to_bigquery(
-        self, _, mock_bigquery_client, should_run_async: bool
+        self, _, mock_bq_utils_cls: MagicMock, should_run_async: bool
     ):
-        # Mock inputs
         gcs_folder = GcsUri("gs://test-bucket/test-folder")
         project_id = "test-project"
         dataset_id = "test-dataset"
         table_id = "test-table"
+        destination = f"{project_id}.{dataset_id}.{table_id}"
+        mock_bq_utils = mock_bq_utils_cls.return_value
+        mock_bq_utils.join_path.return_value = destination
 
-        # Mock BigQuery client and load job
-        mock_client = MagicMock()
-        mock_client.load_table_from_uri.return_value.output_rows = 1000
-        mock_bigquery_client.return_value = mock_client
-
-        # Call the function
         load_job = load_embeddings_to_bigquery(
             gcs_folder,
             project_id,
@@ -418,14 +417,22 @@ class TestEmbeddingExporter(TestCase):
             should_run_async=should_run_async,
         )
 
-        # Assertions
-        mock_bigquery_client.assert_called_once_with(project=project_id)
-        mock_client.load_table_from_uri.assert_called_once_with(
-            source_uris=f"{gcs_folder.uri}/*.avro",
-            destination=mock_client.dataset.return_value.table.return_value,
-            job_config=ANY,
+        mock_bq_utils_cls.assert_called_once_with(project=project_id)
+        mock_bq_utils.join_path.assert_called_once_with(
+            project_id, dataset_id, table_id
         )
-        self.assertEqual(load_job.output_rows, 1000)
+        mock_bq_utils.load_files_to_bq.assert_called_once()
+        _, load_kwargs = mock_bq_utils.load_files_to_bq.call_args
+        self.assertEqual(load_kwargs["source_uris"], f"{gcs_folder.uri}/*.avro")
+        self.assertEqual(load_kwargs["bq_path"], destination)
+        self.assertEqual(load_kwargs["should_run_async"], should_run_async)
+        job_config = load_kwargs["job_config"]
+        self.assertEqual(job_config.source_format, bigquery.SourceFormat.AVRO)
+        self.assertEqual(
+            job_config.write_disposition, bigquery.WriteDisposition.WRITE_APPEND
+        )
+        self.assertEqual(list(job_config.schema), list(EMBEDDING_BIGQUERY_SCHEMA))
+        self.assertIs(load_job, mock_bq_utils.load_files_to_bq.return_value)
 
 
 class TestPredictionsExporter(TestCase):
@@ -746,22 +753,18 @@ class TestPredictionsExporter(TestCase):
             ),
         ]
     )
-    @patch("gigl.common.data.export.bigquery.Client")
+    @patch("gigl.common.data.export.BqUtils")
     def test_load_prediction_to_bigquery(
-        self, _, mock_bigquery_client, should_run_async: bool
+        self, _, mock_bq_utils_cls: MagicMock, should_run_async: bool
     ):
-        # Mock inputs
         gcs_folder = GcsUri("gs://test-bucket/test-folder")
         project_id = "test-project"
         dataset_id = "test-dataset"
         table_id = "test-table"
+        destination = f"{project_id}.{dataset_id}.{table_id}"
+        mock_bq_utils = mock_bq_utils_cls.return_value
+        mock_bq_utils.join_path.return_value = destination
 
-        # Mock BigQuery client and load job
-        mock_client = MagicMock()
-        mock_client.load_table_from_uri.return_value.output_rows = 1000
-        mock_bigquery_client.return_value = mock_client
-
-        # Call the function
         load_job = load_predictions_to_bigquery(
             gcs_folder,
             project_id,
@@ -770,14 +773,22 @@ class TestPredictionsExporter(TestCase):
             should_run_async=should_run_async,
         )
 
-        # Assertions
-        mock_bigquery_client.assert_called_once_with(project=project_id)
-        mock_client.load_table_from_uri.assert_called_once_with(
-            source_uris=f"{gcs_folder.uri}/*.avro",
-            destination=mock_client.dataset.return_value.table.return_value,
-            job_config=ANY,
+        mock_bq_utils_cls.assert_called_once_with(project=project_id)
+        mock_bq_utils.join_path.assert_called_once_with(
+            project_id, dataset_id, table_id
         )
-        self.assertEqual(load_job.output_rows, 1000)
+        mock_bq_utils.load_files_to_bq.assert_called_once()
+        _, load_kwargs = mock_bq_utils.load_files_to_bq.call_args
+        self.assertEqual(load_kwargs["source_uris"], f"{gcs_folder.uri}/*.avro")
+        self.assertEqual(load_kwargs["bq_path"], destination)
+        self.assertEqual(load_kwargs["should_run_async"], should_run_async)
+        job_config = load_kwargs["job_config"]
+        self.assertEqual(job_config.source_format, bigquery.SourceFormat.AVRO)
+        self.assertEqual(
+            job_config.write_disposition, bigquery.WriteDisposition.WRITE_APPEND
+        )
+        self.assertEqual(list(job_config.schema), list(PREDICTION_BIGQUERY_SCHEMA))
+        self.assertIs(load_job, mock_bq_utils.load_files_to_bq.return_value)
 
 
 if __name__ == "__main__":

--- a/tests/unit/common/data/export_test.py
+++ b/tests/unit/common/data/export_test.py
@@ -9,7 +9,6 @@ import fastavro
 import requests
 import torch
 from absl.testing import absltest
-from google.cloud import bigquery
 from google.cloud.exceptions import GoogleCloudError
 from parameterized import param, parameterized
 
@@ -19,12 +18,8 @@ from gigl.common.data.export import (
     _NODE_ID_KEY,
     _NODE_TYPE_KEY,
     _PREDICTION_KEY,
-    EMBEDDING_BIGQUERY_SCHEMA,
-    PREDICTION_BIGQUERY_SCHEMA,
     EmbeddingExporter,
     PredictionExporter,
-    load_embeddings_to_bigquery,
-    load_predictions_to_bigquery,
 )
 from gigl.common.utils.retry import RetriesFailedException
 from tests.test_assets.test_case import TestCase
@@ -385,55 +380,6 @@ class TestEmbeddingExporter(TestCase):
         exporter = EmbeddingExporter(export_dir=gcs_base_uri)
         exporter.flush_records()
 
-    @parameterized.expand(
-        [
-            param(
-                "Test if we can load embeddings synchronously",
-                should_run_async=False,
-            ),
-            param(
-                "Test if we can load embeddings asynchronously",
-                should_run_async=True,
-            ),
-        ]
-    )
-    @patch("gigl.common.data.export.BqUtils")
-    def test_load_embedding_to_bigquery(
-        self, _, mock_bq_utils_cls: MagicMock, should_run_async: bool
-    ):
-        gcs_folder = GcsUri("gs://test-bucket/test-folder")
-        project_id = "test-project"
-        dataset_id = "test-dataset"
-        table_id = "test-table"
-        destination = f"{project_id}.{dataset_id}.{table_id}"
-        mock_bq_utils = mock_bq_utils_cls.return_value
-        mock_bq_utils.join_path.return_value = destination
-
-        load_job = load_embeddings_to_bigquery(
-            gcs_folder,
-            project_id,
-            dataset_id,
-            table_id,
-            should_run_async=should_run_async,
-        )
-
-        mock_bq_utils_cls.assert_called_once_with(project=project_id)
-        mock_bq_utils.join_path.assert_called_once_with(
-            project_id, dataset_id, table_id
-        )
-        mock_bq_utils.load_files_to_bq.assert_called_once()
-        _, load_kwargs = mock_bq_utils.load_files_to_bq.call_args
-        self.assertEqual(load_kwargs["source_uris"], f"{gcs_folder.uri}/*.avro")
-        self.assertEqual(load_kwargs["bq_path"], destination)
-        self.assertEqual(load_kwargs["should_run_async"], should_run_async)
-        job_config = load_kwargs["job_config"]
-        self.assertEqual(job_config.source_format, bigquery.SourceFormat.AVRO)
-        self.assertEqual(
-            job_config.write_disposition, bigquery.WriteDisposition.WRITE_APPEND
-        )
-        self.assertEqual(list(job_config.schema), list(EMBEDDING_BIGQUERY_SCHEMA))
-        self.assertIs(load_job, mock_bq_utils.load_files_to_bq.return_value)
-
 
 class TestPredictionsExporter(TestCase):
     def setUp(self):
@@ -740,55 +686,6 @@ class TestPredictionsExporter(TestCase):
         )
         exporter = PredictionExporter(export_dir=gcs_base_uri)
         exporter.flush_records()
-
-    @parameterized.expand(
-        [
-            param(
-                "Test if we can load predictions synchronously",
-                should_run_async=False,
-            ),
-            param(
-                "Test if we can load predictions asynchronously",
-                should_run_async=True,
-            ),
-        ]
-    )
-    @patch("gigl.common.data.export.BqUtils")
-    def test_load_prediction_to_bigquery(
-        self, _, mock_bq_utils_cls: MagicMock, should_run_async: bool
-    ):
-        gcs_folder = GcsUri("gs://test-bucket/test-folder")
-        project_id = "test-project"
-        dataset_id = "test-dataset"
-        table_id = "test-table"
-        destination = f"{project_id}.{dataset_id}.{table_id}"
-        mock_bq_utils = mock_bq_utils_cls.return_value
-        mock_bq_utils.join_path.return_value = destination
-
-        load_job = load_predictions_to_bigquery(
-            gcs_folder,
-            project_id,
-            dataset_id,
-            table_id,
-            should_run_async=should_run_async,
-        )
-
-        mock_bq_utils_cls.assert_called_once_with(project=project_id)
-        mock_bq_utils.join_path.assert_called_once_with(
-            project_id, dataset_id, table_id
-        )
-        mock_bq_utils.load_files_to_bq.assert_called_once()
-        _, load_kwargs = mock_bq_utils.load_files_to_bq.call_args
-        self.assertEqual(load_kwargs["source_uris"], f"{gcs_folder.uri}/*.avro")
-        self.assertEqual(load_kwargs["bq_path"], destination)
-        self.assertEqual(load_kwargs["should_run_async"], should_run_async)
-        job_config = load_kwargs["job_config"]
-        self.assertEqual(job_config.source_format, bigquery.SourceFormat.AVRO)
-        self.assertEqual(
-            job_config.write_disposition, bigquery.WriteDisposition.WRITE_APPEND
-        )
-        self.assertEqual(list(job_config.schema), list(PREDICTION_BIGQUERY_SCHEMA))
-        self.assertIs(load_job, mock_bq_utils.load_files_to_bq.return_value)
 
 
 if __name__ == "__main__":

--- a/tests/unit/src/common/utils/bq_test.py
+++ b/tests/unit/src/common/utils/bq_test.py
@@ -1,7 +1,6 @@
 from typing import Sequence
 from unittest.mock import MagicMock, patch
 
-from google.cloud import bigquery
 from parameterized import param, parameterized
 
 from gigl.src.common.utils.bq import BqUtils
@@ -142,44 +141,3 @@ class GetLatestTableTest(TestCase):
             bq_table_path_prefix=self.PREFIX, table_partition_suffix="YYYYMMDDHH"
         )
         self.assertEqual(result, "myproject.mydataset.events_2025010112")
-
-
-@patch("gigl.src.common.utils.bq.bigquery.Client")
-class LoadFilesToBqTest(TestCase):
-    def test_sync_load_waits_for_completion_and_returns_job(
-        self, mock_client_cls: MagicMock
-    ) -> None:
-        mock_load_job = mock_client_cls.return_value.load_table_from_uri.return_value
-        mock_load_job.output_rows = 1000
-        bq_utils = BqUtils(project="my-project")
-        job_config = bigquery.LoadJobConfig(source_format=bigquery.SourceFormat.AVRO)
-
-        load_job = bq_utils.load_files_to_bq(
-            source_uris="gs://bucket/folder/*.avro",
-            bq_path="my-project.my-dataset.my-table",
-            job_config=job_config,
-        )
-
-        mock_client_cls.return_value.load_table_from_uri.assert_called_once_with(
-            source_uris="gs://bucket/folder/*.avro",
-            destination="my-project.my-dataset.my-table",
-            job_config=job_config,
-        )
-        mock_load_job.result.assert_called_once_with()
-        self.assertIs(load_job, mock_load_job)
-
-    def test_async_load_returns_without_waiting(
-        self, mock_client_cls: MagicMock
-    ) -> None:
-        mock_load_job = mock_client_cls.return_value.load_table_from_uri.return_value
-        bq_utils = BqUtils(project="my-project")
-
-        load_job = bq_utils.load_files_to_bq(
-            source_uris="gs://bucket/folder/*.avro",
-            bq_path="my-project.my-dataset.my-table",
-            job_config=bigquery.LoadJobConfig(),
-            should_run_async=True,
-        )
-
-        mock_load_job.result.assert_not_called()
-        self.assertIs(load_job, mock_load_job)

--- a/tests/unit/src/common/utils/bq_test.py
+++ b/tests/unit/src/common/utils/bq_test.py
@@ -1,6 +1,7 @@
 from typing import Sequence
 from unittest.mock import MagicMock, patch
 
+from google.cloud import bigquery
 from parameterized import param, parameterized
 
 from gigl.src.common.utils.bq import BqUtils
@@ -141,3 +142,44 @@ class GetLatestTableTest(TestCase):
             bq_table_path_prefix=self.PREFIX, table_partition_suffix="YYYYMMDDHH"
         )
         self.assertEqual(result, "myproject.mydataset.events_2025010112")
+
+
+@patch("gigl.src.common.utils.bq.bigquery.Client")
+class LoadFilesToBqTest(TestCase):
+    def test_sync_load_waits_for_completion_and_returns_job(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        mock_load_job = mock_client_cls.return_value.load_table_from_uri.return_value
+        mock_load_job.output_rows = 1000
+        bq_utils = BqUtils(project="my-project")
+        job_config = bigquery.LoadJobConfig(source_format=bigquery.SourceFormat.AVRO)
+
+        load_job = bq_utils.load_files_to_bq(
+            source_uris="gs://bucket/folder/*.avro",
+            bq_path="my-project.my-dataset.my-table",
+            job_config=job_config,
+        )
+
+        mock_client_cls.return_value.load_table_from_uri.assert_called_once_with(
+            source_uris="gs://bucket/folder/*.avro",
+            destination="my-project.my-dataset.my-table",
+            job_config=job_config,
+        )
+        mock_load_job.result.assert_called_once_with()
+        self.assertIs(load_job, mock_load_job)
+
+    def test_async_load_returns_without_waiting(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        mock_load_job = mock_client_cls.return_value.load_table_from_uri.return_value
+        bq_utils = BqUtils(project="my-project")
+
+        load_job = bq_utils.load_files_to_bq(
+            source_uris="gs://bucket/folder/*.avro",
+            bq_path="my-project.my-dataset.my-table",
+            job_config=bigquery.LoadJobConfig(),
+            should_run_async=True,
+        )
+
+        mock_load_job.result.assert_not_called()
+        self.assertIs(load_job, mock_load_job)


### PR DESCRIPTION
## What

- Adds `BqUtils.load_files_to_bq` for loading one or more GCS files with a caller-provided BigQuery job configuration.
- Preserves synchronous and asynchronous load behavior while centralizing load timing and result logging.
- Routes embedding and prediction Avro exports through `BqUtils` and uses `BqUtils.join_path` for the destination table.
- Adds focused unit coverage for the utility and export delegation, plus end-to-end prediction export coverage.

## Why

The export helpers maintained their own BigQuery client and duplicated load-job orchestration. Centralizing that behavior in `BqUtils` gives file-based loads the same client ownership and a reusable sync/async API while preserving existing public export signatures and load semantics.

## Testing

- `bq_test.py`: 9 tests passed.
- Export delegation tests: 4 tests passed.
- Scoped `ty` checks passed for all changed Python files.
- Ruff check and formatting passed for all changed Python files.
