### PR TITLE
Add PPR min-hop edge attribute

### DIFF
--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -468,15 +468,15 @@ static void addResidualMassToPPRPairs(const SeedNodeTypeState& nodeTypeState,
     }
 }
 
-static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nodeId) {
+static double getNodeHopProximity(const SeedNodeTypeState& nodeTypeState, int32_t nodeId) {
     auto residualStateIter = nodeTypeState.residualStates.find(nodeId);
     TORCH_CHECK(residualStateIter != nodeTypeState.residualStates.end(),
                 "PPR extraction expected a discovered hop for emitted node ",
                 nodeId,
                 ".");
-    int32_t minHop = residualStateIter->second.minHop;
-    TORCH_CHECK(minHop >= 0, "PPR min-hop must be non-negative, got ", minHop, ".");
-    return minHop;
+    int32_t hop = residualStateIter->second.minHop;
+    TORCH_CHECK(hop >= 0, "PPR discovered hop must be non-negative, got ", hop, ".");
+    return 1.0 / (1.0 + static_cast<double>(hop));
 }
 
 // Owns the packed edge_attr layout used while merging typed PPR channels.
@@ -488,7 +488,7 @@ static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nod
 //
 // The width is 2 + (3 * numChannels):
 //   - 2 global columns:
-//       [best_score, min_hop]
+//       [best_score, hop_proximity]
 //     These preserve the regular PPR edge_attr contract at the front of the row.
 //   - 3 columns per typed channel:
 //       [channel_score, channel_hop_proximity, channel_presence]
@@ -496,7 +496,7 @@ static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nod
 //     hop proximity gives models a bounded closeness signal, and the presence bit
 //     is the explicit channel-reachability mask.
 //
-// Channel hop proximity is 1 / (1 + min_hop) when a channel reaches the node:
+// Hop proximity is 1 / (1 + hop) when a channel reaches the node:
 // anchor=1.0, 1-hop=0.5, 2-hop ~= 0.333, and so on. Missing channels remain 0,
 // which is finite, bounded, and never looks closer than a reached channel. For
 // present channels, callers can recover the original hop count as
@@ -512,39 +512,31 @@ public:
         return kNumGlobalFeatures + (kNumPerChannelFeatures * _numChannels);
     }
 
-    // New node feature vectors start empty. All columns can start at 0 because
-    // the first channel write initializes the global min-hop before any
-    // cross-channel min comparison is needed.
+    // New node feature vectors start empty. Scores, proximities, and presence
+    // bits all use 0 as their absent-channel value.
     [[nodiscard]] std::vector<double> makeFeatureVector() const {
         return std::vector<double>(numFeatures(), 0.0);
     }
 
-    // Merge one channel's emitted score/hop into an existing node feature row.
+    // Merge one channel's emitted score/proximity into an existing node feature row.
     //
     // A node can be seen in multiple typed channels. The scalar score column keeps
     // the best emitted PPR score for downstream consumers that expect one weight,
