### PR TITLE
Pin torchrec~=1.3.0 to match fbgemm-gpu~=1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ pyg27-torch28-cpu = [
   "torch_scatter; sys_platform != 'darwin'",
   "torch_sparse; sys_platform != 'darwin'",
   "torch_spline_conv; sys_platform != 'darwin'",
-  "torchrec ; sys_platform != 'darwin'",
+  # Must move in lockstep with fbgemm-gpu~=1.3.0 above; see the FBGEMM/torchrec compatibility matrix: https://docs.pytorch.org/FBGEMM/general/Releases.html
+  "torchrec~=1.3.0 ; sys_platform != 'darwin'",
 ]
 pyg27-torch28-cu128 = [
   "fbgemm-gpu~=1.3.0; sys_platform != 'darwin'",
@@ -82,7 +83,7 @@ pyg27-torch28-cu128 = [
   "torch_scatter; sys_platform != 'darwin'",
   "torch_sparse; sys_platform != 'darwin'",
   "torch_spline_conv; sys_platform != 'darwin'",
-  "torchrec ; sys_platform != 'darwin'",
+  "torchrec~=1.3.0 ; sys_platform != 'darwin'",
 
 ]
 experimental = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ pyg27-torch28-cu128 = [
   "torch_scatter; sys_platform != 'darwin'",
   "torch_sparse; sys_platform != 'darwin'",
   "torch_spline_conv; sys_platform != 'darwin'",
+  # Must move in lockstep with fbgemm-gpu~=1.3.0 above; see the FBGEMM/torchrec compatibility matrix: https://docs.pytorch.org/FBGEMM/general/Releases.html
   "torchrec~=1.3.0 ; sys_platform != 'darwin'",
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ pyg27-torch28-cpu = [
   "torch_scatter; sys_platform != 'darwin'",
   "torch_sparse; sys_platform != 'darwin'",
   "torch_spline_conv; sys_platform != 'darwin'",
-  # Must move in lockstep with fbgemm-gpu~=1.3.0 above; see the FBGEMM/torchrec compatibility matrix: https://docs.pytorch.org/FBGEMM/general/Releases.html
+  # Must move in lockstep with fbgemm-gpu~=1.3.0 above; see https://meta-pytorch.org/torchrec/setup-torchrec.html#version-compatability
   "torchrec~=1.3.0 ; sys_platform != 'darwin'",
 ]
 pyg27-torch28-cu128 = [
@@ -83,7 +83,7 @@ pyg27-torch28-cu128 = [
   "torch_scatter; sys_platform != 'darwin'",
   "torch_sparse; sys_platform != 'darwin'",
   "torch_spline_conv; sys_platform != 'darwin'",
-  # Must move in lockstep with fbgemm-gpu~=1.3.0 above; see the FBGEMM/torchrec compatibility matrix: https://docs.pytorch.org/FBGEMM/general/Releases.html
+  # Must move in lockstep with fbgemm-gpu~=1.3.0 above; see https://meta-pytorch.org/torchrec/setup-torchrec.html#version-compatability
   "torchrec~=1.3.0 ; sys_platform != 'darwin'",
 
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -889,8 +889,8 @@ requires-dist = [
     { name = "torch-sparse", marker = "sys_platform != 'darwin' and extra == 'pyg27-torch28-cu128'", index = "https://data.pyg.org/whl/torch-2.8.0+cu128.html", conflict = { package = "gigl", extra = "pyg27-torch28-cu128" } },
     { name = "torch-spline-conv", marker = "sys_platform != 'darwin' and extra == 'pyg27-torch28-cpu'", index = "https://data.pyg.org/whl/torch-2.8.0+cpu.html", conflict = { package = "gigl", extra = "pyg27-torch28-cpu" } },
     { name = "torch-spline-conv", marker = "sys_platform != 'darwin' and extra == 'pyg27-torch28-cu128'", index = "https://data.pyg.org/whl/torch-2.8.0+cu128.html", conflict = { package = "gigl", extra = "pyg27-torch28-cu128" } },
-    { name = "torchrec", marker = "sys_platform != 'darwin' and extra == 'pyg27-torch28-cpu'", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "gigl", extra = "pyg27-torch28-cpu" } },
-    { name = "torchrec", marker = "sys_platform != 'darwin' and extra == 'pyg27-torch28-cu128'", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "gigl", extra = "pyg27-torch28-cu128" } },
+    { name = "torchrec", marker = "sys_platform != 'darwin' and extra == 'pyg27-torch28-cpu'", specifier = "~=1.3.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "gigl", extra = "pyg27-torch28-cpu" } },
+    { name = "torchrec", marker = "sys_platform != 'darwin' and extra == 'pyg27-torch28-cu128'", specifier = "~=1.3.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "gigl", extra = "pyg27-torch28-cu128" } },
 ]
 provides-extras = ["transform", "pyg27-torch28-cpu", "pyg27-torch28-cu128", "experimental"]
 


### PR DESCRIPTION
gigl.nn depends on torchrec, which in turn depends on fbgemm-gpu for its kernels. fbgemm-gpu is already pinned to ~=1.3.0 in both the pyg27-torch28-cpu and pyg27-torch28-cu128 extras, but torchrec was left unconstrained. An unconstrained re-lock can pull a newer torchrec built against a newer fbgemm-gpu line (e.g. 1.5), whose symbols (such as KVZCHTBEConfig) are absent from the pinned 1.3.0 fbgemm-gpu, breaking `import gigl.nn` at runtime.

https://meta-pytorch.org/torchrec/setup-torchrec.html#version-compatability

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
