### PR TITLE
Update Metrics Service Provider Singleton Semantics

### DIFF
--- a/gigl/src/common/utils/metrics_service_provider.py
+++ b/gigl/src/common/utils/metrics_service_provider.py
@@ -12,6 +12,7 @@ from snapchat.research.gbml.gbml_config_pb2 import GbmlConfig
 logger = Logger()
 
 _metrics_instance: Optional[OpsMetricPublisher] = None
+_WERE_METRICS_INITIALIZED: bool = False
 JOB_NAME_GROUPING_ENV_KEY = "GBML_JOB_NAME"
 
 
@@ -31,7 +32,8 @@ def initialize_metrics(task_config_uri: Uri, service_name: str) -> bool:
         no-op default when no custom class is configured), ``False`` if a
         custom metrics class was specified but could not be loaded or instantiated.
     """
-    global _metrics_instance
+    global _metrics_instance, _WERE_METRICS_INITIALIZED
+    _WERE_METRICS_INITIALIZED = True
     os.environ[JOB_NAME_GROUPING_ENV_KEY] = service_name
     proto_utils = ProtoUtils()
     task_config: GbmlConfig = proto_utils.read_proto_from_yaml(
@@ -60,6 +62,10 @@ def initialize_metrics(task_config_uri: Uri, service_name: str) -> bool:
 
 
 def get_metrics_service_instance() -> Optional[OpsMetricPublisher]:
+    if not _WERE_METRICS_INITIALIZED:
+        raise RuntimeError(
+            "Metrics instance is not initialized. Call initialize_metrics() before getting the instance."
+        )
     return _metrics_instance
 
 

--- a/gigl/src/common/utils/metrics_service_provider.py
+++ b/gigl/src/common/utils/metrics_service_provider.py
@@ -54,22 +54,12 @@ def initialize_metrics(task_config_uri: Uri, service_name: str) -> bool:
         logger.info(f"Instantiated Custom Metrics Class from: {metrics_cls_path}")
         return True
     except Exception as e:
-        logger.error(
-            f"Could not instantiate class {metrics_cls_path}: {e}. Falling back to No-op metrics."
-        )
-        _metrics_instance = NopMetricsPublisher()
+        logger.error(f"Could not instantiate class {metrics_cls_path}: {e}")
+        _metrics_instance = None
         return False
 
 
 def get_metrics_service_instance() -> Optional[OpsMetricPublisher]:
-    if _metrics_instance is None:
-        logger.warning(
-            "initialize_metrics() was not called, using NopMetricsPulisher as default"
-        )
-        raise RuntimeError(
-            "Metrics instance is not initialized. Call initialize_metrics() before getting the instance."
-        )
-
     return _metrics_instance
 
 

--- a/tests/unit/src/common/utils/metrics_service_provider_test.py
+++ b/tests/unit/src/common/utils/metrics_service_provider_test.py
@@ -50,8 +50,8 @@ class MetricsServiceProviderTest(TestCase):
         self.assertTrue(result)
         self.assertIsInstance(get_metrics_service_instance(), NopMetricsPublisher)
 
-    def test_invalid_custom_class_returns_false_and_falls_back_to_nop(self) -> None:
-        """initialize_metrics returns False and falls back to NopMetricsPublisher when the class path does not exist."""
+    def test_invalid_custom_class_returns_false(self) -> None:
+        """initialize_metrics returns False when the class path does not exist."""
         config = gbml_config_pb2.GbmlConfig()
         config.metrics_config.metrics_cls_path = "gigl.does.not.exist.MetricsClass"
         uri = self._write_task_config(config)
@@ -59,9 +59,18 @@ class MetricsServiceProviderTest(TestCase):
         result = initialize_metrics(task_config_uri=uri, service_name="test_service")
 
         self.assertFalse(result)
+        self.assertIsNone(get_metrics_service_instance())
+
+    def test_invalid_custom_class_returns_true_and_falls_back_to_nop(self) -> None:
+        """initialize_metrics returns False and falls back to NopMetricsPublisher when custom metrics class not provided."""
+        config = gbml_config_pb2.GbmlConfig()
+        uri = self._write_task_config(config)
+
+        result = initialize_metrics(task_config_uri=uri, service_name="test_service")
+
+        self.assertTrue(result)
         self.assertIsInstance(get_metrics_service_instance(), NopMetricsPublisher)
 
-    def test_get_metrics_service_instance_raises_before_initialization(self) -> None:
-        """get_metrics_service_instance raises RuntimeError when called before initialize_metrics."""
-        with self.assertRaises(RuntimeError):
-            get_metrics_service_instance()
+    def test_get_metrics_service_instance_returns_none_before_initialization(self) -> None:
+        """get_metrics_service_instance returns None when called before initialize_metrics."""
+        self.assertIsNone(get_metrics_service_instance())

--- a/tests/unit/src/common/utils/metrics_service_provider_test.py
+++ b/tests/unit/src/common/utils/metrics_service_provider_test.py
@@ -61,7 +61,7 @@ class MetricsServiceProviderTest(TestCase):
         self.assertFalse(result)
         self.assertIsNone(get_metrics_service_instance())
 
-    def test_invalid_custom_class_returns_true_and_falls_back_to_nop(self) -> None:
+    def test_custom_class_not_specified_returns_true_and_falls_back_to_nop(self) -> None:
         """initialize_metrics returns False and falls back to NopMetricsPublisher when custom metrics class not provided."""
         config = gbml_config_pb2.GbmlConfig()
         uri = self._write_task_config(config)

--- a/tests/unit/src/common/utils/metrics_service_provider_test.py
+++ b/tests/unit/src/common/utils/metrics_service_provider_test.py
@@ -65,7 +65,7 @@ class MetricsServiceProviderTest(TestCase):
     def test_custom_class_not_specified_returns_true_and_falls_back_to_nop(
         self,
     ) -> None:
-        """initialize_metrics returns False and falls back to NopMetricsPublisher when custom metrics class not provided."""
+        """initialize_metrics returns True and falls back to NopMetricsPublisher when custom metrics class not provided."""
         config = gbml_config_pb2.GbmlConfig()
         uri = self._write_task_config(config)
 

--- a/tests/unit/src/common/utils/metrics_service_provider_test.py
+++ b/tests/unit/src/common/utils/metrics_service_provider_test.py
@@ -21,6 +21,7 @@ class MetricsServiceProviderTest(TestCase):
     def tearDown(self) -> None:
         self.tmp_dir.cleanup()
         metrics_service_provider._metrics_instance = self._original_metrics_instance
+        metrics_service_provider._WERE_METRICS_INITIALIZED = False
 
     def _write_task_config(self, config: gbml_config_pb2.GbmlConfig) -> LocalUri:
         uri = LocalUri.join(self.tmp_dir.name, "task_config.yaml")
@@ -61,7 +62,9 @@ class MetricsServiceProviderTest(TestCase):
         self.assertFalse(result)
         self.assertIsNone(get_metrics_service_instance())
 
-    def test_custom_class_not_specified_returns_true_and_falls_back_to_nop(self) -> None:
+    def test_custom_class_not_specified_returns_true_and_falls_back_to_nop(
+        self,
+    ) -> None:
         """initialize_metrics returns False and falls back to NopMetricsPublisher when custom metrics class not provided."""
         config = gbml_config_pb2.GbmlConfig()
         uri = self._write_task_config(config)
@@ -71,6 +74,7 @@ class MetricsServiceProviderTest(TestCase):
         self.assertTrue(result)
         self.assertIsInstance(get_metrics_service_instance(), NopMetricsPublisher)
 
-    def test_get_metrics_service_instance_returns_none_before_initialization(self) -> None:
-        """get_metrics_service_instance returns None when called before initialize_metrics."""
-        self.assertIsNone(get_metrics_service_instance())
+    def test_get_metrics_service_instance_raises_before_initialization(self) -> None:
+        """get_metrics_service_instance raises RuntimeError when called before initialize_metrics."""
+        with self.assertRaises(RuntimeError):
+            get_metrics_service_instance()

--- a/tests/unit/src/config_populator/config_populator_functionality_test.py
+++ b/tests/unit/src/config_populator/config_populator_functionality_test.py
@@ -241,6 +241,9 @@ class ConfigPopulatorUnitTest(TestCase):
             patch.object(
                 ConfigPopulator, "_ConfigPopulator__run", return_value=frozen_uri
             ),
+            # Bypass metrics init check in metrics_service_provider.get_metrics_service_instance()
+            # and supply a no-op metrics publisher directly
+            patch.object(metrics_service_provider, "_WERE_METRICS_INITIALIZED", True),
             patch.object(
                 metrics_service_provider, "_metrics_instance", NopMetricsPublisher()
             ),


### PR DESCRIPTION
**Summary of Semantics**
- `get_metrics_service_instance` returns the value of the singleton metrics instance as is (could be None), but still raises if `initialize_metrics` was not called first.
- Failing to construct a custom metrics provider in `initiailize_metrics` does **not** fallback to `NoOpMetricsPublisher` - it overrides the metrics instance to `None`.