-    // while the global hop keeps the nearest discovered distance.
-    void updateScores(std::vector<double>& features,
-                      int32_t channelIndex,
-                      double score,
-                      int32_t minHop,
-                      bool isFirstChannelForNode) const {
-        // The extraction loop bounds channelIndex, and getNodeMinHop validates
-        // minHop before this call. Avoid duplicating those checks per candidate.
-        const double hopFeature = static_cast<double>(minHop);
+    // while the global proximity keeps the closest discovered distance.
+    void updateScores(std::vector<double>& features, int32_t channelIndex, double score, double hopProximity) const {
+        // The extraction loop bounds channelIndex, and getNodeHopProximity
+        // validates the underlying hop before this call.
         features[kBestScoreIndex] = std::max(features[kBestScoreIndex], score);
-        if (isFirstChannelForNode || hopFeature < features[kGlobalMinHopIndex]) {
-            features[kGlobalMinHopIndex] = hopFeature;
-        }
+        features[kGlobalHopProximityIndex] = std::max(features[kGlobalHopProximityIndex], hopProximity);
         features[channelScoreIndex(channelIndex)] = score;
-        features[channelHopProximityIndex(channelIndex)] = 1.0 / (1.0 + hopFeature);
+        features[channelHopProximityIndex(channelIndex)] = hopProximity;
         features[channelPresenceIndex(channelIndex)] = 1.0;
     }
 
 private:
     static constexpr int32_t kBestScoreIndex = 0;
-    static constexpr int32_t kGlobalMinHopIndex = 1;
-    static constexpr int32_t kNumGlobalFeatures = 2;     // best score + global min-hop
+    static constexpr int32_t kGlobalHopProximityIndex = 1;
+    static constexpr int32_t kNumGlobalFeatures = 2;     // best score + global hop proximity
     static constexpr int32_t kNumPerChannelFeatures = 3; // score + hop proximity + presence
 
     [[nodiscard]] int32_t channelScoreIndex(int32_t channelIndex) const {
@@ -599,8 +591,7 @@ static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int
 
     for (const auto& [nodeId, score] : nodesAndScores) {
         auto scoreIter = outputScoresByNodeId.find(nodeId);
-        const bool isFirstChannelForNode = scoreIter == outputScoresByNodeId.end();
-        if (isFirstChannelForNode) {
+        if (scoreIter == outputScoresByNodeId.end()) {
             scoreIter = outputScoresByNodeId.emplace(nodeId, featureLayout.makeFeatureVector()).first;
         }
         auto& scoreFeatures = scoreIter->second;
@@ -608,8 +599,7 @@ static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int
         // Record this node's score for the current channel and mark that the
         // channel reached the node. Current extraction emits one row per node
         // per channel, so no intra-channel merge is needed here.
-        featureLayout.updateScores(
-            scoreFeatures, channelIndex, score, getNodeMinHop(nodeTypeState, nodeId), isFirstChannelForNode);
+        featureLayout.updateScores(scoreFeatures, channelIndex, score, getNodeHopProximity(nodeTypeState, nodeId));
 
         // Keep a per-channel sortable candidate list so target counts can be
         // applied after cross-channel attribution.
@@ -797,7 +787,7 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPPRNode
             for (const auto& [nodeId, score] : selectedPairs) {
                 flatIds.push_back(static_cast<int64_t>(nodeId));
                 flatFeatureValues.push_back(score);
-                flatFeatureValues.push_back(static_cast<double>(getNodeMinHop(nodeTypeState, nodeId)));
+                flatFeatureValues.push_back(getNodeHopProximity(nodeTypeState, nodeId));
             }
             validCounts.push_back(static_cast<int64_t>(selectedPairs.size()));
         }
@@ -835,12 +825,11 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
     // Typed edge_attr feature width is 2 + 3C:
     //   column 0: best emitted PPR score across channels, used as the scalar
     //             PPR weight by downstream ranking/sequence construction.
-    //   column 1: global minimum discovered-hop count as 0=anchor,
-    //             1=1-hop, 2=2-hop, and so on.
+    //   column 1: global hop proximity as 1/(1 + closest_hop).
     //   columns [2, 2 + C): emitted PPR score for each channel.
     //   columns [2 + C, 2 + 2C): hop proximity for each channel:
-    //                             1/(1 + min_hop) when present, 0 when missing.
-    //                             For present channels, min_hop can be recovered
+    //                             1/(1 + hop) when present, 0 when missing.
+    //                             For present channels, hop can be recovered
     //                             as (1 - proximity) / proximity; use the
     //                             presence bit before applying this inverse.
     //   columns [2 + 2C, 2 + 3C): presence bit for each channel.

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -15,7 +15,7 @@
 
 namespace gigl {
 
-static constexpr double kUnsetTypedPPRChannelHop = -1.0;
+static constexpr double kUnsetTypedPPRMinHop = -1.0;
 
 // Pack (node_id, etype_id) into a single uint64 for use as a hash key.
 // Inputs are cast through uint32_t to avoid sign-extension of negative int32 values.
@@ -493,17 +493,17 @@ static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nod
 //       [best_score, min_hop]
 //     These preserve the regular PPR edge_attr contract at the front of the row.
 //   - 3 columns per typed channel:
-//       [channel_score, channel_min_hop, channel_presence]
+//       [channel_score, channel_hop_proximity, channel_presence]
 //     The per-channel score supports channel attribution/ranking, the per-channel
-//     hop exposes how far that channel had to walk, and the presence bit is the
-//     explicit channel-reachability mask.
+//     hop proximity gives models a bounded closeness signal, and the presence bit
+//     is the explicit channel-reachability mask.
 //
-// Scores and presence bits naturally default to 0. Channel min-hop columns use
-// an internal -1 marker while channels are merged; that marker is never emitted.
-// Before output, missing channel-hop values are replaced with one past the
-// farthest channel that did reach this node. That keeps the emitted scalar finite
-// and on the "farther" side of every valid channel hop, without introducing
-// inf/NaN into model input.
+// Channel hop proximity is 1 / (1 + min_hop) when a channel reaches the node:
+// anchor=1.0, 1-hop=0.5, 2-hop ~= 0.333, and so on. Missing channels remain 0,
+// which is finite, bounded, and never looks closer than a reached channel. For
+// present channels, callers can recover the original hop count as
+// (1 - proximity) / proximity; use the presence bit before applying this
+// inverse because proximity 0 means the channel is missing.
 class TypedPPRFeatureLayout {
 public:
     explicit TypedPPRFeatureLayout(int32_t numChannels) : _numChannels(numChannels) {
@@ -514,15 +514,12 @@ public:
         return kNumGlobalFeatures + (kNumPerChannelFeatures * _numChannels);
     }
 
-    // New node feature vectors start empty. The global min-hop is also marked
-    // missing until the first channel writes it, which lets updateScores use the
-    // same min-update path for both global and per-channel hop fields.
+    // New node feature vectors start empty. The global min-hop is marked missing
+    // until the first channel writes it, while channel scores, proximities, and
+    // presence bits naturally use 0 as their absent-channel value.
     [[nodiscard]] std::vector<double> makeFeatureVector() const {
         std::vector<double> features(numFeatures(), 0.0);
-        features[kGlobalMinHopIndex] = kUnsetTypedPPRChannelHop;
-        std::fill(features.begin() + channelHopStartIndex(),
-                  features.begin() + channelPresenceStartIndex(),
-                  kUnsetTypedPPRChannelHop);
+        features[kGlobalMinHopIndex] = kUnsetTypedPPRMinHop;
         return features;
     }
 
@@ -530,7 +527,7 @@ public:
     //
     // A node can be seen in multiple typed channels. The scalar score column keeps
     // the best emitted PPR score for downstream consumers that expect one weight,
-    // while hop columns keep the nearest discovered distance.
+    // while the global hop keeps the nearest discovered distance.
     void updateScores(std::vector<double>& features, int32_t channelIndex, double score, int32_t minHop) const {
         // The extraction loop bounds channelIndex, and getNodeMinHop validates
         // minHop before this call. Avoid duplicating those checks per candidate.
@@ -538,59 +535,24 @@ public:
         features[kBestScoreIndex] = std::max(features[kBestScoreIndex], score);
         updateMinHop(features[kGlobalMinHopIndex], hopFeature);
         features[channelScoreIndex(channelIndex)] = score;
-        updateMinHop(features[channelHopIndex(channelIndex)], hopFeature);
+        features[channelHopProximityIndex(channelIndex)] = 1.0 / (1.0 + hopFeature);
         features[channelPresenceIndex(channelIndex)] = 1.0;
-    }
-
-    // Append the feature row using model-facing values. The internal -1 marker is
-    // useful while merging channels, but as a scalar feature it would look closer
-    // than anchor hop 0. Missing channel hops are emitted as max_present_hop + 1
-    // for this node, with the presence bit still carrying the exact mask.
-    void appendOutputFeatures(std::vector<double>& outputFeatureValues, const std::vector<double>& features) const {
-        const auto outputStartIndex = outputFeatureValues.size();
-        outputFeatureValues.insert(outputFeatureValues.end(), features.begin(), features.end());
-
-        double maxPresentChannelHop = kUnsetTypedPPRChannelHop;
-        bool hasMissingChannelHop = false;
-        const int32_t channelHopStart = channelHopStartIndex();
-        const int32_t channelPresenceStart = channelPresenceStartIndex();
-        for (int32_t featureIndex = channelHopStart; featureIndex < channelPresenceStart; ++featureIndex) {
-            const double channelHop = features[featureIndex];
-            if (channelHop == kUnsetTypedPPRChannelHop) {
-                hasMissingChannelHop = true;
-            } else {
-                maxPresentChannelHop = std::max(maxPresentChannelHop, channelHop);
-            }
-        }
-
-        if (!hasMissingChannelHop) {
-            return;
-        }
-        TORCH_CHECK(maxPresentChannelHop != kUnsetTypedPPRChannelHop,
-                    "Typed PPR output feature row has no present channel hop.");
-        const double missingChannelHopFeature = maxPresentChannelHop + 1.0;
-        for (int32_t featureIndex = channelHopStart; featureIndex < channelPresenceStart; ++featureIndex) {
-            const auto outputFeatureIndex = outputStartIndex + static_cast<size_t>(featureIndex);
-            if (outputFeatureValues[outputFeatureIndex] == kUnsetTypedPPRChannelHop) {
-                outputFeatureValues[outputFeatureIndex] = missingChannelHopFeature;
-            }
-        }
     }
 
 private:
     static constexpr int32_t kBestScoreIndex = 0;
     static constexpr int32_t kGlobalMinHopIndex = 1;
     static constexpr int32_t kNumGlobalFeatures = 2;     // best score + global min-hop
-    static constexpr int32_t kNumPerChannelFeatures = 3; // score + min-hop + presence
+    static constexpr int32_t kNumPerChannelFeatures = 3; // score + hop proximity + presence
 
     [[nodiscard]] int32_t channelScoreIndex(int32_t channelIndex) const {
         return kNumGlobalFeatures + channelIndex;
     }
-    [[nodiscard]] int32_t channelHopStartIndex() const {
+    [[nodiscard]] int32_t channelHopProximityStartIndex() const {
         return kNumGlobalFeatures + _numChannels;
     }
-    [[nodiscard]] int32_t channelHopIndex(int32_t channelIndex) const {
-        return channelHopStartIndex() + channelIndex;
+    [[nodiscard]] int32_t channelHopProximityIndex(int32_t channelIndex) const {
+        return channelHopProximityStartIndex() + channelIndex;
     }
     [[nodiscard]] int32_t channelPresenceStartIndex() const {
         return kNumGlobalFeatures + (2 * _numChannels);
@@ -600,7 +562,7 @@ private:
     }
 
     static void updateMinHop(double& currentMinHopFeature, double hopFeature) {
-        if (currentMinHopFeature == kUnsetTypedPPRChannelHop || hopFeature < currentMinHopFeature) {
+        if (currentMinHopFeature == kUnsetTypedPPRMinHop || hopFeature < currentMinHopFeature) {
             currentMinHopFeature = hopFeature;
         }
     }
@@ -626,8 +588,8 @@ private:
 //   outputScoresByNodeId: mutable map from node ID to emitted edge_attr features.
 //   channelOutputCandidates: mutable sortable candidates for target-count selection.
 //
-// Expected output: outputScoresByNodeId has this channel's score/presence
-// features merged in, and channelOutputCandidates contains this channel's
+// Expected output: outputScoresByNodeId has this channel's score, proximity,
+// and presence features merged in, and channelOutputCandidates contains this channel's
 // candidates on the emitted PPR score scale.
 static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int32_t, double>>& nodesAndScores,
                                                  const SeedNodeTypeState& nodeTypeState,
@@ -878,9 +840,11 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
     //   column 1: global minimum discovered-hop count as 0=anchor,
     //             1=1-hop, 2=2-hop, and so on.
     //   columns [2, 2 + C): emitted PPR score for each channel.
-    //   columns [2 + C, 2 + 2C): minimum discovered-hop count for each channel,
-    //                             or max-present-channel-hop + 1 when that channel
-    //                             did not reach the node.
+    //   columns [2 + C, 2 + 2C): hop proximity for each channel:
+    //                             1/(1 + min_hop) when present, 0 when missing.
+    //                             For present channels, min_hop can be recovered
+    //                             as (1 - proximity) / proximity; use the
+    //                             presence bit before applying this inverse.
     //   columns [2 + 2C, 2 + 3C): presence bit for each channel.
     TypedPPRFeatureLayout featureLayout(numChannels);
     int32_t numEdgeAttrFeatures = featureLayout.numFeatures();
@@ -930,7 +894,7 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
             for (int32_t nodeId : selectedNodes) {
                 flatIds.push_back(static_cast<int64_t>(nodeId));
                 const auto& features = outputScores.at(nodeId);
-                featureLayout.appendOutputFeatures(flatFeatureValues, features);
+                flatFeatureValues.insert(flatFeatureValues.end(), features.begin(), features.end());
             }
 
             validCounts.push_back(static_cast<int64_t>(selectedNodeCount));

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -15,7 +15,7 @@
 
 namespace gigl {
 
-static constexpr double kMissingTypedPPRChannelHop = -1.0;
+static constexpr double kUnsetTypedPPRChannelHop = -1.0;
 
 // Pack (node_id, etype_id) into a single uint64 for use as a hash key.
 // Inputs are cast through uint32_t to avoid sign-extension of negative int32 values.
@@ -499,8 +499,11 @@ static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nod
 //     explicit channel-reachability mask.
 //
 // Scores and presence bits naturally default to 0. Channel min-hop columns use
-// -1 for "channel did not reach this node" so missing channels are distinct from
-// the anchor hop 0.
+// an internal -1 marker while channels are merged; that marker is never emitted.
+// Before output, missing channel-hop values are replaced with one past the
+// farthest channel that did reach this node. That keeps the emitted scalar finite
+// and on the "farther" side of every valid channel hop, without introducing
+// inf/NaN into model input.
 class TypedPPRFeatureLayout {
 public:
     explicit TypedPPRFeatureLayout(int32_t numChannels) : _numChannels(numChannels) {
@@ -516,10 +519,10 @@ public:
     // same min-update path for both global and per-channel hop fields.
     [[nodiscard]] std::vector<double> makeFeatureVector() const {
         std::vector<double> features(numFeatures(), 0.0);
-        features[kGlobalMinHopIndex] = kMissingTypedPPRChannelHop;
+        features[kGlobalMinHopIndex] = kUnsetTypedPPRChannelHop;
         std::fill(features.begin() + channelHopStartIndex(),
                   features.begin() + channelPresenceStartIndex(),
-                  kMissingTypedPPRChannelHop);
+                  kUnsetTypedPPRChannelHop);
         return features;
     }
 
@@ -537,6 +540,41 @@ public:
         features[channelScoreIndex(channelIndex)] = score;
         updateMinHop(features[channelHopIndex(channelIndex)], hopFeature);
         features[channelPresenceIndex(channelIndex)] = 1.0;
+    }
+
+    // Append the feature row using model-facing values. The internal -1 marker is
+    // useful while merging channels, but as a scalar feature it would look closer
+    // than anchor hop 0. Missing channel hops are emitted as max_present_hop + 1
+    // for this node, with the presence bit still carrying the exact mask.
+    void appendOutputFeatures(std::vector<double>& outputFeatureValues, const std::vector<double>& features) const {
+        const auto outputStartIndex = outputFeatureValues.size();
+        outputFeatureValues.insert(outputFeatureValues.end(), features.begin(), features.end());
+
+        double maxPresentChannelHop = kUnsetTypedPPRChannelHop;
+        bool hasMissingChannelHop = false;
+        const int32_t channelHopStart = channelHopStartIndex();
+        const int32_t channelPresenceStart = channelPresenceStartIndex();
+        for (int32_t featureIndex = channelHopStart; featureIndex < channelPresenceStart; ++featureIndex) {
+            const double channelHop = features[featureIndex];
+            if (channelHop == kUnsetTypedPPRChannelHop) {
+                hasMissingChannelHop = true;
+            } else {
+                maxPresentChannelHop = std::max(maxPresentChannelHop, channelHop);
+            }
+        }
+
+        if (!hasMissingChannelHop) {
+            return;
+        }
+        TORCH_CHECK(maxPresentChannelHop != kUnsetTypedPPRChannelHop,
+                    "Typed PPR output feature row has no present channel hop.");
+        const double missingChannelHopFeature = maxPresentChannelHop + 1.0;
+        for (int32_t featureIndex = channelHopStart; featureIndex < channelPresenceStart; ++featureIndex) {
+            const auto outputFeatureIndex = outputStartIndex + static_cast<size_t>(featureIndex);
+            if (outputFeatureValues[outputFeatureIndex] == kUnsetTypedPPRChannelHop) {
+                outputFeatureValues[outputFeatureIndex] = missingChannelHopFeature;
+            }
+        }
     }
 
 private:
@@ -562,7 +600,7 @@ private:
     }
 
     static void updateMinHop(double& currentMinHopFeature, double hopFeature) {
-        if (currentMinHopFeature == kMissingTypedPPRChannelHop || hopFeature < currentMinHopFeature) {
+        if (currentMinHopFeature == kUnsetTypedPPRChannelHop || hopFeature < currentMinHopFeature) {
             currentMinHopFeature = hopFeature;
         }
     }
@@ -841,7 +879,8 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
     //             1=1-hop, 2=2-hop, and so on.
     //   columns [2, 2 + C): emitted PPR score for each channel.
     //   columns [2 + C, 2 + 2C): minimum discovered-hop count for each channel,
-    //                             or -1 when that channel did not reach the node.
+    //                             or max-present-channel-hop + 1 when that channel
+    //                             did not reach the node.
     //   columns [2 + 2C, 2 + 3C): presence bit for each channel.
     TypedPPRFeatureLayout featureLayout(numChannels);
     int32_t numEdgeAttrFeatures = featureLayout.numFeatures();
@@ -891,7 +930,7 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
             for (int32_t nodeId : selectedNodes) {
                 flatIds.push_back(static_cast<int64_t>(nodeId));
                 const auto& features = outputScores.at(nodeId);
-                flatFeatureValues.insert(flatFeatureValues.end(), features.begin(), features.end());
+                featureLayout.appendOutputFeatures(flatFeatureValues, features);
             }
 
             validCounts.push_back(static_cast<int64_t>(selectedNodeCount));

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -90,6 +90,7 @@ PPRForwardPush::PPRForwardPush(const torch::Tensor& seedNodes,
         // restart probability).  The first push will move alpha into ppr_score
         // and distribute (1-alpha)*alpha to the seed's neighbors.
         _state[seedIdx][seedNodeTypeId].residuals[seedNodeId] = _alpha;
+        _state[seedIdx][seedNodeTypeId].minHops[seedNodeId] = 0;
         _state[seedIdx][seedNodeTypeId].queue.insert(seedNodeId);
     }
 }
@@ -278,6 +279,8 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
             for (int32_t sourceNodeId : srcNodeTypeState.queuedNodes) {
                 auto residualIter = srcNodeTypeState.residuals.find(sourceNodeId);
                 double sourceResidual = (residualIter != srcNodeTypeState.residuals.end()) ? residualIter->second : 0.0;
+                auto sourceHopIter = srcNodeTypeState.minHops.find(sourceNodeId);
+                int32_t sourceHop = sourceHopIter != srcNodeTypeState.minHops.end() ? sourceHopIter->second : 0;
 
                 // a. Absorb: move residual into the PPR score.
                 srcNodeTypeState.pprScores[sourceNodeId] += sourceResidual;
@@ -331,6 +334,11 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
                     auto& dstNodeTypeState = _state[seedIdx][dstNodeTypeId];
                     for (int32_t neighborNodeId : neighborList->get()) {
                         dstNodeTypeState.residuals[neighborNodeId] += residualPerNeighbor;
+                        int32_t neighborHop = sourceHop + 1;
+                        auto [hopIter, inserted] = dstNodeTypeState.minHops.emplace(neighborNodeId, neighborHop);
+                        if (!inserted && neighborHop < hopIter->second) {
+                            hopIter->second = neighborHop;
+                        }
 
                         double threshold = _requeueThresholdFactor *
                                            static_cast<double>(getTotalDegree(neighborNodeId, dstNodeTypeId));
@@ -455,6 +463,20 @@ static void addResidualMassToPPRPairs(const SeedNodeTypeState& nodeTypeState,
     }
 }
 
+static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nodeId) {
+    auto hopIter = nodeTypeState.minHops.find(nodeId);
+    TORCH_CHECK(hopIter != nodeTypeState.minHops.end(),
+                "PPR extraction expected a discovered hop for emitted node ",
+                nodeId,
+                ".");
+    return hopIter->second;
+}
+
+static double getHopFeature(int32_t minHop) {
+    TORCH_CHECK(minHop >= 0, "PPR min-hop must be non-negative, got ", minHop, ".");
+    return static_cast<double>(minHop);
+}
+
 // Helper function for adding one channel's extracted PPR candidates into the
 // emitted typed feature table and a selection candidate list.
 //
@@ -465,8 +487,10 @@ static void addResidualMassToPPRPairs(const SeedNodeTypeState& nodeTypeState,
 //
 // Inputs:
 //   nodesAndScores: extracted (node_id, score) candidates for one channel.
+//   nodeTypeState: completed PPR state for this seed/node-type/channel.
 //   channelIndex: index of the typed PPR channel being added.
 //   numChannels: total typed PPR channels, used to derive feature width.
+//   numEdgeAttrFeatures: total typed edge-attribute width for this extraction.
 //   outputScoresByNodeId: mutable map from node ID to emitted edge_attr features.
 //   channelOutputCandidates: mutable sortable candidates for target-count selection.
 //
@@ -474,39 +498,49 @@ static void addResidualMassToPPRPairs(const SeedNodeTypeState& nodeTypeState,
 // features merged in, and channelOutputCandidates contains this channel's
 // candidates on the emitted PPR score scale.
 static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int32_t, double>>& nodesAndScores,
+                                                 const SeedNodeTypeState& nodeTypeState,
                                                  int32_t channelIndex,
                                                  int32_t numChannels,
+                                                 int32_t numEdgeAttrFeatures,
                                                  std::unordered_map<int32_t, std::vector<double>>& outputScoresByNodeId,
                                                  std::vector<std::pair<int32_t, double>>& channelOutputCandidates) {
     if (nodesAndScores.empty()) {
         return;
     }
 
-    // Feature width is 1 + 2C:
+    // Feature width is 2 + 2C:
     //   column 0: best emitted PPR score across channels, used as the scalar
     //             PPR weight by downstream ranking/sequence construction. This
     //             stays on the same score scale as untyped PPR output.
-    //   columns [1, C]: emitted PPR score for each channel.
-    //   columns [1 + C, 1 + 2C): presence bit for each channel.
-    int32_t numEdgeAttrFeatures = 1 + (2 * numChannels);
+    //   column 1: global minimum discovered-hop count as 0=anchor,
+    //             1=1-hop, 2=2-hop, and so on.
+    //   columns [2, 2 + C): emitted PPR score for each channel.
+    //   columns [2 + C, 2 + 2C): presence bit for each channel.
     for (const auto& [nodeId, score] : nodesAndScores) {
         auto scoreIter = outputScoresByNodeId.find(nodeId);
-        if (scoreIter == outputScoresByNodeId.end()) {
+        bool isNewNode = scoreIter == outputScoresByNodeId.end();
+        if (isNewNode) {
             scoreIter = outputScoresByNodeId.emplace(nodeId, std::vector<double>(numEdgeAttrFeatures, 0.0)).first;
         }
         auto& scoreFeatures = scoreIter->second;
 
         // Feature layout:
-        // [best_score, per-channel scores..., channel presence bits...].
+        // [best_score, min_hop, per-channel scores..., channel presence bits...].
         scoreFeatures[0] = std::max(scoreFeatures[0], score);
-        int32_t channelScoreIndex = 1 + channelIndex;
-        int32_t channelPresenceIndex = 1 + numChannels + channelIndex;
+        int32_t hopIndex = 1;
+        int32_t channelScoreIndex = 2 + channelIndex;
+        int32_t channelPresenceIndex = 2 + numChannels + channelIndex;
 
         // Record this node's score for the current channel and mark that the
         // channel reached the node. Current extraction emits one row per node
         // per channel, so no intra-channel merge is needed here.
         scoreFeatures[channelScoreIndex] = score;
         scoreFeatures[channelPresenceIndex] = 1.0;
+
+        double hopFeature = getHopFeature(getNodeMinHop(nodeTypeState, nodeId));
+        if (isNewNode || hopFeature < scoreFeatures[hopIndex]) {
+            scoreFeatures[hopIndex] = hopFeature;
+        }
 
         // Keep a per-channel sortable candidate list so target counts can be
         // applied after cross-channel attribution.
@@ -669,7 +703,7 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPPRNode
     // downstream model architectures see a fixed set of PPR edge types every iteration.
     for (int32_t nodeTypeId = 0; nodeTypeId < _numNodeTypes; ++nodeTypeId) {
         std::vector<int64_t> flatIds;
-        std::vector<double> flatWeights;
+        std::vector<double> flatFeatureValues;
         std::vector<int64_t> validCounts;
 
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
@@ -693,14 +727,16 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPPRNode
 
             for (const auto& [nodeId, score] : selectedPairs) {
                 flatIds.push_back(static_cast<int64_t>(nodeId));
-                flatWeights.push_back(score);
+                flatFeatureValues.push_back(score);
+                flatFeatureValues.push_back(getHopFeature(getNodeMinHop(nodeTypeState, nodeId)));
             }
             validCounts.push_back(static_cast<int64_t>(selectedPairs.size()));
         }
 
-        extractedPPRByNodeTypeId[nodeTypeId] = {torch::tensor(flatIds, torch::kLong),
-                                                torch::tensor(flatWeights, torch::kDouble),
-                                                torch::tensor(validCounts, torch::kLong)};
+        auto flatWeights = torch::tensor(flatFeatureValues, torch::kDouble)
+                               .reshape({static_cast<int64_t>(flatIds.size()), /*numEdgeAttrFeatures=*/2});
+        extractedPPRByNodeTypeId[nodeTypeId] = {
+            torch::tensor(flatIds, torch::kLong), flatWeights, torch::tensor(validCounts, torch::kLong)};
     }
     return extractedPPRByNodeTypeId;
 }
@@ -727,12 +763,14 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
     int32_t numNodeTypes = firstState->_numNodeTypes;
     auto numChannels = static_cast<int32_t>(states.size());
     int32_t maxPPRNodes = std::accumulate(channelTargetCounts.begin(), channelTargetCounts.end(), 0);
-    // Feature width is 1 + 2C:
+    // Feature width is 2 + 2C:
     //   column 0: best emitted PPR score across channels, used as the scalar
     //             PPR weight by downstream ranking/sequence construction.
-    //   columns [1, C]: emitted PPR score for each channel.
-    //   columns [1 + C, 1 + 2C): presence bit for each channel.
-    int32_t numEdgeAttrFeatures = 1 + (2 * numChannels);
+    //   column 1: global minimum discovered-hop count as 0=anchor,
+    //             1=1-hop, 2=2-hop, and so on.
+    //   columns [2, 2 + C): emitted PPR score for each channel.
+    //   columns [2 + C, 2 + 2C): presence bit for each channel.
+    int32_t numEdgeAttrFeatures = 2 + (2 * numChannels);
 
     // Pre-size the per-seed feature map below. Each channel can contribute up
     // to maxPPRNodes candidates before cross-channel dedup and target filling.
@@ -766,8 +804,10 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
 
                 outputCandidatesByChannel[channelIndex].reserve(outputNodesAndScores.size());
                 addTypedPPRSeedFeaturesAndCandidates(outputNodesAndScores,
+                                                     nodeTypeState,
                                                      channelIndex,
                                                      numChannels,
+                                                     numEdgeAttrFeatures,
                                                      outputScores,
                                                      outputCandidatesByChannel[channelIndex]);
             }

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -337,11 +337,11 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
                     auto& dstNodeTypeState = _state[seedIdx][dstNodeTypeId];
                     for (int32_t neighborNodeId : neighborList->get()) {
                         const int32_t neighborHop = sourceState.minHop + 1;
-                        auto [residualStateIter, inserted] =
+                        auto [residualStateIter, createdResidualState] =
                             dstNodeTypeState.residualStates.emplace(neighborNodeId, ResidualState{0.0, neighborHop});
                         auto& residualState = residualStateIter->second;
                         residualState.residual += residualPerNeighbor;
-                        if (!inserted && neighborHop < residualState.minHop) {
+                        if (!createdResidualState && neighborHop < residualState.minHop) {
                             residualState.minHop = neighborHop;
                         }
 

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -529,14 +529,8 @@ public:
     // the best emitted PPR score for downstream consumers that expect one weight,
     // while hop columns keep the nearest discovered distance.
     void updateScores(std::vector<double>& features, int32_t channelIndex, double score, int32_t minHop) const {
-        TORCH_CHECK(channelIndex >= 0 && channelIndex < _numChannels,
-                    "Typed PPR channel index ",
-                    channelIndex,
-                    " out of range [0, ",
-                    _numChannels,
-                    ").");
-        TORCH_CHECK(minHop >= 0, "PPR min-hop must be non-negative, got ", minHop, ".");
-
+        // The extraction loop bounds channelIndex, and getNodeMinHop validates
+        // minHop before this call. Avoid duplicating those checks per candidate.
         const double hopFeature = static_cast<double>(minHop);
         features[kBestScoreIndex] = std::max(features[kBestScoreIndex], score);
         updateMinHop(features[kGlobalMinHopIndex], hopFeature);

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -15,6 +15,8 @@
 
 namespace gigl {
 
+static constexpr double kMissingTypedPPRChannelHop = -1.0;
+
 // Pack (node_id, etype_id) into a single uint64 for use as a hash key.
 // Inputs are cast through uint32_t to avoid sign-extension of negative int32 values.
 static uint64_t packKey(int32_t nodeId, int32_t edgeTypeId) {
@@ -282,8 +284,7 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
                             sourceNodeId,
                             ".");
                 auto& sourceState = sourceStateIter->second;
-                double sourceResidual = sourceState.residual;
-                int32_t sourceHop = sourceState.minHop;
+                const double sourceResidual = sourceState.residual;
 
                 // a. Absorb: move residual into the PPR score.
                 srcNodeTypeState.pprScores[sourceNodeId] += sourceResidual;
@@ -336,7 +337,7 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
                     // exceeded.
                     auto& dstNodeTypeState = _state[seedIdx][dstNodeTypeId];
                     for (int32_t neighborNodeId : neighborList->get()) {
-                        int32_t neighborHop = sourceHop + 1;
+                        const int32_t neighborHop = sourceState.minHop + 1;
                         auto [residualStateIter, inserted] =
                             dstNodeTypeState.residualStates.emplace(neighborNodeId, ResidualState{0.0, neighborHop});
                         auto& residualState = residualStateIter->second;
@@ -475,13 +476,78 @@ static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nod
                 "PPR extraction expected a discovered hop for emitted node ",
                 nodeId,
                 ".");
-    return residualStateIter->second.minHop;
+    int32_t minHop = residualStateIter->second.minHop;
+    TORCH_CHECK(minHop >= 0, "PPR min-hop must be non-negative, got ", minHop, ".");
+    return minHop;
 }
 
-static double getHopFeature(int32_t minHop) {
-    TORCH_CHECK(minHop >= 0, "PPR min-hop must be non-negative, got ", minHop, ".");
-    return static_cast<double>(minHop);
-}
+class TypedPPRFeatureLayout {
+public:
+    explicit TypedPPRFeatureLayout(int32_t numChannels)
+        : _numChannels(numChannels), _numFeatures(2 + (3 * numChannels)) {}
+
+    [[nodiscard]] int32_t numFeatures() const {
+        return _numFeatures;
+    }
+
+    [[nodiscard]] std::vector<double> makeFeatureVector() const {
+        std::vector<double> features(_numFeatures, 0.0);
+        features[minHopIndex()] = kMissingTypedPPRChannelHop;
+        std::fill(features.begin() + channelHopStartIndex(),
+                  features.begin() + channelPresenceStartIndex(),
+                  kMissingTypedPPRChannelHop);
+        return features;
+    }
+
+    void updateScores(std::vector<double>& features, int32_t channelIndex, double score, int32_t minHop) const {
+        TORCH_CHECK(channelIndex >= 0 && channelIndex < _numChannels,
+                    "Typed PPR channel index ",
+                    channelIndex,
+                    " out of range [0, ",
+                    _numChannels,
+                    ").");
+        TORCH_CHECK(minHop >= 0, "PPR min-hop must be non-negative, got ", minHop, ".");
+
+        const double hopFeature = static_cast<double>(minHop);
+        features[bestScoreIndex()] = std::max(features[bestScoreIndex()], score);
+        updateMinHop(features[minHopIndex()], hopFeature);
+        features[channelScoreIndex(channelIndex)] = score;
+        updateMinHop(features[channelHopIndex(channelIndex)], hopFeature);
+        features[channelPresenceIndex(channelIndex)] = 1.0;
+    }
+
+private:
+    [[nodiscard]] int32_t bestScoreIndex() const {
+        return 0;
+    }
+    [[nodiscard]] int32_t minHopIndex() const {
+        return 1;
+    }
+    [[nodiscard]] int32_t channelScoreIndex(int32_t channelIndex) const {
+        return 2 + channelIndex;
+    }
+    [[nodiscard]] int32_t channelHopStartIndex() const {
+        return 2 + _numChannels;
+    }
+    [[nodiscard]] int32_t channelHopIndex(int32_t channelIndex) const {
+        return channelHopStartIndex() + channelIndex;
+    }
+    [[nodiscard]] int32_t channelPresenceStartIndex() const {
+        return 2 + (2 * _numChannels);
+    }
+    [[nodiscard]] int32_t channelPresenceIndex(int32_t channelIndex) const {
+        return channelPresenceStartIndex() + channelIndex;
+    }
+
+    static void updateMinHop(double& currentMinHopFeature, double hopFeature) {
+        if (currentMinHopFeature == kMissingTypedPPRChannelHop || hopFeature < currentMinHopFeature) {
+            currentMinHopFeature = hopFeature;
+        }
+    }
+
+    int32_t _numChannels;
+    int32_t _numFeatures;
+};
 
 // Helper function for adding one channel's extracted PPR candidates into the
 // emitted typed feature table and a selection candidate list.
@@ -495,8 +561,7 @@ static double getHopFeature(int32_t minHop) {
 //   nodesAndScores: extracted (node_id, score) candidates for one channel.
 //   nodeTypeState: completed PPR state for this seed/node-type/channel.
 //   channelIndex: index of the typed PPR channel being added.
-//   numChannels: total typed PPR channels, used to derive feature width.
-//   numEdgeAttrFeatures: total typed edge-attribute width for this extraction.
+//   featureLayout: typed edge-attribute layout and update helper.
 //   outputScoresByNodeId: mutable map from node ID to emitted edge_attr features.
 //   channelOutputCandidates: mutable sortable candidates for target-count selection.
 //
@@ -506,53 +571,24 @@ static double getHopFeature(int32_t minHop) {
 static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int32_t, double>>& nodesAndScores,
                                                  const SeedNodeTypeState& nodeTypeState,
                                                  int32_t channelIndex,
-                                                 int32_t numChannels,
-                                                 int32_t numEdgeAttrFeatures,
+                                                 const TypedPPRFeatureLayout& featureLayout,
                                                  std::unordered_map<int32_t, std::vector<double>>& outputScoresByNodeId,
                                                  std::vector<std::pair<int32_t, double>>& channelOutputCandidates) {
     if (nodesAndScores.empty()) {
         return;
     }
 
-    // Feature width is 2 + 3C:
-    //   column 0: best emitted PPR score across channels, used as the scalar
-    //             PPR weight by downstream ranking/sequence construction. This
-    //             stays on the same score scale as untyped PPR output.
-    //   column 1: global minimum discovered-hop count as 0=anchor,
-    //             1=1-hop, 2=2-hop, and so on.
-    //   columns [2, 2 + C): emitted PPR score for each channel.
-    //   columns [2 + C, 2 + 2C): minimum discovered-hop count for each channel.
-    //   columns [2 + 2C, 2 + 3C): presence bit for each channel.
     for (const auto& [nodeId, score] : nodesAndScores) {
         auto scoreIter = outputScoresByNodeId.find(nodeId);
-        bool isNewNode = scoreIter == outputScoresByNodeId.end();
-        if (isNewNode) {
-            scoreIter = outputScoresByNodeId.emplace(nodeId, std::vector<double>(numEdgeAttrFeatures, 0.0)).first;
+        if (scoreIter == outputScoresByNodeId.end()) {
+            scoreIter = outputScoresByNodeId.emplace(nodeId, featureLayout.makeFeatureVector()).first;
         }
         auto& scoreFeatures = scoreIter->second;
-
-        // Feature layout:
-        // [best_score, min_hop, per-channel scores..., per-channel min-hops...,
-        //  channel presence bits...].
-        scoreFeatures[0] = std::max(scoreFeatures[0], score);
-        int32_t globalHopIndex = 1;
-        int32_t channelScoreIndex = 2 + channelIndex;
-        int32_t channelHopIndex = 2 + numChannels + channelIndex;
-        int32_t channelPresenceIndex = 2 + (2 * numChannels) + channelIndex;
 
         // Record this node's score for the current channel and mark that the
         // channel reached the node. Current extraction emits one row per node
         // per channel, so no intra-channel merge is needed here.
-        scoreFeatures[channelScoreIndex] = score;
-        scoreFeatures[channelPresenceIndex] = 1.0;
-
-        double hopFeature = getHopFeature(getNodeMinHop(nodeTypeState, nodeId));
-        if (isNewNode || hopFeature < scoreFeatures[globalHopIndex]) {
-            scoreFeatures[globalHopIndex] = hopFeature;
-        }
-        if (scoreFeatures[channelHopIndex] == 0.0 || hopFeature < scoreFeatures[channelHopIndex]) {
-            scoreFeatures[channelHopIndex] = hopFeature;
-        }
+        featureLayout.updateScores(scoreFeatures, channelIndex, score, getNodeMinHop(nodeTypeState, nodeId));
 
         // Keep a per-channel sortable candidate list so target counts can be
         // applied after cross-channel attribution.
@@ -740,7 +776,7 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPPRNode
             for (const auto& [nodeId, score] : selectedPairs) {
                 flatIds.push_back(static_cast<int64_t>(nodeId));
                 flatFeatureValues.push_back(score);
-                flatFeatureValues.push_back(getHopFeature(getNodeMinHop(nodeTypeState, nodeId)));
+                flatFeatureValues.push_back(static_cast<double>(getNodeMinHop(nodeTypeState, nodeId)));
             }
             validCounts.push_back(static_cast<int64_t>(selectedPairs.size()));
         }
@@ -775,15 +811,17 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
     int32_t numNodeTypes = firstState->_numNodeTypes;
     auto numChannels = static_cast<int32_t>(states.size());
     int32_t maxPPRNodes = std::accumulate(channelTargetCounts.begin(), channelTargetCounts.end(), 0);
-    // Feature width is 2 + 3C:
+    // Typed edge_attr feature width is 2 + 3C:
     //   column 0: best emitted PPR score across channels, used as the scalar
     //             PPR weight by downstream ranking/sequence construction.
     //   column 1: global minimum discovered-hop count as 0=anchor,
     //             1=1-hop, 2=2-hop, and so on.
     //   columns [2, 2 + C): emitted PPR score for each channel.
-    //   columns [2 + C, 2 + 2C): minimum discovered-hop count for each channel.
+    //   columns [2 + C, 2 + 2C): minimum discovered-hop count for each channel,
+    //                             or -1 when that channel did not reach the node.
     //   columns [2 + 2C, 2 + 3C): presence bit for each channel.
-    int32_t numEdgeAttrFeatures = 2 + (3 * numChannels);
+    TypedPPRFeatureLayout featureLayout(numChannels);
+    int32_t numEdgeAttrFeatures = featureLayout.numFeatures();
 
     // Pre-size the per-seed feature map below. Each channel can contribute up
     // to maxPPRNodes candidates before cross-channel dedup and target filling.
@@ -819,8 +857,7 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
                 addTypedPPRSeedFeaturesAndCandidates(outputNodesAndScores,
                                                      nodeTypeState,
                                                      channelIndex,
-                                                     numChannels,
-                                                     numEdgeAttrFeatures,
+                                                     featureLayout,
                                                      outputScores,
                                                      outputCandidatesByChannel[channelIndex]);
             }

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -337,13 +337,12 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
                     auto& dstNodeTypeState = _state[seedIdx][dstNodeTypeId];
                     for (int32_t neighborNodeId : neighborList->get()) {
                         const int32_t neighborHop = sourceState.minHop + 1;
-                        auto [residualStateIter, createdResidualState] =
-                            dstNodeTypeState.residualStates.emplace(neighborNodeId, ResidualState{0.0, neighborHop});
+                        auto residualStateIter =
+                            dstNodeTypeState.residualStates.emplace(neighborNodeId, ResidualState{0.0, neighborHop})
+                                .first;
                         auto& residualState = residualStateIter->second;
                         residualState.residual += residualPerNeighbor;
-                        if (!createdResidualState && neighborHop < residualState.minHop) {
-                            residualState.minHop = neighborHop;
-                        }
+                        residualState.minHop = std::min(residualState.minHop, neighborHop);
 
                         double threshold = _requeueThresholdFactor *
                                            static_cast<double>(getTotalDegree(neighborNodeId, dstNodeTypeId));

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -89,8 +89,7 @@ PPRForwardPush::PPRForwardPush(const torch::Tensor& seedNodes,
         // PPR initialisation: each seed starts with residual = alpha (the
         // restart probability).  The first push will move alpha into ppr_score
         // and distribute (1-alpha)*alpha to the seed's neighbors.
-        _state[seedIdx][seedNodeTypeId].residuals[seedNodeId] = _alpha;
-        _state[seedIdx][seedNodeTypeId].minHops[seedNodeId] = 0;
+        _state[seedIdx][seedNodeTypeId].residualStates[seedNodeId] = ResidualState{_alpha, 0};
         _state[seedIdx][seedNodeTypeId].queue.insert(seedNodeId);
     }
 }
@@ -277,14 +276,18 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
             }
 
             for (int32_t sourceNodeId : srcNodeTypeState.queuedNodes) {
-                auto residualIter = srcNodeTypeState.residuals.find(sourceNodeId);
-                double sourceResidual = (residualIter != srcNodeTypeState.residuals.end()) ? residualIter->second : 0.0;
-                auto sourceHopIter = srcNodeTypeState.minHops.find(sourceNodeId);
-                int32_t sourceHop = sourceHopIter != srcNodeTypeState.minHops.end() ? sourceHopIter->second : 0;
+                auto sourceStateIter = srcNodeTypeState.residualStates.find(sourceNodeId);
+                TORCH_CHECK(sourceStateIter != srcNodeTypeState.residualStates.end(),
+                            "PPR push expected residual state for queued node ",
+                            sourceNodeId,
+                            ".");
+                auto& sourceState = sourceStateIter->second;
+                double sourceResidual = sourceState.residual;
+                int32_t sourceHop = sourceState.minHop;
 
                 // a. Absorb: move residual into the PPR score.
                 srcNodeTypeState.pprScores[sourceNodeId] += sourceResidual;
-                srcNodeTypeState.residuals[sourceNodeId] = 0.0;
+                sourceState.residual = 0.0;
 
                 // b. Count total cached neighbors across all edge types for
                 // this source node.  We normalise by the number of neighbors we
@@ -333,18 +336,20 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
                     // exceeded.
                     auto& dstNodeTypeState = _state[seedIdx][dstNodeTypeId];
                     for (int32_t neighborNodeId : neighborList->get()) {
-                        dstNodeTypeState.residuals[neighborNodeId] += residualPerNeighbor;
                         int32_t neighborHop = sourceHop + 1;
-                        auto [hopIter, inserted] = dstNodeTypeState.minHops.emplace(neighborNodeId, neighborHop);
-                        if (!inserted && neighborHop < hopIter->second) {
-                            hopIter->second = neighborHop;
+                        auto [residualStateIter, inserted] =
+                            dstNodeTypeState.residualStates.emplace(neighborNodeId, ResidualState{0.0, neighborHop});
+                        auto& residualState = residualStateIter->second;
+                        residualState.residual += residualPerNeighbor;
+                        if (!inserted && neighborHop < residualState.minHop) {
+                            residualState.minHop = neighborHop;
                         }
 
                         double threshold = _requeueThresholdFactor *
                                            static_cast<double>(getTotalDegree(neighborNodeId, dstNodeTypeId));
 
                         if (dstNodeTypeState.queue.find(neighborNodeId) == dstNodeTypeState.queue.end() &&
-                            dstNodeTypeState.residuals[neighborNodeId] >= threshold) {
+                            residualState.residual >= threshold) {
                             dstNodeTypeState.queue.insert(neighborNodeId);
                             ++_numNodesInQueue;
                         }
@@ -413,8 +418,9 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
         }
 
         std::vector<std::pair<int32_t, double>> residualPairs;
-        residualPairs.reserve(nodeTypeState.residuals.size());
-        for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
+        residualPairs.reserve(nodeTypeState.residualStates.size());
+        for (const auto& [nodeId, residualState] : nodeTypeState.residualStates) {
+            double residual = residualState.residual;
             // Forward push residuals are non-negative in normal operation. Pushed
             // nodes remain in the map with zero residual, so skip drained entries
             // and any unexpected non-positive values.
@@ -456,20 +462,20 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
 static void addResidualMassToPPRPairs(const SeedNodeTypeState& nodeTypeState,
                                       std::vector<std::pair<int32_t, double>>& selectedPairs) {
     for (auto& [nodeId, score] : selectedPairs) {
-        auto residualIter = nodeTypeState.residuals.find(nodeId);
-        if (residualIter != nodeTypeState.residuals.end()) {
-            score += residualIter->second;
+        auto residualStateIter = nodeTypeState.residualStates.find(nodeId);
+        if (residualStateIter != nodeTypeState.residualStates.end()) {
+            score += residualStateIter->second.residual;
         }
     }
 }
 
 static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nodeId) {
-    auto hopIter = nodeTypeState.minHops.find(nodeId);
-    TORCH_CHECK(hopIter != nodeTypeState.minHops.end(),
+    auto residualStateIter = nodeTypeState.residualStates.find(nodeId);
+    TORCH_CHECK(residualStateIter != nodeTypeState.residualStates.end(),
                 "PPR extraction expected a discovered hop for emitted node ",
                 nodeId,
                 ".");
-    return hopIter->second;
+    return residualStateIter->second.minHop;
 }
 
 static double getHopFeature(int32_t minHop) {

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -1,4 +1,5 @@
 #include "ppr_forward_push.h"
+#include "typed_ppr_feature_layout.h"
 
 #include <torch/torch.h>
 
@@ -479,87 +480,6 @@ static double getNodeHopProximity(const SeedNodeTypeState& nodeTypeState, int32_
     return 1.0 / (1.0 + static_cast<double>(hop));
 }
 
-// Owns the packed edge_attr layout used while merging typed PPR channels.
-//
-// Typed extraction first accumulates one dense feature vector per selected node,
-// then copies those vectors into the final tensor. Keeping the offsets here
-// keeps addTypedPPRSeedFeaturesAndCandidates focused on merge policy instead of
-// repeating manual column math.
-//
-// The width is 2 + (3 * numChannels):
-//   - 2 global columns:
-//       [best_score, hop_proximity]
-//     These preserve the regular PPR edge_attr contract at the front of the row.
-//   - 3 columns per typed channel:
-//       [channel_score, channel_hop_proximity, channel_presence]
-//     The per-channel score supports channel attribution/ranking, the per-channel
-//     hop proximity gives models a bounded closeness signal, and the presence bit
-//     is the explicit channel-reachability mask.
-//
-// Hop proximity is 1 / (1 + hop) when a channel reaches the node:
-// anchor=1.0, 1-hop=0.5, 2-hop ~= 0.333, and so on. Missing channels remain 0,
-// which is finite, bounded, and never looks closer than a reached channel. For
-// present channels, callers can recover the original hop count as
-// (1 - proximity) / proximity; use the presence bit before applying this
-// inverse because proximity 0 means the channel is missing.
-class TypedPPRFeatureLayout {
-public:
-    explicit TypedPPRFeatureLayout(int32_t numChannels) : _numChannels(numChannels) {
-        TORCH_CHECK(numChannels > 0, "Typed PPR feature layout requires at least one channel.");
-    }
-
-    [[nodiscard]] int32_t numFeatures() const {
-        return kNumGlobalFeatures + (kNumPerChannelFeatures * _numChannels);
-    }
-
-    // New node feature vectors start empty. Scores, proximities, and presence
-    // bits all use 0 as their absent-channel value.
-    [[nodiscard]] std::vector<double> makeFeatureVector() const {
-        return std::vector<double>(numFeatures(), 0.0);
-    }
-
-    // Merge one channel's emitted score/proximity into an existing node feature row.
-    //
-    // A node can be seen in multiple typed channels. The scalar score column keeps
-    // the best emitted PPR score for downstream consumers that expect one weight,
-    // while the global proximity keeps the closest discovered distance.
-    void updateScores(std::vector<double>& features, int32_t channelIndex, double score, double hopProximity) const {
-        // The extraction loop bounds channelIndex, and getNodeHopProximity
-        // validates the underlying hop before this call.
-        features[kBestScoreIndex] = std::max(features[kBestScoreIndex], score);
-        features[kGlobalHopProximityIndex] = std::max(features[kGlobalHopProximityIndex], hopProximity);
-        features[channelScoreIndex(channelIndex)] = score;
-        features[channelHopProximityIndex(channelIndex)] = hopProximity;
-        features[channelPresenceIndex(channelIndex)] = 1.0;
-    }
-
-private:
-    static constexpr int32_t kBestScoreIndex = 0;
-    static constexpr int32_t kGlobalHopProximityIndex = 1;
-    static constexpr int32_t kNumGlobalFeatures = 2;     // best score + global hop proximity
-    static constexpr int32_t kNumPerChannelFeatures = 3; // score + hop proximity + presence
-
-    [[nodiscard]] int32_t channelScoreIndex(int32_t channelIndex) const {
-        return kNumGlobalFeatures + channelIndex;
-    }
-    [[nodiscard]] int32_t channelHopProximityStartIndex() const {
-        return kNumGlobalFeatures + _numChannels;
-    }
-    [[nodiscard]] int32_t channelHopProximityIndex(int32_t channelIndex) const {
-        return channelHopProximityStartIndex() + channelIndex;
-    }
-    [[nodiscard]] int32_t channelPresenceStartIndex() const {
-        return kNumGlobalFeatures + (2 * _numChannels);
-    }
-    [[nodiscard]] int32_t channelPresenceIndex(int32_t channelIndex) const {
-        return channelPresenceStartIndex() + channelIndex;
-    }
-
-    // The channel count is the only stored layout state. Every offset is derived
-    // from it, so feature width cannot drift from the per-channel blocks.
-    const int32_t _numChannels;
-};
-
 // Helper function for adding one channel's extracted PPR candidates into the
 // emitted typed feature table and a selection candidate list.
 //
@@ -826,13 +746,12 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
     //   column 0: best emitted PPR score across channels, used as the scalar
     //             PPR weight by downstream ranking/sequence construction.
     //   column 1: global hop proximity as 1/(1 + closest_hop).
-    //   columns [2, 2 + C): emitted PPR score for each channel.
-    //   columns [2 + C, 2 + 2C): hop proximity for each channel:
-    //                             1/(1 + hop) when present, 0 when missing.
-    //                             For present channels, hop can be recovered
-    //                             as (1 - proximity) / proximity; use the
-    //                             presence bit before applying this inverse.
-    //   columns [2 + 2C, 2 + 3C): presence bit for each channel.
+    //   columns [2, 2 + 3C): per-channel triples:
+    //                         (channel_score, channel_hop_proximity, channel_presence).
+    //                         Proximity is 1/(1 + hop) when present and 0 when
+    //                         missing. For present channels, hop can be recovered
+    //                         as (1 - proximity) / proximity; use the presence
+    //                         bit before applying this inverse.
     TypedPPRFeatureLayout featureLayout(numChannels);
     int32_t numEdgeAttrFeatures = featureLayout.numFeatures();
 

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -508,14 +508,15 @@ static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int
         return;
     }
 
-    // Feature width is 2 + 2C:
+    // Feature width is 2 + 3C:
     //   column 0: best emitted PPR score across channels, used as the scalar
     //             PPR weight by downstream ranking/sequence construction. This
     //             stays on the same score scale as untyped PPR output.
     //   column 1: global minimum discovered-hop count as 0=anchor,
     //             1=1-hop, 2=2-hop, and so on.
     //   columns [2, 2 + C): emitted PPR score for each channel.
-    //   columns [2 + C, 2 + 2C): presence bit for each channel.
+    //   columns [2 + C, 2 + 2C): minimum discovered-hop count for each channel.
+    //   columns [2 + 2C, 2 + 3C): presence bit for each channel.
     for (const auto& [nodeId, score] : nodesAndScores) {
         auto scoreIter = outputScoresByNodeId.find(nodeId);
         bool isNewNode = scoreIter == outputScoresByNodeId.end();
@@ -525,11 +526,13 @@ static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int
         auto& scoreFeatures = scoreIter->second;
 
         // Feature layout:
-        // [best_score, min_hop, per-channel scores..., channel presence bits...].
+        // [best_score, min_hop, per-channel scores..., per-channel min-hops...,
+        //  channel presence bits...].
         scoreFeatures[0] = std::max(scoreFeatures[0], score);
-        int32_t hopIndex = 1;
+        int32_t globalHopIndex = 1;
         int32_t channelScoreIndex = 2 + channelIndex;
-        int32_t channelPresenceIndex = 2 + numChannels + channelIndex;
+        int32_t channelHopIndex = 2 + numChannels + channelIndex;
+        int32_t channelPresenceIndex = 2 + (2 * numChannels) + channelIndex;
 
         // Record this node's score for the current channel and mark that the
         // channel reached the node. Current extraction emits one row per node
@@ -538,8 +541,11 @@ static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int
         scoreFeatures[channelPresenceIndex] = 1.0;
 
         double hopFeature = getHopFeature(getNodeMinHop(nodeTypeState, nodeId));
-        if (isNewNode || hopFeature < scoreFeatures[hopIndex]) {
-            scoreFeatures[hopIndex] = hopFeature;
+        if (isNewNode || hopFeature < scoreFeatures[globalHopIndex]) {
+            scoreFeatures[globalHopIndex] = hopFeature;
+        }
+        if (scoreFeatures[channelHopIndex] == 0.0 || hopFeature < scoreFeatures[channelHopIndex]) {
+            scoreFeatures[channelHopIndex] = hopFeature;
         }
 
         // Keep a per-channel sortable candidate list so target counts can be
@@ -763,14 +769,15 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
     int32_t numNodeTypes = firstState->_numNodeTypes;
     auto numChannels = static_cast<int32_t>(states.size());
     int32_t maxPPRNodes = std::accumulate(channelTargetCounts.begin(), channelTargetCounts.end(), 0);
-    // Feature width is 2 + 2C:
+    // Feature width is 2 + 3C:
     //   column 0: best emitted PPR score across channels, used as the scalar
     //             PPR weight by downstream ranking/sequence construction.
     //   column 1: global minimum discovered-hop count as 0=anchor,
     //             1=1-hop, 2=2-hop, and so on.
     //   columns [2, 2 + C): emitted PPR score for each channel.
-    //   columns [2 + C, 2 + 2C): presence bit for each channel.
-    int32_t numEdgeAttrFeatures = 2 + (2 * numChannels);
+    //   columns [2 + C, 2 + 2C): minimum discovered-hop count for each channel.
+    //   columns [2 + 2C, 2 + 3C): presence bit for each channel.
+    int32_t numEdgeAttrFeatures = 2 + (3 * numChannels);
 
     // Pre-size the per-seed feature map below. Each channel can contribute up
     // to maxPPRNodes candidates before cross-channel dedup and target filling.

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -15,8 +15,6 @@
 
 namespace gigl {
 
-static constexpr double kUnsetTypedPPRMinHop = -1.0;
-
 // Pack (node_id, etype_id) into a single uint64 for use as a hash key.
 // Inputs are cast through uint32_t to avoid sign-extension of negative int32 values.
 static uint64_t packKey(int32_t nodeId, int32_t edgeTypeId) {
@@ -514,13 +512,11 @@ public:
         return kNumGlobalFeatures + (kNumPerChannelFeatures * _numChannels);
     }
 
-    // New node feature vectors start empty. The global min-hop is marked missing
-    // until the first channel writes it, while channel scores, proximities, and
-    // presence bits naturally use 0 as their absent-channel value.
+    // New node feature vectors start empty. All columns can start at 0 because
+    // the first channel write initializes the global min-hop before any
+    // cross-channel min comparison is needed.
     [[nodiscard]] std::vector<double> makeFeatureVector() const {
-        std::vector<double> features(numFeatures(), 0.0);
-        features[kGlobalMinHopIndex] = kUnsetTypedPPRMinHop;
-        return features;
+        return std::vector<double>(numFeatures(), 0.0);
     }
 
     // Merge one channel's emitted score/hop into an existing node feature row.
@@ -528,12 +524,18 @@ public:
     // A node can be seen in multiple typed channels. The scalar score column keeps
     // the best emitted PPR score for downstream consumers that expect one weight,
     // while the global hop keeps the nearest discovered distance.
-    void updateScores(std::vector<double>& features, int32_t channelIndex, double score, int32_t minHop) const {
+    void updateScores(std::vector<double>& features,
+                      int32_t channelIndex,
+                      double score,
+                      int32_t minHop,
+                      bool isFirstChannelForNode) const {
         // The extraction loop bounds channelIndex, and getNodeMinHop validates
         // minHop before this call. Avoid duplicating those checks per candidate.
         const double hopFeature = static_cast<double>(minHop);
         features[kBestScoreIndex] = std::max(features[kBestScoreIndex], score);
-        updateMinHop(features[kGlobalMinHopIndex], hopFeature);
+        if (isFirstChannelForNode || hopFeature < features[kGlobalMinHopIndex]) {
+            features[kGlobalMinHopIndex] = hopFeature;
+        }
         features[channelScoreIndex(channelIndex)] = score;
         features[channelHopProximityIndex(channelIndex)] = 1.0 / (1.0 + hopFeature);
         features[channelPresenceIndex(channelIndex)] = 1.0;
@@ -559,12 +561,6 @@ private:
     }
     [[nodiscard]] int32_t channelPresenceIndex(int32_t channelIndex) const {
         return channelPresenceStartIndex() + channelIndex;
-    }
-
-    static void updateMinHop(double& currentMinHopFeature, double hopFeature) {
-        if (currentMinHopFeature == kUnsetTypedPPRMinHop || hopFeature < currentMinHopFeature) {
-            currentMinHopFeature = hopFeature;
-        }
     }
 
     // The channel count is the only stored layout state. Every offset is derived
@@ -603,7 +599,8 @@ static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int
 
     for (const auto& [nodeId, score] : nodesAndScores) {
         auto scoreIter = outputScoresByNodeId.find(nodeId);
-        if (scoreIter == outputScoresByNodeId.end()) {
+        const bool isFirstChannelForNode = scoreIter == outputScoresByNodeId.end();
+        if (isFirstChannelForNode) {
             scoreIter = outputScoresByNodeId.emplace(nodeId, featureLayout.makeFeatureVector()).first;
         }
         auto& scoreFeatures = scoreIter->second;
@@ -611,7 +608,8 @@ static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int
         // Record this node's score for the current channel and mark that the
         // channel reached the node. Current extraction emits one row per node
         // per channel, so no intra-channel merge is needed here.
-        featureLayout.updateScores(scoreFeatures, channelIndex, score, getNodeMinHop(nodeTypeState, nodeId));
+        featureLayout.updateScores(
+            scoreFeatures, channelIndex, score, getNodeMinHop(nodeTypeState, nodeId), isFirstChannelForNode);
 
         // Keep a per-channel sortable candidate list so target counts can be
         // applied after cross-channel attribution.

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -481,6 +481,20 @@ static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nod
     return minHop;
 }
 
+// Owns the packed edge_attr layout used while merging typed PPR channels.
+//
+// Typed extraction first accumulates one dense feature vector per selected node,
+// then copies those vectors into the final tensor. Keeping the offsets here
+// keeps addTypedPPRSeedFeaturesAndCandidates focused on merge policy instead of
+// repeating manual column math.
+//
+// Layout:
+//   [best_score, min_hop, channel_scores..., channel_min_hops...,
+//    channel_presence_bits...]
+//
+// Scores and presence bits naturally default to 0. Channel min-hop columns use
+// -1 for "channel did not reach this node" so missing channels are distinct from
+// the anchor hop 0.
 class TypedPPRFeatureLayout {
 public:
     explicit TypedPPRFeatureLayout(int32_t numChannels)
@@ -490,6 +504,9 @@ public:
         return _numFeatures;
     }
 
+    // New node feature vectors start empty. The global min-hop is also marked
+    // missing until the first channel writes it, which lets updateScores use the
+    // same min-update path for both global and per-channel hop fields.
     [[nodiscard]] std::vector<double> makeFeatureVector() const {
         std::vector<double> features(_numFeatures, 0.0);
         features[minHopIndex()] = kMissingTypedPPRChannelHop;
@@ -499,6 +516,11 @@ public:
         return features;
     }
 
+    // Merge one channel's emitted score/hop into an existing node feature row.
+    //
+    // A node can be seen in multiple typed channels. The scalar score column keeps
+    // the best emitted PPR score for downstream consumers that expect one weight,
+    // while hop columns keep the nearest discovered distance.
     void updateScores(std::vector<double>& features, int32_t channelIndex, double score, int32_t minHop) const {
         TORCH_CHECK(channelIndex >= 0 && channelIndex < _numChannels,
                     "Typed PPR channel index ",

--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -488,28 +488,35 @@ static int32_t getNodeMinHop(const SeedNodeTypeState& nodeTypeState, int32_t nod
 // keeps addTypedPPRSeedFeaturesAndCandidates focused on merge policy instead of
 // repeating manual column math.
 //
-// Layout:
-//   [best_score, min_hop, channel_scores..., channel_min_hops...,
-//    channel_presence_bits...]
+// The width is 2 + (3 * numChannels):
+//   - 2 global columns:
+//       [best_score, min_hop]
+//     These preserve the regular PPR edge_attr contract at the front of the row.
+//   - 3 columns per typed channel:
+//       [channel_score, channel_min_hop, channel_presence]
+//     The per-channel score supports channel attribution/ranking, the per-channel
+//     hop exposes how far that channel had to walk, and the presence bit is the
+//     explicit channel-reachability mask.
 //
 // Scores and presence bits naturally default to 0. Channel min-hop columns use
 // -1 for "channel did not reach this node" so missing channels are distinct from
 // the anchor hop 0.
 class TypedPPRFeatureLayout {
 public:
-    explicit TypedPPRFeatureLayout(int32_t numChannels)
-        : _numChannels(numChannels), _numFeatures(2 + (3 * numChannels)) {}
+    explicit TypedPPRFeatureLayout(int32_t numChannels) : _numChannels(numChannels) {
+        TORCH_CHECK(numChannels > 0, "Typed PPR feature layout requires at least one channel.");
+    }
 
     [[nodiscard]] int32_t numFeatures() const {
-        return _numFeatures;
+        return kNumGlobalFeatures + (kNumPerChannelFeatures * _numChannels);
     }
 
     // New node feature vectors start empty. The global min-hop is also marked
     // missing until the first channel writes it, which lets updateScores use the
     // same min-update path for both global and per-channel hop fields.
     [[nodiscard]] std::vector<double> makeFeatureVector() const {
-        std::vector<double> features(_numFeatures, 0.0);
-        features[minHopIndex()] = kMissingTypedPPRChannelHop;
+        std::vector<double> features(numFeatures(), 0.0);
+        features[kGlobalMinHopIndex] = kMissingTypedPPRChannelHop;
         std::fill(features.begin() + channelHopStartIndex(),
                   features.begin() + channelPresenceStartIndex(),
                   kMissingTypedPPRChannelHop);
@@ -531,31 +538,30 @@ public:
         TORCH_CHECK(minHop >= 0, "PPR min-hop must be non-negative, got ", minHop, ".");
 
         const double hopFeature = static_cast<double>(minHop);
-        features[bestScoreIndex()] = std::max(features[bestScoreIndex()], score);
-        updateMinHop(features[minHopIndex()], hopFeature);
+        features[kBestScoreIndex] = std::max(features[kBestScoreIndex], score);
+        updateMinHop(features[kGlobalMinHopIndex], hopFeature);
         features[channelScoreIndex(channelIndex)] = score;
         updateMinHop(features[channelHopIndex(channelIndex)], hopFeature);
         features[channelPresenceIndex(channelIndex)] = 1.0;
     }
 
 private:
-    [[nodiscard]] int32_t bestScoreIndex() const {
-        return 0;
-    }
-    [[nodiscard]] int32_t minHopIndex() const {
-        return 1;
-    }
+    static constexpr int32_t kBestScoreIndex = 0;
+    static constexpr int32_t kGlobalMinHopIndex = 1;
+    static constexpr int32_t kNumGlobalFeatures = 2;     // best score + global min-hop
+    static constexpr int32_t kNumPerChannelFeatures = 3; // score + min-hop + presence
+
     [[nodiscard]] int32_t channelScoreIndex(int32_t channelIndex) const {
-        return 2 + channelIndex;
+        return kNumGlobalFeatures + channelIndex;
     }
     [[nodiscard]] int32_t channelHopStartIndex() const {
-        return 2 + _numChannels;
+        return kNumGlobalFeatures + _numChannels;
     }
     [[nodiscard]] int32_t channelHopIndex(int32_t channelIndex) const {
         return channelHopStartIndex() + channelIndex;
     }
     [[nodiscard]] int32_t channelPresenceStartIndex() const {
-        return 2 + (2 * _numChannels);
+        return kNumGlobalFeatures + (2 * _numChannels);
     }
     [[nodiscard]] int32_t channelPresenceIndex(int32_t channelIndex) const {
         return channelPresenceStartIndex() + channelIndex;
@@ -567,8 +573,9 @@ private:
         }
     }
 
-    int32_t _numChannels;
-    int32_t _numFeatures;
+    // The channel count is the only stored layout state. Every offset is derived
+    // from it, so feature width cannot drift from the per-channel blocks.
+    const int32_t _numChannels;
 };
 
 // Helper function for adding one channel's extracted PPR candidates into the

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -217,9 +217,12 @@ TypedPPRQueueDrainResult drainTypedPPRChannelQueues(const std::vector<PPRForward
 //   ids: int64 node IDs, flattened across seeds.
 //   weights: double feature matrix with columns
 //            [best_score, min_hop, per-channel scores...,
-//             per-channel min-hops..., presence bits...].
-//            When a channel did not reach the selected node, its min-hop is one
-//            greater than the largest min-hop among channels that did reach it.
+//             per-channel hop proximities..., presence bits...].
+//            Per-channel hop proximity is 1 / (1 + min_hop) when that channel
+//            reached the selected node, and 0 when it did not.
+//            For present channels, the original hop count can be recovered as
+//            (1 - proximity) / proximity; use the presence bit before applying
+//            this inverse because missing channels have proximity 0.
 //   valid_counts: int64 count of selected nodes per seed.
 PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardPush*>& states,
                                                    const std::vector<int32_t>& channelTargetCounts,

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -117,8 +117,8 @@ public:
     // maxPPRNodes is the final per-seed cap across finalized PPR and residual
     // top-up candidates.
     //
-    // Edge attributes are emitted as [ppr_score, min_hop], where min_hop is the
-    // minimum discovered-hop count: 0=anchor, 1=1-hop, 2=2-hop, and so on.
+    // Edge attributes are emitted as [ppr_score, hop_proximity], where
+    // hop_proximity = 1 / (1 + hop): anchor=1.0, 1-hop=0.5, and so on.
     PPRExtractResult extractTopKWithResidualTopUp(int32_t maxPPRNodes, bool enableResidualTopUp);
 
     friend PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardPush*>& states,
@@ -216,10 +216,10 @@ TypedPPRQueueDrainResult drainTypedPPRChannelQueues(const std::vector<PPRForward
 // extractTopKWithResidualTopUp:
 //   ids: int64 node IDs, flattened across seeds.
 //   weights: double feature matrix with columns
-//            [best_score, min_hop, per-channel scores...,
+//            [best_score, hop_proximity, per-channel scores...,
 //             per-channel hop proximities..., presence bits...].
-//            Per-channel hop proximity is 1 / (1 + min_hop) when that channel
-//            reached the selected node, and 0 when it did not.
+//            Hop proximity is 1 / (1 + hop). Per-channel proximity is 0 when
+//            that channel did not reach the selected node.
 //            For present channels, the original hop count can be recovered as
 //            (1 - proximity) / proximity; use the presence bit before applying
 //            this inverse because missing channels have proximity 0.

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -23,7 +23,7 @@ using PPRExtractResult = std::unordered_map<int32_t, PPRExtractTensors>;
 
 struct ResidualState {
     double residual; // unabsorbed mass waiting to push
-    int32_t minHop;  // minimum discovered hop from seed
+    int32_t minHop;  // minimum discovered hop within one seed's traversal
 };
 
 // Per-seed, per-node-type PPR algorithm state.
@@ -216,8 +216,8 @@ TypedPPRQueueDrainResult drainTypedPPRChannelQueues(const std::vector<PPRForward
 // extractTopKWithResidualTopUp:
 //   ids: int64 node IDs, flattened across seeds.
 //   weights: double feature matrix with columns
-//            [best_score, hop_proximity, per-channel scores...,
-//             per-channel hop proximities..., presence bits...].
+//            [best_score, hop_proximity,
+//             (channel_score, channel_hop_proximity, channel_presence), ...].
 //            Hop proximity is 1 / (1 + hop). Per-channel proximity is 0 when
 //            that channel did not reach the selected node.
 //            For present channels, the original hop count can be recovered as

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -21,19 +21,23 @@ using NeighborFetchMap = std::unordered_map<int32_t, NeighborFetchTensors>;
 using PPRExtractTensors = std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>;
 using PPRExtractResult = std::unordered_map<int32_t, PPRExtractTensors>;
 
+struct ResidualState {
+    double residual; // unabsorbed mass waiting to push
+    int32_t minHop;  // minimum discovered hop from seed
+};
+
 // Per-seed, per-node-type PPR algorithm state.
-// Grouping all four tables into one struct is a logical convenience: a single
-// _state[seedIdx][nodeTypeId] access reaches all four tables for a given (seed, ntype)
+// Grouping all four containers into one struct is a logical convenience: a single
+// _state[seedIdx][nodeTypeId] access reaches all state for a given (seed, ntype)
 // pair, rather than indexing four separate 2D arrays.  Note that unordered_map and
 // unordered_set heap-allocate their bucket storage, so the actual key-value data is
 // not co-located in memory — only the control-plane metadata (size, bucket pointer)
 // lives inside the struct.
 struct SeedNodeTypeState {
-    std::unordered_map<int32_t, double> pprScores; // absorbed PPR mass
-    std::unordered_map<int32_t, double> residuals; // unabsorbed mass waiting to push
-    std::unordered_map<int32_t, int32_t> minHops;  // minimum discovered hop from seed
-    std::unordered_set<int32_t> queue;             // nodes queued for the next drain
-    std::unordered_set<int32_t> queuedNodes;       // snapshot captured by drainQueue()
+    std::unordered_map<int32_t, double> pprScores;             // absorbed PPR mass
+    std::unordered_map<int32_t, ResidualState> residualStates; // unabsorbed mass and discovered hop
+    std::unordered_set<int32_t> queue;                         // nodes queued for the next drain
+    std::unordered_set<int32_t> queuedNodes;                   // snapshot captured by drainQueue()
 };
 
 // Batched drain result for typed-PPR channels.

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -31,6 +31,7 @@ using PPRExtractResult = std::unordered_map<int32_t, PPRExtractTensors>;
 struct SeedNodeTypeState {
     std::unordered_map<int32_t, double> pprScores; // absorbed PPR mass
     std::unordered_map<int32_t, double> residuals; // unabsorbed mass waiting to push
+    std::unordered_map<int32_t, int32_t> minHops;  // minimum discovered hop from seed
     std::unordered_set<int32_t> queue;             // nodes queued for the next drain
     std::unordered_set<int32_t> queuedNodes;       // snapshot captured by drainQueue()
 };
@@ -111,6 +112,9 @@ public:
     // it is not a global top-k over ppr_score + residual when maxPPRNodes is tight.
     // maxPPRNodes is the final per-seed cap across finalized PPR and residual
     // top-up candidates.
+    //
+    // Edge attributes are emitted as [ppr_score, min_hop], where min_hop is the
+    // minimum discovered-hop count: 0=anchor, 1=1-hop, 2=2-hop, and so on.
     PPRExtractResult extractTopKWithResidualTopUp(int32_t maxPPRNodes, bool enableResidualTopUp);
 
     friend PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardPush*>& states,
@@ -208,7 +212,7 @@ TypedPPRQueueDrainResult drainTypedPPRChannelQueues(const std::vector<PPRForward
 // extractTopKWithResidualTopUp:
 //   ids: int64 node IDs, flattened across seeds.
 //   weights: double feature matrix with columns
-//            [best_score, per-channel scores..., presence bits...].
+//            [best_score, min_hop, per-channel scores..., presence bits...].
 //   valid_counts: int64 count of selected nodes per seed.
 PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardPush*>& states,
                                                    const std::vector<int32_t>& channelTargetCounts,

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -218,8 +218,8 @@ TypedPPRQueueDrainResult drainTypedPPRChannelQueues(const std::vector<PPRForward
 //   weights: double feature matrix with columns
 //            [best_score, min_hop, per-channel scores...,
 //             per-channel min-hops..., presence bits...].
-//            Per-channel min-hop is -1 when that channel did not reach the
-//            selected node.
+//            When a channel did not reach the selected node, its min-hop is one
+//            greater than the largest min-hop among channels that did reach it.
 //   valid_counts: int64 count of selected nodes per seed.
 PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardPush*>& states,
                                                    const std::vector<int32_t>& channelTargetCounts,

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -212,7 +212,8 @@ TypedPPRQueueDrainResult drainTypedPPRChannelQueues(const std::vector<PPRForward
 // extractTopKWithResidualTopUp:
 //   ids: int64 node IDs, flattened across seeds.
 //   weights: double feature matrix with columns
-//            [best_score, min_hop, per-channel scores..., presence bits...].
+//            [best_score, min_hop, per-channel scores...,
+//             per-channel min-hops..., presence bits...].
 //   valid_counts: int64 count of selected nodes per seed.
 PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardPush*>& states,
                                                    const std::vector<int32_t>& channelTargetCounts,

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -218,6 +218,8 @@ TypedPPRQueueDrainResult drainTypedPPRChannelQueues(const std::vector<PPRForward
 //   weights: double feature matrix with columns
 //            [best_score, min_hop, per-channel scores...,
 //             per-channel min-hops..., presence bits...].
+//            Per-channel min-hop is -1 when that channel did not reach the
+//            selected node.
 //   valid_counts: int64 count of selected nodes per seed.
 PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardPush*>& states,
                                                    const std::vector<int32_t>& channelTargetCounts,

--- a/gigl-core/core/sampling/typed_ppr_feature_layout.h
+++ b/gigl-core/core/sampling/typed_ppr_feature_layout.h
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <torch/torch.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace gigl {
+
+// Owns the packed edge_attr layout used while merging typed PPR channels.
+//
+// Typed extraction first accumulates one dense feature vector per selected node,
+// then copies those vectors into the final tensor. Keeping the offsets here
+// keeps addTypedPPRSeedFeaturesAndCandidates focused on merge policy instead of
+// repeating manual column math.
+//
+// The width is 2 + (3 * numChannels):
+//   - 2 global columns:
+//       [best_score, hop_proximity]
+//     These preserve the regular PPR edge_attr contract at the front of the row.
+//   - 3 columns per typed channel:
+//       [(channel_score, channel_hop_proximity, channel_presence), ...]
+//     The per-channel score supports channel attribution/ranking, the per-channel
+//     hop proximity gives models a bounded closeness signal, and the presence bit
+//     is the explicit channel-reachability mask.
+//
+// Hop proximity is 1 / (1 + hop) when a channel reaches the node:
+// anchor=1.0, 1-hop=0.5, 2-hop ~= 0.333, and so on. Missing channels remain 0,
+// which is finite, bounded, and never looks closer than a reached channel. For
+// present channels, callers can recover the original hop count as
+// (1 - proximity) / proximity; use the presence bit before applying this
+// inverse because proximity 0 means the channel is missing.
+class TypedPPRFeatureLayout {
+public:
+    explicit TypedPPRFeatureLayout(int32_t numChannels) : _numChannels(numChannels) {
+        TORCH_CHECK(numChannels > 0, "Typed PPR feature layout requires at least one channel.");
+    }
+
+    [[nodiscard]] int32_t numFeatures() const {
+        return kNumGlobalFeatures + (kNumPerChannelFeatures * _numChannels);
+    }
+
+    // New node feature vectors start empty. Scores, proximities, and presence
+    // bits all use 0 as their absent-channel value.
+    [[nodiscard]] std::vector<double> makeFeatureVector() const {
+        return std::vector<double>(numFeatures(), 0.0);
+    }
+
+    // Merge one channel's emitted score/proximity into an existing node feature row.
+    //
+    // A node can be seen in multiple typed channels. The scalar score column keeps
+    // the best emitted PPR score for downstream consumers that expect one weight,
+    // while the global proximity keeps the closest discovered distance.
+    void updateScores(std::vector<double>& features, int32_t channelIndex, double score, double hopProximity) const {
+        validateFeatureVector(features);
+        validateChannelIndex(channelIndex);
+
+        // Repeated observations keep the strongest score and closest proximity.
+        // Current extraction emits at most one row per node per channel, but the
+        // monotonic merge keeps this helper safe if that changes.
+        features[kBestScoreIndex] = std::max(features[kBestScoreIndex], score);
+        features[kGlobalHopProximityIndex] = std::max(features[kGlobalHopProximityIndex], hopProximity);
+        features[channelScoreIndex(channelIndex)] = std::max(features[channelScoreIndex(channelIndex)], score);
+        features[channelHopProximityIndex(channelIndex)] =
+            std::max(features[channelHopProximityIndex(channelIndex)], hopProximity);
+        features[channelPresenceIndex(channelIndex)] = 1.0;
+    }
+
+private:
+    static constexpr int32_t kBestScoreIndex = 0;
+    static constexpr int32_t kGlobalHopProximityIndex = 1;
+    static constexpr int32_t kNumGlobalFeatures = 2;     // best score + global hop proximity
+    static constexpr int32_t kNumPerChannelFeatures = 3; // score + hop proximity + presence
+
+    [[nodiscard]] int32_t channelBaseIndex(int32_t channelIndex) const {
+        return kNumGlobalFeatures + (kNumPerChannelFeatures * channelIndex);
+    }
+    [[nodiscard]] int32_t channelScoreIndex(int32_t channelIndex) const {
+        return channelBaseIndex(channelIndex);
+    }
+    [[nodiscard]] int32_t channelHopProximityIndex(int32_t channelIndex) const {
+        return channelBaseIndex(channelIndex) + 1;
+    }
+    [[nodiscard]] int32_t channelPresenceIndex(int32_t channelIndex) const {
+        return channelBaseIndex(channelIndex) + 2;
+    }
+
+    void validateFeatureVector(const std::vector<double>& features) const {
+        TORCH_CHECK(features.size() == static_cast<std::size_t>(numFeatures()),
+                    "Typed PPR feature row width must be ",
+                    numFeatures(),
+                    ", got ",
+                    features.size(),
+                    ".");
+    }
+
+    void validateChannelIndex(int32_t channelIndex) const {
+        TORCH_CHECK(channelIndex >= 0 && channelIndex < _numChannels,
+                    "Typed PPR channel index ",
+                    channelIndex,
+                    " out of range [0, ",
+                    _numChannels,
+                    ").");
+    }
+
+    // The channel count is the only stored layout state. Every offset is derived
+    // from it, so feature width cannot drift from the per-channel triples.
+    const int32_t _numChannels;
+};
+
+} // namespace gigl

--- a/gigl-core/core/sampling/typed_ppr_feature_layout.h
+++ b/gigl-core/core/sampling/typed_ppr_feature_layout.h
@@ -9,6 +9,11 @@
 
 namespace gigl {
 
+constexpr int32_t kTypedPPRBestScoreIndex = 0;
+constexpr int32_t kTypedPPRGlobalHopProximityIndex = 1;
+constexpr int32_t kTypedPPRNumGlobalFeatures = 2;     // best score + global hop proximity
+constexpr int32_t kTypedPPRNumPerChannelFeatures = 3; // score + hop proximity + presence
+
 // Owns the packed edge_attr layout used while merging typed PPR channels.
 //
 // Typed extraction first accumulates one dense feature vector per selected node,
@@ -39,7 +44,7 @@ public:
     }
 
     [[nodiscard]] int32_t numFeatures() const {
-        return kNumGlobalFeatures + (kNumPerChannelFeatures * _numChannels);
+        return kTypedPPRNumGlobalFeatures + (kTypedPPRNumPerChannelFeatures * _numChannels);
     }
 
     // New node feature vectors start empty. Scores, proximities, and presence
@@ -60,8 +65,8 @@ public:
         // Repeated observations keep the strongest score and closest proximity.
         // Current extraction emits at most one row per node per channel, but the
         // monotonic merge keeps this helper safe if that changes.
-        features[kBestScoreIndex] = std::max(features[kBestScoreIndex], score);
-        features[kGlobalHopProximityIndex] = std::max(features[kGlobalHopProximityIndex], hopProximity);
+        features[kTypedPPRBestScoreIndex] = std::max(features[kTypedPPRBestScoreIndex], score);
+        features[kTypedPPRGlobalHopProximityIndex] = std::max(features[kTypedPPRGlobalHopProximityIndex], hopProximity);
         features[channelScoreIndex(channelIndex)] = std::max(features[channelScoreIndex(channelIndex)], score);
         features[channelHopProximityIndex(channelIndex)] =
             std::max(features[channelHopProximityIndex(channelIndex)], hopProximity);
@@ -69,13 +74,8 @@ public:
     }
 
 private:
-    static constexpr int32_t kBestScoreIndex = 0;
-    static constexpr int32_t kGlobalHopProximityIndex = 1;
-    static constexpr int32_t kNumGlobalFeatures = 2;     // best score + global hop proximity
-    static constexpr int32_t kNumPerChannelFeatures = 3; // score + hop proximity + presence
-
     [[nodiscard]] int32_t channelBaseIndex(int32_t channelIndex) const {
-        return kNumGlobalFeatures + (kNumPerChannelFeatures * channelIndex);
+        return kTypedPPRNumGlobalFeatures + (kTypedPPRNumPerChannelFeatures * channelIndex);
     }
     [[nodiscard]] int32_t channelScoreIndex(int32_t channelIndex) const {
         return channelBaseIndex(channelIndex);

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -221,7 +221,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][5], -1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][5], 2.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][6], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][7], 0.0, 1e-9);
 
@@ -229,7 +229,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[2][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][2], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][3], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][4], -1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][4], 2.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][5], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][6], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][7], 1.0, 1e-9);
@@ -270,7 +270,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
     EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][2], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][4], -1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][4], 2.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][5], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][6], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][7], 1.0, 1e-9);

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -83,7 +83,9 @@ TEST(PPRForwardPush, PprScoreAbsorbsAlpha) {
     ASSERT_NE(topk.find(0), topk.end());
     const auto& [ids, weights, counts] = topk.at(0);
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
-    EXPECT_NEAR(weights[0].item<float>(), static_cast<float>(alpha), 1e-5F);
+    ASSERT_EQ(weights.size(1), 2);
+    EXPECT_NEAR(weights[0][0].item<float>(), static_cast<float>(alpha), 1e-5F);
+    EXPECT_NEAR(weights[0][1].item<float>(), 0.0F, 1e-5F);
 }
 
 // Node 0 (degree 1) pushes (1-alpha)*alpha residual to node 1 (sink).
@@ -107,8 +109,11 @@ TEST(PPRForwardPush, ResidualDistributedToNeighbor) {
     ASSERT_EQ(counts[0].item<int64_t>(), 2);
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
     EXPECT_EQ(ids[1].item<int64_t>(), 1);
-    EXPECT_NEAR(weights[0].item<float>(), static_cast<float>(alpha), 1e-5F);
-    EXPECT_NEAR(weights[1].item<float>(), static_cast<float>((1.0 - alpha) * alpha), 1e-5F);
+    ASSERT_EQ(weights.size(1), 2);
+    EXPECT_NEAR(weights[0][0].item<float>(), static_cast<float>(alpha), 1e-5F);
+    EXPECT_NEAR(weights[0][1].item<float>(), 0.0F, 1e-5F);
+    EXPECT_NEAR(weights[1][0].item<float>(), static_cast<float>((1.0 - alpha) * alpha), 1e-5F);
+    EXPECT_NEAR(weights[1][1].item<float>(), 1.0F, 1e-5F);
 }
 
 // Once a (node, edge type) neighbor list is fetched, it should be cached for the
@@ -199,26 +204,29 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({0, 10, 20}));
     EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({3}));
     ASSERT_EQ(features.size(0), 3);
-    ASSERT_EQ(features.size(1), 5);
+    ASSERT_EQ(features.size(1), 6);
 
     auto featureAccessor = features.accessor<double, 2>();
     EXPECT_NEAR(featureAccessor[0][0], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][1], 0.5, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][3], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][5], 1.0, 1e-9);
 
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][1], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][2], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][3], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][4], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][3], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][5], 0.0, 1e-9);
 
     EXPECT_NEAR(featureAccessor[2][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][1], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][2], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][3], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][4], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][1], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][2], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][3], 0.25, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][4], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][5], 1.0, 1e-9);
 }
 
 TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows) {
@@ -240,20 +248,22 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
     EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({0, 20}));
     EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({2}));
     ASSERT_EQ(features.size(0), 2);
