### PR TITLE
Refactor PPR top-k selection helper

### DIFF
--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -278,18 +278,20 @@ void PPRForwardPush::pushResiduals(
 static std::vector<std::pair<int32_t, double>> selectFinalizedPPRPairs(const SeedNodeTypeState& nodeTypeState,
                                                                        int32_t finalizedPPRNodeLimit) {
     const auto& scores = nodeTypeState.pprScores;
-    const auto higherScore = [](const auto& a, const auto& b) { return a.second > b.second; };
 
-    const int32_t pprTopK = std::min(finalizedPPRNodeLimit, static_cast<int32_t>(scores.size()));
+    const int32_t numReturnedPairs = std::min(finalizedPPRNodeLimit, static_cast<int32_t>(scores.size()));
     std::vector<std::pair<int32_t, double>> selectedPairs;
-    selectedPairs.reserve(static_cast<size_t>(pprTopK));
-    if (pprTopK > 0) {
+    selectedPairs.reserve(static_cast<size_t>(numReturnedPairs));
+    if (numReturnedPairs > 0) {
         std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
-        if (pprTopK < static_cast<int32_t>(scorePairs.size())) {
-            std::nth_element(scorePairs.begin(), scorePairs.begin() + pprTopK, scorePairs.end(), higherScore);
+        if (numReturnedPairs < static_cast<int32_t>(scorePairs.size())) {
+            std::nth_element(scorePairs.begin(),
+                             scorePairs.begin() + numReturnedPairs,
+                             scorePairs.end(),
+                             [](const auto& a, const auto& b) { return a.second > b.second; });
         }
 
-        for (int32_t rankIdx = 0; rankIdx < pprTopK; ++rankIdx) {
+        for (int32_t rankIdx = 0; rankIdx < numReturnedPairs; ++rankIdx) {
             selectedPairs.emplace_back(scorePairs[rankIdx].first, scorePairs[rankIdx].second);
         }
     }
@@ -314,8 +316,7 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
     const int32_t residualTopUpBudget =
         std::max<int32_t>(0, sequenceLength - static_cast<int32_t>(selectedPairs.size()));
     if (residualTopUpBudget > 0) {
-        const auto& scores = nodeTypeState.pprScores;
-        const auto higherScore = [](const auto& a, const auto& b) { return a.second > b.second; };
+        const std::unordered_map<int32_t, double>& pprScoresByNodeId = nodeTypeState.pprScores;
         std::unordered_set<int32_t> selectedPPRNodeIds;
         selectedPPRNodeIds.reserve(selectedPairs.size());
         for (const auto& selectedPair : selectedPairs) {
@@ -325,12 +326,15 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
         std::vector<std::pair<int32_t, double>> residualPairs;
         residualPairs.reserve(nodeTypeState.residuals.size());
         for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
+            // Forward push residuals are non-negative in normal operation. Pushed
+            // nodes remain in the map with zero residual, so skip drained entries
+            // and any unexpected non-positive values.
             if (residual <= 0.0 || selectedPPRNodeIds.find(nodeId) != selectedPPRNodeIds.end()) {
                 continue;
             }
 
-            auto scoreIter = scores.find(nodeId);
-            double pprScore = (scoreIter != scores.end()) ? scoreIter->second : 0.0;
+            std::unordered_map<int32_t, double>::const_iterator pprScoreIter = pprScoresByNodeId.find(nodeId);
+            double pprScore = (pprScoreIter != pprScoresByNodeId.end()) ? pprScoreIter->second : 0.0;
             double outputScore = pprScore + residual;
             residualPairs.emplace_back(nodeId, outputScore);
         }
@@ -338,8 +342,10 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
         const int32_t residualTopK = std::min(residualTopUpBudget, static_cast<int32_t>(residualPairs.size()));
         if (residualTopK > 0) {
             if (residualTopK < static_cast<int32_t>(residualPairs.size())) {
-                std::nth_element(
-                    residualPairs.begin(), residualPairs.begin() + residualTopK, residualPairs.end(), higherScore);
+                std::nth_element(residualPairs.begin(),
+                                 residualPairs.begin() + residualTopK,
+                                 residualPairs.end(),
+                                 [](const auto& a, const auto& b) { return a.second > b.second; });
             }
 
             for (int32_t rankIdx = 0; rankIdx < residualTopK; ++rankIdx) {
@@ -389,12 +395,15 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
                 appendResidualTopUpPairs(nodeTypeState, selectedPairs, maxPPRNodes);
             }
 
-            // Empty and singleton outputs are already ordered. Multi-row outputs can
-            // be unordered because the selection helpers use nth_element, so sort once
-            // to rank emitted rows by the score returned to callers.
+            // The selection helpers use nth_element, which selects the right rows
+            // but does not order them. Sort the selected rows once to preserve the
+            // emitted ordering contract. With residual top-up enabled, this matches
+            // the previous behavior: selected finalized and top-up rows are ordered
+            // together by emitted score, so top-up rows may interleave after selection.
             if (selectedPairs.size() > 1) {
-                const auto higherScore = [](const auto& a, const auto& b) { return a.second > b.second; };
-                std::sort(selectedPairs.begin(), selectedPairs.end(), higherScore);
+                std::sort(selectedPairs.begin(), selectedPairs.end(), [](const auto& a, const auto& b) {
+                    return a.second > b.second;
+                });
             }
 
             for (const auto& [nodeId, score] : selectedPairs) {

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -333,7 +333,7 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
                 continue;
             }
 
-            std::unordered_map<int32_t, double>::const_iterator pprScoreIter = pprScoresByNodeId.find(nodeId);
+            const auto pprScoreIter = pprScoresByNodeId.find(nodeId);
             double pprScore = (pprScoreIter != pprScoresByNodeId.end()) ? pprScoreIter->second : 0.0;
             double outputScore = pprScore + residual;
             residualPairs.emplace_back(nodeId, outputScore);

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -266,11 +266,113 @@ void PPRForwardPush::pushResiduals(
     }
 }
 
+// Helper function for selecting one seed/node-type's finalized PPR rows.
+//
+// Inputs:
+//   nodeTypeState: finalized PPR scores and residuals for one seed/node type.
+//   finalizedPPRNodeLimit: maximum finalized-PPR rows to select before top-up.
+//
+// Expected output: (node_id, raw_ppr_score) pairs selected by raw PPR score.
+// The order is unspecified; callers that emit these directly should sort the
+// returned vector before writing output tensors.
+static std::vector<std::pair<int32_t, double>> selectFinalizedPPRPairs(const SeedNodeTypeState& nodeTypeState,
+                                                                       int32_t finalizedPPRNodeLimit) {
+    const auto& scores = nodeTypeState.pprScores;
+    const auto higherScore = [](const auto& a, const auto& b) { return a.second > b.second; };
+
+    const int32_t pprTopK = std::min(finalizedPPRNodeLimit, static_cast<int32_t>(scores.size()));
+    std::vector<std::pair<int32_t, double>> selectedPairs;
+    selectedPairs.reserve(static_cast<size_t>(pprTopK));
+    if (pprTopK > 0) {
+        std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
+        if (pprTopK < static_cast<int32_t>(scorePairs.size())) {
+            std::nth_element(scorePairs.begin(), scorePairs.begin() + pprTopK, scorePairs.end(), higherScore);
+        }
+
+        for (int32_t rankIdx = 0; rankIdx < pprTopK; ++rankIdx) {
+            selectedPairs.emplace_back(scorePairs[rankIdx].first, scorePairs[rankIdx].second);
+        }
+    }
+
+    return selectedPairs;
+}
+
+// Helper function for extending one seed/node-type's selected PPR rows with
+// residual top-up candidates.
+//
+// Inputs:
+//   nodeTypeState: finalized PPR scores and residuals for one seed/node type.
+//   selectedPairs: mutable finalized-PPR rows already selected for this seed.
+//   sequenceLength: maximum total rows after residual top-up.
+//
+// Expected output: selectedPairs has up to sequenceLength rows after appending
+// highest-scoring residual candidates that are not already selected. This helper
+// does not sort selectedPairs; callers sort only when their output needs it.
+static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
+                                     std::vector<std::pair<int32_t, double>>& selectedPairs,
+                                     int32_t sequenceLength) {
+    const int32_t residualTopUpBudget =
+        std::max<int32_t>(0, sequenceLength - static_cast<int32_t>(selectedPairs.size()));
+    if (residualTopUpBudget > 0) {
+        const auto& scores = nodeTypeState.pprScores;
+        const auto higherScore = [](const auto& a, const auto& b) { return a.second > b.second; };
+        std::unordered_set<int32_t> selectedPPRNodeIds;
+        selectedPPRNodeIds.reserve(selectedPairs.size());
+        for (const auto& selectedPair : selectedPairs) {
+            selectedPPRNodeIds.insert(selectedPair.first);
+        }
+
+        std::vector<std::pair<int32_t, double>> residualPairs;
+        residualPairs.reserve(nodeTypeState.residuals.size());
+        for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
+            if (residual <= 0.0 || selectedPPRNodeIds.find(nodeId) != selectedPPRNodeIds.end()) {
+                continue;
+            }
+
+            auto scoreIter = scores.find(nodeId);
+            double pprScore = (scoreIter != scores.end()) ? scoreIter->second : 0.0;
+            double outputScore = pprScore + residual;
+            residualPairs.emplace_back(nodeId, outputScore);
+        }
+
+        const int32_t residualTopK = std::min(residualTopUpBudget, static_cast<int32_t>(residualPairs.size()));
+        if (residualTopK > 0) {
+            if (residualTopK < static_cast<int32_t>(residualPairs.size())) {
+                std::nth_element(
+                    residualPairs.begin(), residualPairs.begin() + residualTopK, residualPairs.end(), higherScore);
+            }
+
+            for (int32_t rankIdx = 0; rankIdx < residualTopK; ++rankIdx) {
+                selectedPairs.emplace_back(residualPairs[rankIdx].first, residualPairs[rankIdx].second);
+            }
+        }
+    }
+}
+
+// Helper function for moving finalized-PPR rows onto the same score scale as
+// residual top-up rows.
+//
+// Inputs:
+//   nodeTypeState: residual table for one seed/node type.
+//   selectedPairs: mutable finalized-PPR rows with raw PPR scores.
+//
+// Expected output: selectedPairs scores are updated in-place to
+// ppr_score + residual(node) when residual mass exists for that node.
+static void addResidualMassToPPRPairs(const SeedNodeTypeState& nodeTypeState,
+                                      std::vector<std::pair<int32_t, double>>& selectedPairs) {
+    for (auto& [nodeId, score] : selectedPairs) {
+        auto residualIter = nodeTypeState.residuals.find(nodeId);
+        if (residualIter != nodeTypeState.residuals.end()) {
+            score += residualIter->second;
+        }
+    }
+}
+
 std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> PPRForwardPush::
     extractTopKWithResidualTopUp(int32_t maxPPRNodes, bool enableResidualTopUp) {
     TORCH_CHECK(maxPPRNodes >= 0, "maxPPRNodes must be non-negative, got ", maxPPRNodes, ".");
 
-    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> result;
+    std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>> extractedPPRByNodeTypeId;
     // Emit an entry for every node type, even if unreachable in this batch (empty tensors,
     // all-zero valid_counts).  This keeps the output shape consistent across batches so
     // downstream model architectures see a fixed set of PPR edge types every iteration.
@@ -281,83 +383,20 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
 
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
             const auto& nodeTypeState = _state[seedIdx][nodeTypeId];
-            const auto& scores = nodeTypeState.pprScores;
-            const auto higherScore = [](const auto& a, const auto& b) { return a.second > b.second; };
-
-            const int32_t topK = std::min(maxPPRNodes, static_cast<int32_t>(scores.size()));
-            const int32_t residualTopUpBudget = enableResidualTopUp ? maxPPRNodes - topK : 0;
-            std::vector<std::pair<int32_t, double>> selectedPairs;
-            selectedPairs.reserve(static_cast<size_t>(topK) + static_cast<size_t>(residualTopUpBudget));
-            std::unordered_set<int32_t> selectedPPRNodeIds;
-            if (topK > 0) {
-                if (residualTopUpBudget > 0) {
-                    selectedPPRNodeIds.reserve(static_cast<size_t>(topK));
-                }
-                std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
-                // Selection is intentionally two-phase: finalized nodes are selected
-                // first by raw PPR score, and residual candidates only compete for
-                // the remaining budget.
-                if (enableResidualTopUp) {
-                    // The final emitted order is sorted by ppr_score + residual
-                    // after top-up candidates are selected, so this pass only
-                    // needs to partition out the raw-PPR top K.
-                    if (topK < static_cast<int32_t>(scorePairs.size())) {
-                        std::nth_element(scorePairs.begin(), scorePairs.begin() + topK, scorePairs.end(), higherScore);
-                    }
-                } else {
-                    std::partial_sort(scorePairs.begin(), scorePairs.begin() + topK, scorePairs.end(), higherScore);
-                }
-
-                for (int32_t rankIdx = 0; rankIdx < topK; ++rankIdx) {
-                    int32_t nodeId = scorePairs[rankIdx].first;
-                    double outputScore = scorePairs[rankIdx].second;
-                    if (enableResidualTopUp) {
-                        auto residualIter = nodeTypeState.residuals.find(nodeId);
-                        if (residualIter != nodeTypeState.residuals.end()) {
-                            outputScore += residualIter->second;
-                        }
-                    }
-                    selectedPairs.emplace_back(nodeId, outputScore);
-                    if (residualTopUpBudget > 0) {
-                        selectedPPRNodeIds.insert(nodeId);
-                    }
-                }
+            auto selectedPairs = selectFinalizedPPRPairs(nodeTypeState, maxPPRNodes);
+            if (enableResidualTopUp) {
+                addResidualMassToPPRPairs(nodeTypeState, selectedPairs);
+                appendResidualTopUpPairs(nodeTypeState, selectedPairs, maxPPRNodes);
             }
 
-            if (residualTopUpBudget > 0) {
-                std::vector<std::pair<int32_t, double>> residualPairs;
-                residualPairs.reserve(nodeTypeState.residuals.size());
-                for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
-                    if (residual <= 0.0 || selectedPPRNodeIds.find(nodeId) != selectedPPRNodeIds.end()) {
-                        continue;
-                    }
-
-                    auto scoreIter = scores.find(nodeId);
-                    double pprScore = (scoreIter != scores.end()) ? scoreIter->second : 0.0;
-                    double outputScore = pprScore + residual;
-                    residualPairs.emplace_back(nodeId, outputScore);
-                }
-
-                const int32_t residualTopK = std::min(residualTopUpBudget, static_cast<int32_t>(residualPairs.size()));
-                if (residualTopK > 0) {
-                    // Residual candidates only need selection here; selected
-                    // finalized and residual rows are sorted together below.
-                    if (residualTopK < static_cast<int32_t>(residualPairs.size())) {
-                        std::nth_element(residualPairs.begin(),
-                                         residualPairs.begin() + residualTopK,
-                                         residualPairs.end(),
-                                         higherScore);
-                    }
-
-                    for (int32_t rankIdx = 0; rankIdx < residualTopK; ++rankIdx) {
-                        selectedPairs.emplace_back(residualPairs[rankIdx].first, residualPairs[rankIdx].second);
-                    }
-                }
-            }
-
-            if (enableResidualTopUp && selectedPairs.size() > 1) {
+            // Empty and singleton outputs are already ordered. Multi-row outputs can
+            // be unordered because the selection helpers use nth_element, so sort once
+            // to rank emitted rows by the score returned to callers.
+            if (selectedPairs.size() > 1) {
+                const auto higherScore = [](const auto& a, const auto& b) { return a.second > b.second; };
                 std::sort(selectedPairs.begin(), selectedPairs.end(), higherScore);
             }
+
             for (const auto& [nodeId, score] : selectedPairs) {
                 flatIds.push_back(static_cast<int64_t>(nodeId));
                 flatWeights.push_back(score);
@@ -365,11 +404,11 @@ std::unordered_map<int32_t, std::tuple<torch::Tensor, torch::Tensor, torch::Tens
             validCounts.push_back(static_cast<int64_t>(selectedPairs.size()));
         }
 
-        result[nodeTypeId] = {torch::tensor(flatIds, torch::kLong),
-                              torch::tensor(flatWeights, torch::kDouble),
-                              torch::tensor(validCounts, torch::kLong)};
+        extractedPPRByNodeTypeId[nodeTypeId] = {torch::tensor(flatIds, torch::kLong),
+                                                torch::tensor(flatWeights, torch::kDouble),
+                                                torch::tensor(validCounts, torch::kLong)};
     }
-    return result;
+    return extractedPPRByNodeTypeId;
 }
 
 int32_t PPRForwardPush::getTotalDegree(int32_t nodeId, int32_t nodeTypeId) const {


### PR DESCRIPTION
### Description

This PR refactors PPR extraction by moving the existing inline finalized-PPR selection and residual top-up logic into smaller C++ helpers.

The extraction behavior is intended to stay the same, but the implementation is now split into reusable pieces:

- `selectFinalizedPPRPairs`: selects finalized PPR candidates by raw PPR score
- `addResidualMassToPPRPairs`: adds residual mass to selected finalized PPR candidates when residual top-up is enabled
- `appendResidualTopUpPairs`: appends residual candidates into remaining sequence slots

These helpers replace logic that previously lived directly inside `extractTopKWithResidualTopUp`. The untyped extraction path still owns final output assembly and sorting, but the lower-level pieces can now be reused by the typed-channel PPR extraction work in the stacked PR.

No functional change is intended.

### Performance

This refactor should be mostly performance-neutral, if not slightly faster.

The main algorithmic work is the same as before: scan finalized PPR scores, select finalized top-k candidates, optionally scan residuals for top-up candidates, add residual mass to selected finalized candidates, append top-up rows, and sort the emitted rows. The PR mostly moves those existing steps into named helpers.

One small implementation detail changes: finalized PPR selection now uses `nth_element` followed by a final sort of the selected output rows, instead of relying on `partial_sort` in the non-top-up path. This avoids ordering intermediate candidates before we know the final emitted set. The asymptotic behavior is unchanged for the final output, but this can save some unnecessary ordering work, so any runtime difference should skew neutral-to-slightly-faster rather than slower.

### Testing

- `make -C gigl-core format_cpp`
- `git diff --check`
- `uv run ty check .github/scripts examples gigl tests snapchat scripts`
- `make -C gigl-core unit_test_cpp`