-    ASSERT_EQ(features.size(1), 5);
+    ASSERT_EQ(features.size(1), 6);
 
     auto featureAccessor = features.accessor<double, 2>();
     EXPECT_NEAR(featureAccessor[0][0], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][1], 0.5, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][3], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][5], 1.0, 1e-9);
 
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][1], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][3], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][2], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][3], 0.25, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][4], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][5], 1.0, 1e-9);
 }
 
 TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpEmitsResidualAwareBaseRows) {
@@ -273,15 +283,17 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpEmitsResidualAwareBaseRows
     EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({0, 1}));
     EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({2}));
     ASSERT_EQ(features.size(0), 2);
-    ASSERT_EQ(features.size(1), 3);
+    ASSERT_EQ(features.size(1), 4);
 
     auto featureAccessor = features.accessor<double, 2>();
     EXPECT_NEAR(featureAccessor[0][0], 0.625, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][1], 0.625, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][2], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][2], 0.625, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][3], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][1], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][2], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][3], 1.0, 1e-9);
 }
 
 TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpCanDisableTopUp) {
@@ -303,7 +315,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpCanDisableTopUp) {
     EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({0}));
     EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({1}));
     ASSERT_EQ(features.size(0), 1);
-    ASSERT_EQ(features.size(1), 5);
+    ASSERT_EQ(features.size(1), 6);
 }
 
 // Two seeds (0 and 1) both push residual to sink node 2.  The neighbor-lookup
@@ -375,11 +387,13 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpIncludesUnpushedResiduals) {
     const auto& [ids, weights, counts] = topkWithResiduals.at(0);
     ASSERT_EQ(counts[0].item<int64_t>(), 3);
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
-    EXPECT_NEAR(weights[0].item<float>(), static_cast<float>(alpha), 1e-5F);
+    ASSERT_EQ(weights.size(1), 2);
+    EXPECT_NEAR(weights[0][0].item<float>(), static_cast<float>(alpha), 1e-5F);
+    EXPECT_NEAR(weights[0][1].item<float>(), 0.0F, 1e-5F);
 
     std::unordered_map<int64_t, float> residualWeights;
-    residualWeights[ids[1].item<int64_t>()] = weights[1].item<float>();
-    residualWeights[ids[2].item<int64_t>()] = weights[2].item<float>();
+    residualWeights[ids[1].item<int64_t>()] = weights[1][0].item<float>();
+    residualWeights[ids[2].item<int64_t>()] = weights[2][0].item<float>();
     ASSERT_NE(residualWeights.find(1), residualWeights.end());
     ASSERT_NE(residualWeights.find(2), residualWeights.end());
     EXPECT_NEAR(residualWeights[1], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
@@ -410,17 +424,23 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpSortsSelectedResultsByScore) {
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
     EXPECT_EQ(ids[3].item<int64_t>(), 3);
     for (int64_t index = 1; index < counts[0].item<int64_t>(); ++index) {
-        EXPECT_GE(weights[index - 1].item<float>(), weights[index].item<float>());
+        EXPECT_GE(weights[index - 1][0].item<float>(), weights[index][0].item<float>());
     }
 
     std::unordered_map<int64_t, float> weightsByNodeId;
+    std::unordered_map<int64_t, float> hopsByNodeId;
     for (int64_t index = 0; index < counts[0].item<int64_t>(); ++index) {
-        weightsByNodeId[ids[index].item<int64_t>()] = weights[index].item<float>();
+        weightsByNodeId[ids[index].item<int64_t>()] = weights[index][0].item<float>();
+        hopsByNodeId[ids[index].item<int64_t>()] = weights[index][1].item<float>();
     }
     EXPECT_NEAR(weightsByNodeId[0], static_cast<float>(alpha), 1e-5F);
     EXPECT_NEAR(weightsByNodeId[1], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
     EXPECT_NEAR(weightsByNodeId[2], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
     EXPECT_NEAR(weightsByNodeId[3], static_cast<float>((1.0 - alpha) * (1.0 - alpha) * alpha / 2.0), 1e-5F);
+    EXPECT_NEAR(hopsByNodeId[0], 0.0F, 1e-5F);
+    EXPECT_NEAR(hopsByNodeId[1], 1.0F, 1e-5F);
+    EXPECT_NEAR(hopsByNodeId[2], 1.0F, 1e-5F);
+    EXPECT_NEAR(hopsByNodeId[3], 2.0F, 1e-5F);
 }
 
 // maxPPRNodes is the total output cap across finalized PPR and residual top-up
@@ -439,7 +459,9 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpUsesMaxPPRNodesAsTotalCap) {
 
     ASSERT_EQ(counts[0].item<int64_t>(), 2);
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
-    EXPECT_NEAR(weights[0].item<float>(), static_cast<float>(alpha), 1e-5F);
+    ASSERT_EQ(weights.size(1), 2);
+    EXPECT_NEAR(weights[0][0].item<float>(), static_cast<float>(alpha), 1e-5F);
+    EXPECT_NEAR(weights[0][1].item<float>(), 0.0F, 1e-5F);
 }
 
 TEST(PPRForwardPush, ExtractTopKWithResidualTopUpRejectsNegativeMaxPPRNodes) {

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -211,8 +211,8 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][4], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][5], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][5], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][6], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][7], 1.0, 1e-9);
 
@@ -220,8 +220,8 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][5], 2.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][4], 0.5, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][5], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][6], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][7], 0.0, 1e-9);
 
@@ -229,8 +229,8 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[2][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][2], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][3], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][4], 2.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][5], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][4], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][5], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[2][6], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][7], 1.0, 1e-9);
 }
@@ -261,8 +261,8 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
     EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][4], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][5], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][5], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][6], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][7], 1.0, 1e-9);
 
@@ -270,8 +270,8 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
     EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][2], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][4], 2.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][5], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][4], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][5], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[1][6], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][7], 1.0, 1e-9);
 }
@@ -299,12 +299,12 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpEmitsResidualAwareBaseRows
     EXPECT_NEAR(featureAccessor[0][0], 0.625, 1e-9);
     EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.625, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][3], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][3], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][3], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][3], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
 }
 

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -85,7 +85,7 @@ TEST(PPRForwardPush, PprScoreAbsorbsAlpha) {
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
     ASSERT_EQ(weights.size(1), 2);
     EXPECT_NEAR(weights[0][0].item<float>(), static_cast<float>(alpha), 1e-5F);
-    EXPECT_NEAR(weights[0][1].item<float>(), 0.0F, 1e-5F);
+    EXPECT_NEAR(weights[0][1].item<float>(), 1.0F, 1e-5F);
 }
 
 // Node 0 (degree 1) pushes (1-alpha)*alpha residual to node 1 (sink).
@@ -111,9 +111,9 @@ TEST(PPRForwardPush, ResidualDistributedToNeighbor) {
     EXPECT_EQ(ids[1].item<int64_t>(), 1);
     ASSERT_EQ(weights.size(1), 2);
     EXPECT_NEAR(weights[0][0].item<float>(), static_cast<float>(alpha), 1e-5F);
-    EXPECT_NEAR(weights[0][1].item<float>(), 0.0F, 1e-5F);
+    EXPECT_NEAR(weights[0][1].item<float>(), 1.0F, 1e-5F);
     EXPECT_NEAR(weights[1][0].item<float>(), static_cast<float>((1.0 - alpha) * alpha), 1e-5F);
-    EXPECT_NEAR(weights[1][1].item<float>(), 1.0F, 1e-5F);
+    EXPECT_NEAR(weights[1][1].item<float>(), 0.5F, 1e-5F);
 }
 
 // Once a (node, edge type) neighbor list is fetched, it should be cached for the
@@ -208,7 +208,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
 
     auto featureAccessor = features.accessor<double, 2>();
     EXPECT_NEAR(featureAccessor[0][0], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
@@ -217,7 +217,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[0][7], 1.0, 1e-9);
 
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][1], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][4], 0.5, 1e-9);
@@ -226,7 +226,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[1][7], 0.0, 1e-9);
 
     EXPECT_NEAR(featureAccessor[2][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][1], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][1], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[2][2], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][3], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[2][4], 0.0, 1e-9);
@@ -258,7 +258,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
 
     auto featureAccessor = features.accessor<double, 2>();
     EXPECT_NEAR(featureAccessor[0][0], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
@@ -267,7 +267,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
     EXPECT_NEAR(featureAccessor[0][7], 1.0, 1e-9);
 
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][1], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[1][2], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][4], 0.0, 1e-9);
@@ -297,12 +297,12 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpEmitsResidualAwareBaseRows
 
     auto featureAccessor = features.accessor<double, 2>();
     EXPECT_NEAR(featureAccessor[0][0], 0.625, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.625, 1e-9);
     EXPECT_NEAR(featureAccessor[0][3], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][1], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
@@ -401,7 +401,7 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpIncludesUnpushedResiduals) {
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
     ASSERT_EQ(weights.size(1), 2);
     EXPECT_NEAR(weights[0][0].item<float>(), static_cast<float>(alpha), 1e-5F);
-    EXPECT_NEAR(weights[0][1].item<float>(), 0.0F, 1e-5F);
+    EXPECT_NEAR(weights[0][1].item<float>(), 1.0F, 1e-5F);
 
     std::unordered_map<int64_t, float> residualWeights;
     residualWeights[ids[1].item<int64_t>()] = weights[1][0].item<float>();
@@ -440,19 +440,19 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpSortsSelectedResultsByScore) {
     }
 
     std::unordered_map<int64_t, float> weightsByNodeId;
-    std::unordered_map<int64_t, float> hopsByNodeId;
+    std::unordered_map<int64_t, float> proximitiesByNodeId;
     for (int64_t index = 0; index < counts[0].item<int64_t>(); ++index) {
         weightsByNodeId[ids[index].item<int64_t>()] = weights[index][0].item<float>();
-        hopsByNodeId[ids[index].item<int64_t>()] = weights[index][1].item<float>();
+        proximitiesByNodeId[ids[index].item<int64_t>()] = weights[index][1].item<float>();
     }
     EXPECT_NEAR(weightsByNodeId[0], static_cast<float>(alpha), 1e-5F);
     EXPECT_NEAR(weightsByNodeId[1], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
     EXPECT_NEAR(weightsByNodeId[2], static_cast<float>((1.0 - alpha) * alpha / 2.0), 1e-5F);
     EXPECT_NEAR(weightsByNodeId[3], static_cast<float>((1.0 - alpha) * (1.0 - alpha) * alpha / 2.0), 1e-5F);
-    EXPECT_NEAR(hopsByNodeId[0], 0.0F, 1e-5F);
-    EXPECT_NEAR(hopsByNodeId[1], 1.0F, 1e-5F);
-    EXPECT_NEAR(hopsByNodeId[2], 1.0F, 1e-5F);
-    EXPECT_NEAR(hopsByNodeId[3], 2.0F, 1e-5F);
+    EXPECT_NEAR(proximitiesByNodeId[0], 1.0F, 1e-5F);
+    EXPECT_NEAR(proximitiesByNodeId[1], 0.5F, 1e-5F);
+    EXPECT_NEAR(proximitiesByNodeId[2], 0.5F, 1e-5F);
+    EXPECT_NEAR(proximitiesByNodeId[3], 1.0F / 3.0F, 1e-5F);
 }
 
 // maxPPRNodes is the total output cap across finalized PPR and residual top-up
@@ -473,7 +473,7 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpUsesMaxPPRNodesAsTotalCap) {
     EXPECT_EQ(ids[0].item<int64_t>(), 0);
     ASSERT_EQ(weights.size(1), 2);
     EXPECT_NEAR(weights[0][0].item<float>(), static_cast<float>(alpha), 1e-5F);
-    EXPECT_NEAR(weights[0][1].item<float>(), 0.0F, 1e-5F);
+    EXPECT_NEAR(weights[0][1].item<float>(), 1.0F, 1e-5F);
 }
 
 TEST(PPRForwardPush, ExtractTopKWithResidualTopUpRejectsNegativeMaxPPRNodes) {

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -54,6 +54,34 @@ static std::vector<int64_t> tensorToInt64Vector(const torch::Tensor& values) {
     return result;
 }
 
+static void expectTypedPPRFeatureRowNear(const torch::Tensor& features,
+                                         int64_t rowIndex,
+                                         double bestScore,
+                                         double hopProximity,
+                                         const std::vector<double>& channelScores,
+                                         const std::vector<double>& channelHopProximities,
+                                         const std::vector<double>& channelPresence) {
+    SCOPED_TRACE(::testing::Message() << "typed PPR feature row " << rowIndex);
+    ASSERT_EQ(features.dim(), 2);
+    ASSERT_GE(rowIndex, 0);
+    ASSERT_LT(rowIndex, features.size(0));
+    ASSERT_EQ(channelScores.size(), channelHopProximities.size());
+    ASSERT_EQ(channelScores.size(), channelPresence.size());
+
+    const auto numChannels = static_cast<int64_t>(channelScores.size());
+    ASSERT_EQ(features.size(1), 2 + (3 * numChannels));
+
+    auto featureAccessor = features.accessor<double, 2>();
+    EXPECT_NEAR(featureAccessor[rowIndex][0], bestScore, 1e-9);
+    EXPECT_NEAR(featureAccessor[rowIndex][1], hopProximity, 1e-9);
+    for (int64_t channelIndex = 0; channelIndex < numChannels; ++channelIndex) {
+        const int64_t channelBaseIndex = 2 + (3 * channelIndex);
+        EXPECT_NEAR(featureAccessor[rowIndex][channelBaseIndex], channelScores[channelIndex], 1e-9);
+        EXPECT_NEAR(featureAccessor[rowIndex][channelBaseIndex + 1], channelHopProximities[channelIndex], 1e-9);
+        EXPECT_NEAR(featureAccessor[rowIndex][channelBaseIndex + 2], channelPresence[channelIndex], 1e-9);
+    }
+}
+
 // After construction, drainQueue() returns the seed node under etype 0.
 TEST(PPRForwardPush, DrainQueueReturnsSeedNodeInitially) {
     auto state = makeState(/*seeds=*/{0}, /*alpha=*/0.15, /*requeueThresholdFactor=*/1e-6, /*degrees=*/{1});
@@ -114,6 +142,26 @@ TEST(PPRForwardPush, ResidualDistributedToNeighbor) {
     EXPECT_NEAR(weights[0][1].item<float>(), 1.0F, 1e-5F);
     EXPECT_NEAR(weights[1][0].item<float>(), static_cast<float>((1.0 - alpha) * alpha), 1e-5F);
     EXPECT_NEAR(weights[1][1].item<float>(), 0.5F, 1e-5F);
+}
+
+TEST(PPRForwardPush, HopProximityIsScopedPerSeed) {
+    auto state = makeState(/*seeds=*/{0, 1}, /*alpha=*/0.5, /*requeueThresholdFactor=*/1.0, /*degrees=*/{1, 0});
+
+    state.drainQueue();
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0, 1}, /*flatNeighborIds=*/{1}, /*counts=*/{1, 0}));
+    state.drainQueue();
+    state.pushResiduals({});
+
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*enableResidualTopUp=*/false);
+    ASSERT_NE(topk.find(0), topk.end());
+    const auto& [ids, weights, counts] = topk.at(0);
+
+    EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({0, 1, 1}));
+    EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({2, 1}));
+    ASSERT_EQ(weights.size(1), 2);
+    EXPECT_NEAR(weights[0][1].item<float>(), 1.0F, 1e-5F); // seed 0 anchor
+    EXPECT_NEAR(weights[1][1].item<float>(), 0.5F, 1e-5F); // seed 0 reaches node 1 at 1-hop
+    EXPECT_NEAR(weights[2][1].item<float>(), 1.0F, 1e-5F); // seed 1 anchor remains isolated
 }
 
 // Once a (node, edge type) neighbor list is fetched, it should be cached for the
@@ -206,33 +254,27 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     ASSERT_EQ(features.size(0), 3);
     ASSERT_EQ(features.size(1), 8);
 
-    auto featureAccessor = features.accessor<double, 2>();
-    EXPECT_NEAR(featureAccessor[0][0], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][1], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][5], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][6], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][7], 1.0, 1e-9);
-
-    EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][1], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][3], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][4], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][5], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][6], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][7], 0.0, 1e-9);
-
-    EXPECT_NEAR(featureAccessor[2][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][1], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][2], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][3], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][4], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][5], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][6], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][7], 1.0, 1e-9);
+    expectTypedPPRFeatureRowNear(features,
+                                 /*rowIndex=*/0,
+                                 /*bestScore=*/0.5,
+                                 /*hopProximity=*/1.0,
+                                 /*channelScores=*/{0.5, 0.5},
+                                 /*channelHopProximities=*/{1.0, 1.0},
+                                 /*channelPresence=*/{1.0, 1.0});
+    expectTypedPPRFeatureRowNear(features,
+                                 /*rowIndex=*/1,
+                                 /*bestScore=*/0.25,
+                                 /*hopProximity=*/0.5,
+                                 /*channelScores=*/{0.25, 0.0},
+                                 /*channelHopProximities=*/{0.5, 0.0},
+                                 /*channelPresence=*/{1.0, 0.0});
+    expectTypedPPRFeatureRowNear(features,
+                                 /*rowIndex=*/2,
+                                 /*bestScore=*/0.25,
+                                 /*hopProximity=*/0.5,
+                                 /*channelScores=*/{0.0, 0.25},
+                                 /*channelHopProximities=*/{0.0, 0.5},
+                                 /*channelPresence=*/{0.0, 1.0});
 }
 
 TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows) {
@@ -256,24 +298,20 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
     ASSERT_EQ(features.size(0), 2);
     ASSERT_EQ(features.size(1), 8);
 
-    auto featureAccessor = features.accessor<double, 2>();
-    EXPECT_NEAR(featureAccessor[0][0], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][1], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][5], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][6], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][7], 1.0, 1e-9);
-
-    EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][1], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][2], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][3], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][4], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][5], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][6], 0.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][7], 1.0, 1e-9);
+    expectTypedPPRFeatureRowNear(features,
+                                 /*rowIndex=*/0,
+                                 /*bestScore=*/0.5,
+                                 /*hopProximity=*/1.0,
+                                 /*channelScores=*/{0.5, 0.5},
+                                 /*channelHopProximities=*/{1.0, 1.0},
+                                 /*channelPresence=*/{1.0, 1.0});
+    expectTypedPPRFeatureRowNear(features,
+                                 /*rowIndex=*/1,
+                                 /*bestScore=*/0.25,
+                                 /*hopProximity=*/0.5,
+                                 /*channelScores=*/{0.0, 0.25},
+                                 /*channelHopProximities=*/{0.0, 0.5},
+                                 /*channelPresence=*/{0.0, 1.0});
 }
 
 TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpEmitsResidualAwareBaseRows) {
@@ -295,17 +333,20 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpEmitsResidualAwareBaseRows
     ASSERT_EQ(features.size(0), 2);
     ASSERT_EQ(features.size(1), 5);
 
-    auto featureAccessor = features.accessor<double, 2>();
-    EXPECT_NEAR(featureAccessor[0][0], 0.625, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][1], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][2], 0.625, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][3], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][1], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][3], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
+    expectTypedPPRFeatureRowNear(features,
+                                 /*rowIndex=*/0,
+                                 /*bestScore=*/0.625,
+                                 /*hopProximity=*/1.0,
+                                 /*channelScores=*/{0.625},
+                                 /*channelHopProximities=*/{1.0},
+                                 /*channelPresence=*/{1.0});
+    expectTypedPPRFeatureRowNear(features,
+                                 /*rowIndex=*/1,
+                                 /*bestScore=*/0.25,
+                                 /*hopProximity=*/0.5,
+                                 /*channelScores=*/{0.25},
+                                 /*channelHopProximities=*/{0.5},
+                                 /*channelPresence=*/{1.0});
 }
 
 TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpCanDisableTopUp) {

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -221,7 +221,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][5], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][5], -1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][6], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][7], 0.0, 1e-9);
 
@@ -229,7 +229,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[2][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][2], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][3], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[2][4], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][4], -1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][5], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][6], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][7], 1.0, 1e-9);
@@ -270,7 +270,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
     EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][2], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 0.25, 1e-9);
-    EXPECT_NEAR(featureAccessor[1][4], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][4], -1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][5], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][6], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][7], 1.0, 1e-9);

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -204,15 +204,17 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({0, 10, 20}));
     EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({3}));
     ASSERT_EQ(features.size(0), 3);
-    ASSERT_EQ(features.size(1), 6);
+    ASSERT_EQ(features.size(1), 8);
 
     auto featureAccessor = features.accessor<double, 2>();
     EXPECT_NEAR(featureAccessor[0][0], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][5], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][4], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][5], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][6], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][7], 1.0, 1e-9);
 
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
@@ -220,6 +222,8 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[1][3], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][5], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][6], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][7], 0.0, 1e-9);
 
     EXPECT_NEAR(featureAccessor[2][0], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[2][1], 1.0, 1e-9);
@@ -227,6 +231,8 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpMergesChannelsInCpp) {
     EXPECT_NEAR(featureAccessor[2][3], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[2][4], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[2][5], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][6], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[2][7], 1.0, 1e-9);
 }
 
 TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows) {
@@ -248,15 +254,17 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
     EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({0, 20}));
     EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({2}));
     ASSERT_EQ(features.size(0), 2);
-    ASSERT_EQ(features.size(1), 6);
+    ASSERT_EQ(features.size(1), 8);
 
     auto featureAccessor = features.accessor<double, 2>();
     EXPECT_NEAR(featureAccessor[0][0], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.5, 1e-9);
     EXPECT_NEAR(featureAccessor[0][3], 0.5, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][5], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][4], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][5], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][6], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][7], 1.0, 1e-9);
 
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
@@ -264,6 +272,8 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpUsesTargetsForResidualRows
     EXPECT_NEAR(featureAccessor[1][3], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][4], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][5], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][6], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][7], 1.0, 1e-9);
 }
 
 TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpEmitsResidualAwareBaseRows) {
@@ -283,17 +293,19 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpEmitsResidualAwareBaseRows
     EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({0, 1}));
     EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({2}));
     ASSERT_EQ(features.size(0), 2);
-    ASSERT_EQ(features.size(1), 4);
+    ASSERT_EQ(features.size(1), 5);
 
     auto featureAccessor = features.accessor<double, 2>();
     EXPECT_NEAR(featureAccessor[0][0], 0.625, 1e-9);
     EXPECT_NEAR(featureAccessor[0][1], 0.0, 1e-9);
     EXPECT_NEAR(featureAccessor[0][2], 0.625, 1e-9);
-    EXPECT_NEAR(featureAccessor[0][3], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][3], 0.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[0][4], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][0], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][1], 1.0, 1e-9);
     EXPECT_NEAR(featureAccessor[1][2], 0.25, 1e-9);
     EXPECT_NEAR(featureAccessor[1][3], 1.0, 1e-9);
+    EXPECT_NEAR(featureAccessor[1][4], 1.0, 1e-9);
 }
 
 TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpCanDisableTopUp) {
@@ -315,7 +327,7 @@ TEST(PPRForwardPush, ExtractTypedTopKWithResidualTopUpCanDisableTopUp) {
     EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({0}));
     EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({1}));
     ASSERT_EQ(features.size(0), 1);
-    ASSERT_EQ(features.size(1), 6);
+    ASSERT_EQ(features.size(1), 8);
 }
 
 // Two seeds (0 and 1) both push residual to sink node 2.  The neighbor-lookup

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -114,7 +114,8 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         - ``data[(seed_type, "ppr", neighbor_type)].edge_attr``:
           ``[ppr_score, min_hop]`` for regular PPR. For typed PPR, edge attrs
           are multi-column:
-          ``[best_score, min_hop, channel_scores..., channel_presence_bits...]``.
+          ``[best_score, min_hop, channel_scores..., channel_min_hops...,
+          channel_presence_bits...]``.
           Scores use the same PPR mass scale as regular PPR output.
           Channel columns follow the insertion order of
           ``typed_channel_ratios``. Column 0 is the scalar best score for

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -47,9 +47,9 @@ _PPR_HOMOGENEOUS_EDGE_TYPE = (
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
 )
 
-# C++ PPR extraction output: flat node IDs, flat weights, and per-seed valid
-# counts. Homogeneous extraction uses tensors directly; heterogeneous extraction
-# uses dictionaries keyed by node type.
+# C++ PPR extraction output: flat node IDs, flat edge-attribute rows, and
+# per-seed valid counts. Homogeneous extraction uses tensors directly;
+# heterogeneous extraction uses dictionaries keyed by node type.
 PPRResult = tuple[
     Union[torch.Tensor, dict[NodeType, torch.Tensor]],
     Union[torch.Tensor, dict[NodeType, torch.Tensor]],
@@ -120,7 +120,8 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
           Channel columns follow the insertion order of
           ``typed_channel_ratios``. Column 0 is the scalar best score for
           consumers that need a single PPR weight, and column 1 is always the
-          minimum-hop count.
+          global minimum-hop count. Per-channel min-hop columns use ``-1`` when
+          that channel did not reach the node.
 
     Args:
         alpha: Restart probability (teleport probability back to seed). Higher values
@@ -554,17 +555,18 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
                 homogeneous graphs (internally mapped to a sentinel type).
 
         Returns:
-            A 3-tuple ``(flat_neighbor_ids, flat_weights, valid_counts)``.
-            For homogeneous graphs each element is a 1-D tensor; for
-            heterogeneous graphs each element is a ``dict[NodeType, Tensor]``
-            where each tensor has the same structure as the homogeneous case.
+            A 3-tuple ``(flat_neighbor_ids, flat_edge_attrs, valid_counts)``.
+            For homogeneous graphs each element is a tensor; for heterogeneous
+            graphs each element is a ``dict[NodeType, Tensor]`` where each
+            tensor has the same structure as the homogeneous case.
 
             - ``flat_neighbor_ids``: global neighbor IDs selected by top-k PPR
               score, concatenated across seeds.  For batch of size ``B`` with
               ``C_i`` neighbors for seed ``i``, shape is
               ``[sum(C_0, ..., C_{B-1})]``.
-            - ``flat_weights``: PPR scores corresponding to each entry in
-              ``flat_neighbor_ids``, same shape.
+            - ``flat_edge_attrs``: ``[ppr_score, min_hop]`` rows
+              corresponding to each entry in ``flat_neighbor_ids``, shape
+              ``[sum(C_0, ..., C_{B-1}), 2]``.
             - ``valid_counts``: number of PPR neighbors contributed by each
               seed, shape ``[batch_size]``.  Used to slice the flat tensors into
               per-seed groups: seed ``i``'s neighbors are at
@@ -574,8 +576,8 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
 
             # 4 seeds, valid_counts = [1, 3, 2, 0]  →  6 total (seed, neighbor) pairs
             flat_neighbor_ids = tensor([d0, d1a, d1b, d1c, d2a, d2b])
-            flat_weights      = tensor([w0, w1a, w1b, w1c, w2a, w2b])
-            valid_counts      = tensor([1,  3,   2,   0])
+            flat_edge_attrs   = tensor([[w0, h0], [w1a, h1a], ..., [w2b, h2b]])
+            valid_counts      = tensor([1, 3, 2, 0])
         """
         if seed_node_type is None:
             seed_node_type = DEFAULT_HOMOGENEOUS_NODE_TYPE

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -104,25 +104,24 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
     **Homogeneous (Data):**
         - ``data.edge_index``: ``[2, N]`` int64 — row 0 is local seed indices,
           row 1 is local neighbor indices.
-        - ``data.edge_attr``: ``[N, 2]`` float — ``[ppr_score, min_hop]`` for
-          each pair. ``min_hop`` is emitted as ``0`` for the anchor, ``1``
-          for 1-hop, ``2`` for 2-hop, and so on.
+        - ``data.edge_attr``: ``[N, 2]`` float — ``[ppr_score, hop_proximity]``
+          for each pair. ``hop_proximity`` is ``1 / (1 + hop)``: ``1.0`` for
+          the anchor, ``0.5`` for 1-hop, and so on.
 
     **Heterogeneous (HeteroData)** — one PPR edge type per
     ``(seed_type, neighbor_type)`` pair, with ``"ppr"`` as the relation:
         - ``data[(seed_type, "ppr", neighbor_type)].edge_index``: same format as above.
         - ``data[(seed_type, "ppr", neighbor_type)].edge_attr``:
-          ``[ppr_score, min_hop]`` for regular PPR. For typed PPR, edge attrs
-          are multi-column:
-          ``[best_score, min_hop, channel_scores..., channel_hop_proximities...,
+          ``[ppr_score, hop_proximity]`` for regular PPR. For typed PPR, edge
+          attrs are multi-column:
+          ``[best_score, hop_proximity, channel_scores..., channel_hop_proximities...,
           channel_presence_bits...]``.
           Scores use the same PPR mass scale as regular PPR output.
           Channel columns follow the insertion order of
           ``typed_channel_ratios``. Column 0 is the scalar best score for
           consumers that need a single PPR weight, and column 1 is always the
-          global minimum-hop count. Per-channel hop proximity is
-          ``1 / (1 + min_hop)`` when that channel reached the node, and ``0``
-          when it did not.
+          global hop proximity. Per-channel hop proximity is ``1 / (1 + hop)``
+          when that channel reached the node, and ``0`` when it did not.
           For present channels, the original hop count can be recovered as
           ``(1 - proximity) / proximity``; use the presence bit before applying
           this inverse because missing channels have proximity ``0``.
@@ -568,7 +567,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
               score, concatenated across seeds.  For batch of size ``B`` with
               ``C_i`` neighbors for seed ``i``, shape is
               ``[sum(C_0, ..., C_{B-1})]``.
-            - ``flat_edge_attrs``: ``[ppr_score, min_hop]`` rows
+            - ``flat_edge_attrs``: ``[ppr_score, hop_proximity]`` rows
               corresponding to each entry in ``flat_neighbor_ids``, shape
               ``[sum(C_0, ..., C_{B-1}), 2]``.
             - ``valid_counts``: number of PPR neighbors contributed by each
@@ -580,7 +579,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
 
             # 4 seeds, valid_counts = [1, 3, 2, 0]  →  6 total (seed, neighbor) pairs
             flat_neighbor_ids = tensor([d0, d1a, d1b, d1c, d2a, d2b])
-            flat_edge_attrs   = tensor([[w0, h0], [w1a, h1a], ..., [w2b, h2b]])
+            flat_edge_attrs   = tensor([[w0, p0], [w1a, p1a], ..., [w2b, p2b]])
             valid_counts      = tensor([1, 3, 2, 0])
         """
         if seed_node_type is None:

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -114,8 +114,8 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         - ``data[(seed_type, "ppr", neighbor_type)].edge_attr``:
           ``[ppr_score, hop_proximity]`` for regular PPR. For typed PPR, edge
           attrs are multi-column:
-          ``[best_score, hop_proximity, channel_scores..., channel_hop_proximities...,
-          channel_presence_bits...]``.
+          ``[best_score, hop_proximity, (channel_score, channel_hop_proximity,
+          channel_presence), ...]``.
           Scores use the same PPR mass scale as regular PPR output.
           Channel columns follow the insertion order of
           ``typed_channel_ratios``. Column 0 is the scalar best score for

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -104,18 +104,22 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
     **Homogeneous (Data):**
         - ``data.edge_index``: ``[2, N]`` int64 — row 0 is local seed indices,
           row 1 is local neighbor indices.
-        - ``data.edge_attr``: ``[N]`` float — PPR score for each pair.
+        - ``data.edge_attr``: ``[N, 2]`` float — ``[ppr_score, min_hop]`` for
+          each pair. ``min_hop`` is emitted as ``0`` for the anchor, ``1``
+          for 1-hop, ``2`` for 2-hop, and so on.
 
     **Heterogeneous (HeteroData)** — one PPR edge type per
     ``(seed_type, neighbor_type)`` pair, with ``"ppr"`` as the relation:
         - ``data[(seed_type, "ppr", neighbor_type)].edge_index``: same format as above.
-        - ``data[(seed_type, "ppr", neighbor_type)].edge_attr``: scalar PPR
-          score for regular PPR. For typed PPR, edge attrs are multi-column:
-          ``[best_score, channel_scores..., channel_presence_bits...]``.
-          Scores use the same PPR mass scale as regular scalar PPR output.
+        - ``data[(seed_type, "ppr", neighbor_type)].edge_attr``:
+          ``[ppr_score, min_hop]`` for regular PPR. For typed PPR, edge attrs
+          are multi-column:
+          ``[best_score, min_hop, channel_scores..., channel_presence_bits...]``.
+          Scores use the same PPR mass scale as regular PPR output.
           Channel columns follow the insertion order of
           ``typed_channel_ratios``. Column 0 is the scalar best score for
-          consumers that need a single PPR weight.
+          consumers that need a single PPR weight, and column 1 is always the
+          minimum-hop count.
 
     Args:
         alpha: Restart probability (teleport probability back to seed). Higher values

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -120,8 +120,9 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
           Channel columns follow the insertion order of
           ``typed_channel_ratios``. Column 0 is the scalar best score for
           consumers that need a single PPR weight, and column 1 is always the
-          global minimum-hop count. Per-channel min-hop columns use ``-1`` when
-          that channel did not reach the node.
+          global minimum-hop count. Per-channel min-hop columns use one greater
+          than the largest reached-channel min-hop for that node when the
+          channel did not reach the node.
 
     Args:
         alpha: Restart probability (teleport probability back to seed). Higher values

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -114,15 +114,18 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         - ``data[(seed_type, "ppr", neighbor_type)].edge_attr``:
           ``[ppr_score, min_hop]`` for regular PPR. For typed PPR, edge attrs
           are multi-column:
-          ``[best_score, min_hop, channel_scores..., channel_min_hops...,
+          ``[best_score, min_hop, channel_scores..., channel_hop_proximities...,
           channel_presence_bits...]``.
           Scores use the same PPR mass scale as regular PPR output.
           Channel columns follow the insertion order of
           ``typed_channel_ratios``. Column 0 is the scalar best score for
           consumers that need a single PPR weight, and column 1 is always the
-          global minimum-hop count. Per-channel min-hop columns use one greater
-          than the largest reached-channel min-hop for that node when the
-          channel did not reach the node.
+          global minimum-hop count. Per-channel hop proximity is
+          ``1 / (1 + min_hop)`` when that channel reached the node, and ``0``
+          when it did not.
+          For present channels, the original hop count can be recovered as
+          ``(1 - proximity) / proximity``; use the presence bit before applying
+          this inverse because missing channels have proximity ``0``.
 
     Args:
         alpha: Restart probability (teleport probability back to seed). Higher values

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -49,7 +49,8 @@ class PPRSamplerOptions:
       ``[best_score, min_hop, channel_scores..., channel_min_hops...,
       channel_presence_bits...]``.
       Column 0 is the scalar best score for consumers that need a single PPR
-      weight, and column 1 is always the minimum-hop count.
+      weight, and column 1 is always the global minimum-hop count. Per-channel
+      min-hop columns use ``-1`` when that channel did not reach the node.
 
     For homogeneous graphs these live directly on ``data.edge_index`` / ``data.edge_attr``.
 

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -46,8 +46,8 @@ class PPRSamplerOptions:
       ``hop_proximity`` is ``1 / (1 + hop)``: ``1.0`` for the anchor, ``0.5``
       for 1-hop, and so on.
       Typed PPR emits additional channel columns:
-      ``[best_score, hop_proximity, channel_scores..., channel_hop_proximities...,
-      channel_presence_bits...]``.
+      ``[best_score, hop_proximity, (channel_score, channel_hop_proximity,
+      channel_presence), ...]``.
       Column 0 is the scalar best score for consumers that need a single PPR
       weight, and column 1 is always the global hop proximity.
       Per-channel hop proximity is ``1 / (1 + hop)`` when that channel

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -41,16 +41,16 @@ class PPRSamplerOptions:
 
     - ``edge_index``: ``[2, N]`` int64 — row 0 is local seed indices, row 1 is local
       neighbor indices.
-    - ``edge_attr``: ``[N, 2]`` float — PPR score and minimum discovered-hop
-      count for each (seed, neighbor) pair: ``[ppr_score, min_hop]``.
-      ``min_hop`` is emitted as ``0`` for the anchor, ``1`` for 1-hop, ``2``
-      for 2-hop, and so on.
+    - ``edge_attr``: ``[N, 2]`` float — PPR score and hop proximity for each
+      (seed, neighbor) pair: ``[ppr_score, hop_proximity]``.
+      ``hop_proximity`` is ``1 / (1 + hop)``: ``1.0`` for the anchor, ``0.5``
+      for 1-hop, and so on.
       Typed PPR emits additional channel columns:
-      ``[best_score, min_hop, channel_scores..., channel_hop_proximities...,
+      ``[best_score, hop_proximity, channel_scores..., channel_hop_proximities...,
       channel_presence_bits...]``.
       Column 0 is the scalar best score for consumers that need a single PPR
-      weight, and column 1 is always the global minimum-hop count.
-      Per-channel hop proximity is ``1 / (1 + min_hop)`` when that channel
+      weight, and column 1 is always the global hop proximity.
+      Per-channel hop proximity is ``1 / (1 + hop)`` when that channel
       reached the node, and ``0`` when it did not.
       For present channels, the original hop count can be recovered as
       ``(1 - proximity) / proximity``; use the presence bit before applying

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -50,7 +50,8 @@ class PPRSamplerOptions:
       channel_presence_bits...]``.
       Column 0 is the scalar best score for consumers that need a single PPR
       weight, and column 1 is always the global minimum-hop count. Per-channel
-      min-hop columns use ``-1`` when that channel did not reach the node.
+      min-hop columns use one greater than the largest reached-channel min-hop
+      for that node when the channel did not reach the node.
 
     For homogeneous graphs these live directly on ``data.edge_index`` / ``data.edge_attr``.
 

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -41,11 +41,14 @@ class PPRSamplerOptions:
 
     - ``edge_index``: ``[2, N]`` int64 — row 0 is local seed indices, row 1 is local
       neighbor indices.
-    - ``edge_attr``: ``[N]`` float — PPR score for each (seed, neighbor) pair.
-      Typed PPR emits multi-column edge attrs:
-      ``[best_score, channel_scores..., channel_presence_bits...]``.
+    - ``edge_attr``: ``[N, 2]`` float — PPR score and minimum discovered-hop
+      count for each (seed, neighbor) pair: ``[ppr_score, min_hop]``.
+      ``min_hop`` is emitted as ``0`` for the anchor, ``1`` for 1-hop, ``2``
+      for 2-hop, and so on.
+      Typed PPR emits additional channel columns:
+      ``[best_score, min_hop, channel_scores..., channel_presence_bits...]``.
       Column 0 is the scalar best score for consumers that need a single PPR
-      weight.
+      weight, and column 1 is always the minimum-hop count.
 
     For homogeneous graphs these live directly on ``data.edge_index`` / ``data.edge_attr``.
 

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -46,12 +46,15 @@ class PPRSamplerOptions:
       ``min_hop`` is emitted as ``0`` for the anchor, ``1`` for 1-hop, ``2``
       for 2-hop, and so on.
       Typed PPR emits additional channel columns:
-      ``[best_score, min_hop, channel_scores..., channel_min_hops...,
+      ``[best_score, min_hop, channel_scores..., channel_hop_proximities...,
       channel_presence_bits...]``.
       Column 0 is the scalar best score for consumers that need a single PPR
-      weight, and column 1 is always the global minimum-hop count. Per-channel
-      min-hop columns use one greater than the largest reached-channel min-hop
-      for that node when the channel did not reach the node.
+      weight, and column 1 is always the global minimum-hop count.
+      Per-channel hop proximity is ``1 / (1 + min_hop)`` when that channel
+      reached the node, and ``0`` when it did not.
+      For present channels, the original hop count can be recovered as
+      ``(1 - proximity) / proximity``; use the presence bit before applying
+      this inverse because missing channels have proximity ``0``.
 
     For homogeneous graphs these live directly on ``data.edge_index`` / ``data.edge_attr``.
 

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -46,7 +46,8 @@ class PPRSamplerOptions:
       ``min_hop`` is emitted as ``0`` for the anchor, ``1`` for 1-hop, ``2``
       for 2-hop, and so on.
       Typed PPR emits additional channel columns:
-      ``[best_score, min_hop, channel_scores..., channel_presence_bits...]``.
+      ``[best_score, min_hop, channel_scores..., channel_min_hops...,
+      channel_presence_bits...]``.
       Column 0 is the scalar best score for consumers that need a single PPR
       weight, and column 1 is always the minimum-hop count.
 

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -93,6 +93,7 @@ _NUM_TEST_STORIES = 3
 _TEST_ALPHA = 0.5
 _TEST_EPS = 1e-6
 _TEST_MAX_PPR_NODES = 5
+_MISSING_TYPED_PPR_CHANNEL_HOP = -1.0
 
 
 # ---------------------------------------------------------------------------
@@ -276,6 +277,18 @@ def _assert_valid_min_hops(min_hops: torch.Tensor) -> None:
     assert torch.allclose(min_hops, min_hops.round())
 
 
+def _assert_typed_channel_min_hops(
+    channel_min_hops: torch.Tensor,
+    channel_presence: torch.Tensor,
+) -> None:
+    """Assert typed channel min-hops distinguish missing channels from anchors."""
+    assert torch.allclose(channel_min_hops, channel_min_hops.round())
+    assert (channel_min_hops[channel_presence == 1] >= 0).all()
+    assert (
+        channel_min_hops[channel_presence == 0] == _MISSING_TYPED_PPR_CHANNEL_HOP
+    ).all()
+
+
 def _assert_ppr_scores_match_reference(
     ntype_to_sampler_ppr: dict[str, dict[int, float]],
     reference_ppr: dict[str, dict[int, float]],
@@ -346,19 +359,17 @@ def _assert_typed_ppr_edge_attrs(
         best_scores = ppr_edge_attr[:, 0]
         min_hops = ppr_edge_attr[:, 1]
         channel_scores = ppr_edge_attr[:, 2 : 2 + num_channels]
-        channel_min_hops = ppr_edge_attr[
-            :, 2 + num_channels : 2 + (2 * num_channels)
-        ]
+        channel_min_hops = ppr_edge_attr[:, 2 + num_channels : 2 + (2 * num_channels)]
+        channel_presence = ppr_edge_attr[:, 2 + (2 * num_channels) :]
         assert (best_scores >= 0).all()
         assert (best_scores <= 1).all()
         _assert_valid_min_hops(min_hops)
         assert (channel_scores >= 0).all()
         assert (channel_scores <= 1).all()
-        _assert_valid_min_hops(channel_min_hops)
+        _assert_typed_channel_min_hops(channel_min_hops, channel_presence)
         if best_scores.size(0) > 1:
             assert (best_scores[:-1] >= best_scores[1:]).all()
 
-        channel_presence = ppr_edge_attr[:, 2 + (2 * num_channels) :]
         assert ((channel_presence == 0) | (channel_presence == 1)).all()
 
 

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -93,7 +93,6 @@ _NUM_TEST_STORIES = 3
 _TEST_ALPHA = 0.5
 _TEST_EPS = 1e-6
 _TEST_MAX_PPR_NODES = 5
-_MISSING_TYPED_PPR_CHANNEL_HOP = -1.0
 
 
 # ---------------------------------------------------------------------------
@@ -281,11 +280,25 @@ def _assert_typed_channel_min_hops(
     channel_min_hops: torch.Tensor,
     channel_presence: torch.Tensor,
 ) -> None:
-    """Assert typed channel min-hops distinguish missing channels from anchors."""
+    """Assert missing typed-channel hops are finite and farther than present hops."""
     assert torch.allclose(channel_min_hops, channel_min_hops.round())
-    assert (channel_min_hops[channel_presence == 1] >= 0).all()
+    assert (channel_min_hops >= 0).all()
+    present_channel_mask = channel_presence == 1
+    assert present_channel_mask.any(dim=1).all()
+    row_max_present_hops = (
+        channel_min_hops.masked_fill(
+            ~present_channel_mask,
+            -1.0,
+        )
+        .max(dim=1)
+        .values
+    )
+    expected_missing_hops = (
+        (row_max_present_hops + 1).unsqueeze(1).expand_as(channel_min_hops)
+    )
     assert (
-        channel_min_hops[channel_presence == 0] == _MISSING_TYPED_PPR_CHANNEL_HOP
+        channel_min_hops[~present_channel_mask]
+        == expected_missing_hops[~present_channel_mask]
     ).all()
 
 

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -319,7 +319,7 @@ def _assert_typed_ppr_edge_attrs(
     num_channels: int,
 ) -> None:
     """Assert typed PPR edge attributes have the expected channel layout."""
-    expected_width = 2 + (2 * num_channels)
+    expected_width = 2 + (3 * num_channels)
     for node_type in node_types:
         ppr_edge_type = (seed_type, "ppr", node_type)
         assert ppr_edge_type in datum.edge_types, (
@@ -345,13 +345,20 @@ def _assert_typed_ppr_edge_attrs(
 
         best_scores = ppr_edge_attr[:, 0]
         min_hops = ppr_edge_attr[:, 1]
+        channel_scores = ppr_edge_attr[:, 2 : 2 + num_channels]
+        channel_min_hops = ppr_edge_attr[
+            :, 2 + num_channels : 2 + (2 * num_channels)
+        ]
         assert (best_scores >= 0).all()
         assert (best_scores <= 1).all()
         _assert_valid_min_hops(min_hops)
+        assert (channel_scores >= 0).all()
+        assert (channel_scores <= 1).all()
+        _assert_valid_min_hops(channel_min_hops)
         if best_scores.size(0) > 1:
             assert (best_scores[:-1] >= best_scores[1:]).all()
 
-        channel_presence = ppr_edge_attr[:, 2 + num_channels :]
+        channel_presence = ppr_edge_attr[:, 2 + (2 * num_channels) :]
         assert ((channel_presence == 0) | (channel_presence == 1)).all()
 
 
@@ -617,7 +624,7 @@ def _run_typed_ppr_loader_shape_check(_: int) -> None:
         num_channels=2,
     )
     empty_story_edge_attr = empty_story_datum[(str(USER), "ppr", STORY)].edge_attr
-    assert tuple(empty_story_edge_attr.shape) == (0, 6)
+    assert tuple(empty_story_edge_attr.shape) == (0, 8)
 
     shutdown_rpc()
 

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -276,30 +276,21 @@ def _assert_valid_min_hops(min_hops: torch.Tensor) -> None:
     assert torch.allclose(min_hops, min_hops.round())
 
 
-def _assert_typed_channel_min_hops(
-    channel_min_hops: torch.Tensor,
+def _assert_typed_channel_hop_proximities(
+    channel_hop_proximities: torch.Tensor,
     channel_presence: torch.Tensor,
 ) -> None:
-    """Assert missing typed-channel hops are finite and farther than present hops."""
-    assert torch.allclose(channel_min_hops, channel_min_hops.round())
-    assert (channel_min_hops >= 0).all()
+    """Assert typed-channel hop proximity is bounded and zero when missing."""
+    assert (channel_hop_proximities >= 0).all()
+    assert (channel_hop_proximities <= 1).all()
     present_channel_mask = channel_presence == 1
     assert present_channel_mask.any(dim=1).all()
-    row_max_present_hops = (
-        channel_min_hops.masked_fill(
-            ~present_channel_mask,
-            -1.0,
-        )
-        .max(dim=1)
-        .values
-    )
-    expected_missing_hops = (
-        (row_max_present_hops + 1).unsqueeze(1).expand_as(channel_min_hops)
-    )
-    assert (
-        channel_min_hops[~present_channel_mask]
-        == expected_missing_hops[~present_channel_mask]
-    ).all()
+    assert (channel_hop_proximities[present_channel_mask] > 0).all()
+    recovered_present_hops = (
+        1 - channel_hop_proximities[present_channel_mask]
+    ) / channel_hop_proximities[present_channel_mask]
+    assert torch.allclose(recovered_present_hops, recovered_present_hops.round())
+    assert (channel_hop_proximities[~present_channel_mask] == 0).all()
 
 
 def _assert_ppr_scores_match_reference(
@@ -372,14 +363,16 @@ def _assert_typed_ppr_edge_attrs(
         best_scores = ppr_edge_attr[:, 0]
         min_hops = ppr_edge_attr[:, 1]
         channel_scores = ppr_edge_attr[:, 2 : 2 + num_channels]
-        channel_min_hops = ppr_edge_attr[:, 2 + num_channels : 2 + (2 * num_channels)]
+        channel_hop_proximities = ppr_edge_attr[
+            :, 2 + num_channels : 2 + (2 * num_channels)
+        ]
         channel_presence = ppr_edge_attr[:, 2 + (2 * num_channels) :]
         assert (best_scores >= 0).all()
         assert (best_scores <= 1).all()
         _assert_valid_min_hops(min_hops)
         assert (channel_scores >= 0).all()
         assert (channel_scores <= 1).all()
-        _assert_typed_channel_min_hops(channel_min_hops, channel_presence)
+        _assert_typed_channel_hop_proximities(channel_hop_proximities, channel_presence)
         if best_scores.size(0) > 1:
             assert (best_scores[:-1] >= best_scores[1:]).all()
 

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -243,14 +243,18 @@ def _extract_hetero_ppr_scores(
         )
 
         ppr_edge_index = datum[ppr_edge_type].edge_index
-        ppr_weights = datum[ppr_edge_type].edge_attr
+        ppr_edge_attr = datum[ppr_edge_type].edge_attr
 
         assert ppr_edge_index.dim() == 2 and ppr_edge_index.size(0) == 2, (
             f"Expected [2, X] edge_index, got shape {list(ppr_edge_index.shape)}"
         )
-        assert ppr_weights.dim() == 1
-        assert ppr_edge_index.size(1) == ppr_weights.size(0)
+        assert ppr_edge_attr.dim() == 2
+        assert ppr_edge_attr.size(1) == 2
+        assert ppr_edge_index.size(1) == ppr_edge_attr.size(0)
+        ppr_weights = ppr_edge_attr[:, 0]
+        ppr_hops = ppr_edge_attr[:, 1]
         assert (ppr_weights > 0).all(), f"PPR weights for {ntype} must be positive"
+        _assert_valid_min_hops(ppr_hops)
         assert (ppr_edge_index[0] == 0).all(), (
             "All src indices must be 0 for batch_size=1"
         )
@@ -264,6 +268,12 @@ def _extract_hetero_ppr_scores(
         ntype_to_sampler_ppr[str(ntype)] = type_ppr
 
     return ntype_to_sampler_ppr
+
+
+def _assert_valid_min_hops(min_hops: torch.Tensor) -> None:
+    """Assert PPR min-hop features are emitted as non-negative hop counts."""
+    assert (min_hops >= 0).all()
+    assert torch.allclose(min_hops, min_hops.round())
 
 
 def _assert_ppr_scores_match_reference(
@@ -309,7 +319,7 @@ def _assert_typed_ppr_edge_attrs(
     num_channels: int,
 ) -> None:
     """Assert typed PPR edge attributes have the expected channel layout."""
-    expected_width = 1 + (2 * num_channels)
+    expected_width = 2 + (2 * num_channels)
     for node_type in node_types:
         ppr_edge_type = (seed_type, "ppr", node_type)
         assert ppr_edge_type in datum.edge_types, (
@@ -334,12 +344,14 @@ def _assert_typed_ppr_edge_attrs(
             continue
 
         best_scores = ppr_edge_attr[:, 0]
+        min_hops = ppr_edge_attr[:, 1]
         assert (best_scores >= 0).all()
         assert (best_scores <= 1).all()
+        _assert_valid_min_hops(min_hops)
         if best_scores.size(0) > 1:
             assert (best_scores[:-1] >= best_scores[1:]).all()
 
-        channel_presence = ppr_edge_attr[:, 1 + num_channels :]
+        channel_presence = ppr_edge_attr[:, 2 + num_channels :]
         assert ((channel_presence == 0) | (channel_presence == 1)).all()
 
 
@@ -394,16 +406,22 @@ def _run_ppr_loader_correctness_check(
         assert hasattr(datum, "edge_attr"), "Missing edge_attr on Data"
 
         ppr_edge_index = datum.edge_index
-        ppr_weights = datum.edge_attr
+        ppr_edge_attr = datum.edge_attr
 
         assert ppr_edge_index.dim() == 2 and ppr_edge_index.size(0) == 2, (
             f"Expected [2, X] edge_index, got shape {list(ppr_edge_index.shape)}"
         )
-        assert ppr_weights.dim() == 1, f"Expected 1D weights, got {ppr_weights.dim()}D"
-        assert ppr_edge_index.size(1) == ppr_weights.size(0), (
-            f"Edge count mismatch: {ppr_edge_index.size(1)} vs {ppr_weights.size(0)}"
+        assert ppr_edge_attr.dim() == 2, (
+            f"Expected 2D PPR edge_attr, got {ppr_edge_attr.dim()}D"
         )
+        assert ppr_edge_attr.size(1) == 2
+        assert ppr_edge_index.size(1) == ppr_edge_attr.size(0), (
+            f"Edge count mismatch: {ppr_edge_index.size(1)} vs {ppr_edge_attr.size(0)}"
+        )
+        ppr_weights = ppr_edge_attr[:, 0]
+        ppr_hops = ppr_edge_attr[:, 1]
         assert (ppr_weights > 0).all(), "PPR weights must be positive"
+        _assert_valid_min_hops(ppr_hops)
         assert (ppr_edge_index[0] == 0).all(), (
             "All src indices must be 0 for batch_size=1"
         )
@@ -599,7 +617,7 @@ def _run_typed_ppr_loader_shape_check(_: int) -> None:
         num_channels=2,
     )
     empty_story_edge_attr = empty_story_datum[(str(USER), "ppr", STORY)].edge_attr
-    assert tuple(empty_story_edge_attr.shape) == (0, 5)
+    assert tuple(empty_story_edge_attr.shape) == (0, 6)
 
     shutdown_rpc()
 
@@ -699,13 +717,17 @@ def _run_ppr_ablp_loader_correctness_check(
             )
 
             ppr_edge_index = datum[ppr_edge_type].edge_index
-            ppr_weights = datum[ppr_edge_type].edge_attr
+            ppr_edge_attr = datum[ppr_edge_type].edge_attr
 
             assert ppr_edge_index.dim() == 2 and ppr_edge_index.size(0) == 2
-            assert ppr_weights.dim() == 1
-            assert ppr_edge_index.size(1) == ppr_weights.size(0)
-            if ppr_weights.numel() > 0:
+            assert ppr_edge_attr.dim() == 2
+            assert ppr_edge_attr.size(1) == 2
+            assert ppr_edge_index.size(1) == ppr_edge_attr.size(0)
+            if ppr_edge_attr.numel() > 0:
+                ppr_weights = ppr_edge_attr[:, 0]
+                ppr_hops = ppr_edge_attr[:, 1]
                 assert (ppr_weights > 0).all()
+                _assert_valid_min_hops(ppr_hops)
             assert (ppr_edge_index[1] >= 0).all()
             assert (ppr_edge_index[1] < datum[ntype].node.size(0)).all()
 
@@ -761,7 +783,9 @@ def _run_ppr_labeled_homogeneous_ablp_loader_check(_: int) -> None:
     assert hasattr(datum, "y_negative"), "Missing y_negative on Data"
     assert datum.edge_index.dim() == 2
     assert datum.edge_index.size(0) == 2
-    assert datum.edge_index.size(1) == datum.edge_attr.numel()
+    assert datum.edge_attr.dim() == 2
+    assert datum.edge_attr.size(1) == 2
+    assert datum.edge_index.size(1) == datum.edge_attr.size(0)
 
     shutdown_rpc()
 
@@ -811,7 +835,7 @@ def _run_ppr_destination_only_node_type(_: int) -> None:
     assert datum[ppr_edge_type].edge_index.shape[1] > 0, (
         "Expected at least one PPR edge to STORY"
     )
-    assert (datum[ppr_edge_type].edge_attr > 0).all()
+    assert (datum[ppr_edge_type].edge_attr[:, 0] > 0).all()
 
     shutdown_rpc()
 

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -364,11 +364,12 @@ def _assert_typed_ppr_edge_attrs(
 
         best_scores = ppr_edge_attr[:, 0]
         hop_proximities = ppr_edge_attr[:, 1]
-        channel_scores = ppr_edge_attr[:, 2 : 2 + num_channels]
-        channel_hop_proximities = ppr_edge_attr[
-            :, 2 + num_channels : 2 + (2 * num_channels)
-        ]
-        channel_presence = ppr_edge_attr[:, 2 + (2 * num_channels) :]
+        channel_features = ppr_edge_attr[:, 2:].reshape(
+            ppr_edge_attr.size(0), num_channels, 3
+        )
+        channel_scores = channel_features[:, :, 0]
+        channel_hop_proximities = channel_features[:, :, 1]
+        channel_presence = channel_features[:, :, 2]
         assert (best_scores >= 0).all()
         assert (best_scores <= 1).all()
         _assert_valid_hop_proximities(hop_proximities)

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -252,9 +252,9 @@ def _extract_hetero_ppr_scores(
         assert ppr_edge_attr.size(1) == 2
         assert ppr_edge_index.size(1) == ppr_edge_attr.size(0)
         ppr_weights = ppr_edge_attr[:, 0]
-        ppr_hops = ppr_edge_attr[:, 1]
+        ppr_hop_proximities = ppr_edge_attr[:, 1]
         assert (ppr_weights > 0).all(), f"PPR weights for {ntype} must be positive"
-        _assert_valid_min_hops(ppr_hops)
+        _assert_valid_hop_proximities(ppr_hop_proximities)
         assert (ppr_edge_index[0] == 0).all(), (
             "All src indices must be 0 for batch_size=1"
         )
@@ -270,10 +270,12 @@ def _extract_hetero_ppr_scores(
     return ntype_to_sampler_ppr
 
 
-def _assert_valid_min_hops(min_hops: torch.Tensor) -> None:
-    """Assert PPR min-hop features are emitted as non-negative hop counts."""
-    assert (min_hops >= 0).all()
-    assert torch.allclose(min_hops, min_hops.round())
+def _assert_valid_hop_proximities(hop_proximities: torch.Tensor) -> None:
+    """Assert PPR hop proximity is bounded and invertible for emitted rows."""
+    assert (hop_proximities > 0).all()
+    assert (hop_proximities <= 1).all()
+    recovered_hops = (1 - hop_proximities) / hop_proximities
+    assert torch.allclose(recovered_hops, recovered_hops.round())
 
 
 def _assert_typed_channel_hop_proximities(
@@ -361,7 +363,7 @@ def _assert_typed_ppr_edge_attrs(
             continue
 
         best_scores = ppr_edge_attr[:, 0]
-        min_hops = ppr_edge_attr[:, 1]
+        hop_proximities = ppr_edge_attr[:, 1]
         channel_scores = ppr_edge_attr[:, 2 : 2 + num_channels]
         channel_hop_proximities = ppr_edge_attr[
             :, 2 + num_channels : 2 + (2 * num_channels)
@@ -369,7 +371,7 @@ def _assert_typed_ppr_edge_attrs(
         channel_presence = ppr_edge_attr[:, 2 + (2 * num_channels) :]
         assert (best_scores >= 0).all()
         assert (best_scores <= 1).all()
-        _assert_valid_min_hops(min_hops)
+        _assert_valid_hop_proximities(hop_proximities)
         assert (channel_scores >= 0).all()
         assert (channel_scores <= 1).all()
         _assert_typed_channel_hop_proximities(channel_hop_proximities, channel_presence)
@@ -443,9 +445,9 @@ def _run_ppr_loader_correctness_check(
             f"Edge count mismatch: {ppr_edge_index.size(1)} vs {ppr_edge_attr.size(0)}"
         )
         ppr_weights = ppr_edge_attr[:, 0]
-        ppr_hops = ppr_edge_attr[:, 1]
+        ppr_hop_proximities = ppr_edge_attr[:, 1]
         assert (ppr_weights > 0).all(), "PPR weights must be positive"
-        _assert_valid_min_hops(ppr_hops)
+        _assert_valid_hop_proximities(ppr_hop_proximities)
         assert (ppr_edge_index[0] == 0).all(), (
             "All src indices must be 0 for batch_size=1"
         )
@@ -749,9 +751,9 @@ def _run_ppr_ablp_loader_correctness_check(
             assert ppr_edge_index.size(1) == ppr_edge_attr.size(0)
             if ppr_edge_attr.numel() > 0:
                 ppr_weights = ppr_edge_attr[:, 0]
-                ppr_hops = ppr_edge_attr[:, 1]
+                ppr_hop_proximities = ppr_edge_attr[:, 1]
                 assert (ppr_weights > 0).all()
-                _assert_valid_min_hops(ppr_hops)
+                _assert_valid_hop_proximities(ppr_hop_proximities)
             assert (ppr_edge_index[1] >= 0).all()
             assert (ppr_edge_index[1] < datum[ntype].node.size(0)).all()
 


### PR DESCRIPTION
## Summary

Adds hop-distance metadata to PPR sampler outputs so downstream models can distinguish how close each sampled node was to the anchor during forward push.

For untyped PPR, `edge_attr` is now `[ppr_score, min_hop]`.

For typed/channel PPR, `edge_attr` is now `[best_score, global_min_hop, channel_scores..., channel_min_hops..., channel_presence_bits...]`.

`min_hop` is emitted as the raw minimum discovered hop count, e.g. `1` for 1-hop, `2` for 2-hop, `4` for 4-hop.

## Why

This lets models use PPR rank/score together with structural proximity. In typed PPR, the global min-hop is always available in a fixed position, while per-channel min-hop values allow relation-specific proximity features when needed.

## Profiling

A local synthetic C++ PPR benchmark compared this branch against `origin/main`.

| Variant | Untyped mean | Typed mean |
|---|---:|---:|
| `origin/main` | `0.495s` | `0.251s` |
| This branch | `0.478s` | `0.253s` |

The optimized implementation is roughly baseline in this synthetic benchmark:

- Untyped: approximately baseline, slightly faster in this run.
- Typed/channel PPR: about `+1%` versus `origin/main`, effectively noise-level for this benchmark.

## Testing

- `git diff --check`
- `python3 -m py_compile gigl/distributed/dist_ppr_sampler.py gigl/distributed/sampler_options.py tests/unit/distributed/dist_ppr_sampler_test.py`
- C++ formatting check on modified PPR forward-push files
- `make -C gigl-core unit_test_cpp`