### PR TITLE
Add typed PPR metapath channels

### DIFF
--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <climits>
 #include <cstdint>
+#include <functional>
 #include <future>
 #include <numeric>
 #include <optional>
@@ -21,6 +22,18 @@ static uint64_t packKey(int32_t nodeId, int32_t edgeTypeId) {
     return (static_cast<uint64_t>(static_cast<uint32_t>(nodeId)) << 32) | static_cast<uint32_t>(edgeTypeId);
 }
 
+static PPRTraversalProgram buildSingleStateTraversalProgram(
+    const std::vector<std::vector<int32_t>>& nodeTypeToEdgeTypeIds) {
+    PPRTraversalProgram traversalProgram(1);
+    traversalProgram[0].resize(nodeTypeToEdgeTypeIds.size());
+    for (size_t nodeTypeId = 0; nodeTypeId < nodeTypeToEdgeTypeIds.size(); ++nodeTypeId) {
+        for (int32_t edgeTypeId : nodeTypeToEdgeTypeIds[nodeTypeId]) {
+            traversalProgram[0][nodeTypeId].emplace_back(edgeTypeId, 0);
+        }
+    }
+    return traversalProgram;
+}
+
 PPRForwardPush::PPRForwardPush(const torch::Tensor& seedNodes,
                                int32_t seedNodeTypeId,
                                double alpha,
@@ -28,18 +41,42 @@ PPRForwardPush::PPRForwardPush(const torch::Tensor& seedNodes,
                                std::vector<std::vector<int32_t>> nodeTypeToEdgeTypeIds,
                                std::vector<int32_t> edgeTypeToDstNtypeId,
                                std::vector<torch::Tensor> degreeTensors)
+    : PPRForwardPush(seedNodes,
+                     seedNodeTypeId,
+                     alpha,
+                     requeueThresholdFactor,
+                     buildSingleStateTraversalProgram(nodeTypeToEdgeTypeIds),
+                     /*emittingTraversalStateIds=*/{0},
+                     std::move(edgeTypeToDstNtypeId),
+                     std::move(degreeTensors)) {}
+
+PPRForwardPush::PPRForwardPush(const torch::Tensor& seedNodes,
+                               int32_t seedNodeTypeId,
+                               double alpha,
+                               double requeueThresholdFactor,
+                               PPRTraversalProgram traversalProgram,
+                               std::vector<int32_t> emittingTraversalStateIds,
+                               std::vector<int32_t> edgeTypeToDstNtypeId,
+                               std::vector<torch::Tensor> degreeTensors)
     : _alpha(alpha),
       _requeueThresholdFactor(requeueThresholdFactor),
-      // std::move transfers ownership of each vector into the member variable
-      // without copying its contents — equivalent to Python's list hand-off
-      // when you no longer need the original.
-      _nodeTypeToEdgeTypeIds(std::move(nodeTypeToEdgeTypeIds)),
+      _traversalProgram(std::move(traversalProgram)),
+      _emittingTraversalStateIds(std::move(emittingTraversalStateIds)),
       _edgeTypeToDstNtypeId(std::move(edgeTypeToDstNtypeId)),
       _degreeTensors(std::move(degreeTensors)) {
     TORCH_CHECK(seedNodes.dim() == 1, "seedNodes must be 1D");
     // int32_t is sufficient: batch sizes approaching 2B seeds are not a realistic concern.
     _batchSize = static_cast<int32_t>(seedNodes.size(0));
-    _numNodeTypes = static_cast<int32_t>(_nodeTypeToEdgeTypeIds.size());
+    _numTraversalStates = static_cast<int32_t>(_traversalProgram.size());
+    TORCH_CHECK(_numTraversalStates > 0, "traversalProgram must contain at least one traversal state.");
+    _numNodeTypes = static_cast<int32_t>(_traversalProgram[0].size());
+    TORCH_CHECK(_numNodeTypes > 0, "traversalProgram must contain at least one node type per traversal state.");
+    TORCH_CHECK(static_cast<int32_t>(_degreeTensors.size()) == _numNodeTypes,
+                "Expected one degree tensor per node type, got ",
+                _degreeTensors.size(),
+                " degree tensors for ",
+                _numNodeTypes,
+                " node types.");
 
     TORCH_CHECK(seedNodeTypeId >= 0, "seedNodeTypeId ", seedNodeTypeId, " is negative.");
     TORCH_CHECK(
@@ -57,28 +94,78 @@ PPRForwardPush::PPRForwardPush(const torch::Tensor& seedNodes,
                     _numNodeTypes,
                     ").");
     }
-    for (int32_t nodeTypeId = 0; nodeTypeId < _numNodeTypes; ++nodeTypeId) {
-        for (int32_t edgeTypeId : _nodeTypeToEdgeTypeIds[nodeTypeId]) {
-            TORCH_CHECK(edgeTypeId >= 0,
-                        "nodeTypeToEdgeTypeIds[",
-                        nodeTypeId,
-                        "] contains negative edge type id ",
-                        edgeTypeId,
-                        ".");
-            TORCH_CHECK(edgeTypeId < numEdgeTypes,
-                        "nodeTypeToEdgeTypeIds[",
-                        nodeTypeId,
-                        "] contains edge type id ",
-                        edgeTypeId,
-                        " out of range [0, ",
-                        numEdgeTypes,
-                        ").");
+    TORCH_CHECK(!_emittingTraversalStateIds.empty(),
+                "emittingTraversalStateIds must contain at least one traversal state.");
+    for (int32_t emittingTraversalStateId : _emittingTraversalStateIds) {
+        TORCH_CHECK(emittingTraversalStateId >= 0,
+                    "emittingTraversalStateIds contains negative traversal state id ",
+                    emittingTraversalStateId,
+                    ".");
+        TORCH_CHECK(emittingTraversalStateId < _numTraversalStates,
+                    "emittingTraversalStateIds contains traversal state id ",
+                    emittingTraversalStateId,
+                    " out of range [0, ",
+                    _numTraversalStates,
+                    ").");
+    }
+    for (int32_t traversalStateId = 0; traversalStateId < _numTraversalStates; ++traversalStateId) {
+        TORCH_CHECK(static_cast<int32_t>(_traversalProgram[traversalStateId].size()) == _numNodeTypes,
+                    "traversalProgram[",
+                    traversalStateId,
+                    "] has ",
+                    _traversalProgram[traversalStateId].size(),
+                    " node-type entries, expected ",
+                    _numNodeTypes,
+                    ".");
+        for (int32_t nodeTypeId = 0; nodeTypeId < _numNodeTypes; ++nodeTypeId) {
+            for (const auto& transition : _traversalProgram[traversalStateId][nodeTypeId]) {
+                int32_t edgeTypeId = std::get<0>(transition);
+                int32_t nextTraversalStateId = std::get<1>(transition);
+                TORCH_CHECK(edgeTypeId >= 0,
+                            "traversalProgram[",
+                            traversalStateId,
+                            "][",
+                            nodeTypeId,
+                            "] contains negative edge type id ",
+                            edgeTypeId,
+                            ".");
+                TORCH_CHECK(edgeTypeId < numEdgeTypes,
+                            "traversalProgram[",
+                            traversalStateId,
+                            "][",
+                            nodeTypeId,
+                            "] contains edge type id ",
+                            edgeTypeId,
+                            " out of range [0, ",
+                            numEdgeTypes,
+                            ").");
+                TORCH_CHECK(nextTraversalStateId >= 0,
+                            "traversalProgram[",
+                            traversalStateId,
+                            "][",
+                            nodeTypeId,
+                            "] contains negative next traversal state id ",
+                            nextTraversalStateId,
+                            ".");
+                TORCH_CHECK(nextTraversalStateId < _numTraversalStates,
+                            "traversalProgram[",
+                            traversalStateId,
+                            "][",
+                            nodeTypeId,
+                            "] contains next traversal state id ",
+                            nextTraversalStateId,
+                            " out of range [0, ",
+                            _numTraversalStates,
+                            ").");
+            }
         }
     }
 
-    // Allocate per-seed, per-node-type state.
+    // Allocate per-seed, per-traversal-state, per-node-type state.
     // .assign(n, val) fills a vector with n independent copies of val — like [val for _ in range(n)] in Python.
-    _state.assign(_batchSize, std::vector<SeedNodeTypeState>(_numNodeTypes));
+    _state.assign(_batchSize,
+                  std::vector<std::vector<SeedNodeTypeState>>(_numTraversalStates,
+                                                              std::vector<SeedNodeTypeState>(_numNodeTypes)));
 
     // accessor<dtype, ndim>() returns a typed view into the tensor's data that
     // supports [i] indexing with bounds checking in debug builds.
@@ -89,8 +176,8 @@ PPRForwardPush::PPRForwardPush(const torch::Tensor& seedNodes,
         // PPR initialisation: each seed starts with residual = alpha (the
         // restart probability).  The first push will move alpha into ppr_score
         // and distribute (1-alpha)*alpha to the seed's neighbors.
-        _state[seedIdx][seedNodeTypeId].residuals[seedNodeId] = _alpha;
-        _state[seedIdx][seedNodeTypeId].queue.insert(seedNodeId);
+        _state[seedIdx][0][seedNodeTypeId].residuals[seedNodeId] = _alpha;
+        _state[seedIdx][0][seedNodeTypeId].queue.insert(seedNodeId);
     }
 }
 
@@ -103,8 +190,10 @@ std::optional<std::unordered_map<int32_t, torch::Tensor>> PPRForwardPush::drainQ
     // TODO: if this loop becomes a bottleneck, consider parallelising with
     // std::for_each(std::execution::par_unseq, ...) or adding vectorisation hints.
     for (auto& perSeedState : _state) {
-        for (auto& nodeTypeState : perSeedState) {
-            nodeTypeState.queuedNodes.clear();
+        for (auto& traversalState : perSeedState) {
+            for (auto& nodeTypeState : traversalState) {
+                nodeTypeState.queuedNodes.clear();
+            }
         }
     }
 
@@ -118,23 +207,27 @@ std::optional<std::unordered_map<int32_t, torch::Tensor>> PPRForwardPush::drainQ
     // dedicated homogeneous code path could eliminate the loop entirely.  Profile
     // before splitting.
     for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
-        for (int32_t nodeTypeId = 0; nodeTypeId < _numNodeTypes; ++nodeTypeId) {
-            auto& seedNodeTypeState = _state[seedIdx][nodeTypeId];
-            if (seedNodeTypeState.queue.empty()) {
-                continue;
-            }
+        for (int32_t traversalStateId = 0; traversalStateId < _numTraversalStates; ++traversalStateId) {
+            for (int32_t nodeTypeId = 0; nodeTypeId < _numNodeTypes; ++nodeTypeId) {
+                auto& seedNodeTypeState = _state[seedIdx][traversalStateId][nodeTypeId];
+                if (seedNodeTypeState.queue.empty()) {
+                    continue;
+                }
 
-            // Move the live queue into the snapshot in O(1) — avoids copying all node IDs.
-            // The explicit clear() after move is defensive: the standard only guarantees
-            // a moved-from container is "valid but unspecified", not necessarily empty.
-            seedNodeTypeState.queuedNodes = std::move(seedNodeTypeState.queue);
-            seedNodeTypeState.queue.clear();
-            _numNodesInQueue -= static_cast<int32_t>(seedNodeTypeState.queuedNodes.size());
+                // Move the live queue into the snapshot in O(1) — avoids copying all node IDs.
+                // The explicit clear() after move is defensive: the standard only guarantees
+                // a moved-from container is "valid but unspecified", not necessarily empty.
+                seedNodeTypeState.queuedNodes = std::move(seedNodeTypeState.queue);
+                seedNodeTypeState.queue.clear();
+                _numNodesInQueue -= static_cast<int32_t>(seedNodeTypeState.queuedNodes.size());
 
-            for (int32_t nodeId : seedNodeTypeState.queuedNodes) {
-                for (int32_t edgeTypeId : _nodeTypeToEdgeTypeIds[nodeTypeId]) {
-                    if (_neighborCache.find(packKey(nodeId, edgeTypeId)) == _neighborCache.end()) {
-                        nodesToLookup[edgeTypeId].insert(nodeId);
+                const auto& transitions = _traversalProgram[traversalStateId][nodeTypeId];
+                for (int32_t nodeId : seedNodeTypeState.queuedNodes) {
+                    for (const auto& transition : transitions) {
+                        int32_t edgeTypeId = std::get<0>(transition);
+                        if (_neighborCache.find(packKey(nodeId, edgeTypeId)) == _neighborCache.end()) {
+                            nodesToLookup[edgeTypeId].insert(nodeId);
+                        }
                     }
                 }
             }
@@ -269,76 +362,84 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
     //   b. Distribute (1-alpha) * residual equally to each neighbor.
     //   c. Enqueue any neighbor whose residual now exceeds the requeue threshold.
     for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
-        for (int32_t nodeTypeId = 0; nodeTypeId < _numNodeTypes; ++nodeTypeId) {
-            auto& srcNodeTypeState = _state[seedIdx][nodeTypeId];
-            if (srcNodeTypeState.queuedNodes.empty()) {
-                continue;
-            }
-
-            for (int32_t sourceNodeId : srcNodeTypeState.queuedNodes) {
-                auto residualIter = srcNodeTypeState.residuals.find(sourceNodeId);
-                double sourceResidual = (residualIter != srcNodeTypeState.residuals.end()) ? residualIter->second : 0.0;
-
-                // a. Absorb: move residual into the PPR score.
-                srcNodeTypeState.pprScores[sourceNodeId] += sourceResidual;
-                srcNodeTypeState.residuals[sourceNodeId] = 0.0;
-
-                // b. Count total cached neighbors across all edge types for
-                // this source node.  We normalise by the number of neighbors we
-                // actually retrieved, not the true degree, so residual is fully
-                // distributed among known neighbors rather than leaking to unfetched
-                // ones (which matters when num_neighbors_per_hop < true_degree).
-                int32_t totalCachedNeighbors = 0;
-                for (int32_t edgeTypeId : _nodeTypeToEdgeTypeIds[nodeTypeId]) {
-                    auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
-                    if (cachedEntry != _neighborCache.end()) {
-                        totalCachedNeighbors += static_cast<int32_t>(cachedEntry->second.size());
-                    }
-                }
-                // Two cases reach here:
-                //   1. True sink node (no outgoing edges): absorbing the full residual is correct.
-                //   2. Budget exhausted, no cache entry: the (1-α)·r that should flow to
-                //      neighbors has nowhere to go, so it gets absorbed into src's score instead.
-                //      This overstates src and understates its neighbors.  This is expected
-                //      behavior when max_fetch_iterations is set, which intentionally trades
-                //      theoretical PPR correctness for better throughput.
-                if (totalCachedNeighbors == 0) {
+        for (int32_t traversalStateId = 0; traversalStateId < _numTraversalStates; ++traversalStateId) {
+            for (int32_t nodeTypeId = 0; nodeTypeId < _numNodeTypes; ++nodeTypeId) {
+                auto& srcNodeTypeState = _state[seedIdx][traversalStateId][nodeTypeId];
+                if (srcNodeTypeState.queuedNodes.empty()) {
                     continue;
                 }
 
-                double residualPerNeighbor =
-                    (1.0 - _alpha) * sourceResidual / static_cast<double>(totalCachedNeighbors);
+                const auto& transitions = _traversalProgram[traversalStateId][nodeTypeId];
+                for (int32_t sourceNodeId : srcNodeTypeState.queuedNodes) {
+                    auto residualIter = srcNodeTypeState.residuals.find(sourceNodeId);
+                    double sourceResidual =
+                        (residualIter != srcNodeTypeState.residuals.end()) ? residualIter->second : 0.0;
 
-                for (int32_t edgeTypeId : _nodeTypeToEdgeTypeIds[nodeTypeId]) {
-                    // Neighbor list for this (src, edgeTypeId) pair, borrowed from whichever
-                    // map holds it.  reference_wrapper is used because std::optional cannot
-                    // hold a reference directly, and we want to avoid copying the vector —
-                    // the data already exists in _neighborCache and outlives this loop body.
-                    // Access via neighborList->get().
-                    std::optional<std::reference_wrapper<const std::vector<int32_t>>> neighborList;
-                    auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
-                    if (cachedEntry != _neighborCache.end()) {
-                        neighborList = std::cref(cachedEntry->second);
+                    // a. Absorb: move residual into the PPR score at this traversal state.
+                    srcNodeTypeState.pprScores[sourceNodeId] += sourceResidual;
+                    srcNodeTypeState.residuals[sourceNodeId] = 0.0;
+
+                    // b. Count total cached neighbors across all transitions allowed
+                    // from this traversal state and source node type. We normalise by
+                    // the number of neighbors we actually retrieved, not the true
+                    // degree, so residual is fully distributed among known neighbors
+                    // rather than leaking to unfetched ones.
+                    int32_t totalCachedNeighbors = 0;
+                    for (const auto& transition : transitions) {
+                        int32_t edgeTypeId = std::get<0>(transition);
+                        auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
+                        if (cachedEntry != _neighborCache.end()) {
+                            totalCachedNeighbors += static_cast<int32_t>(cachedEntry->second.size());
+                        }
                     }
-                    if (!neighborList || neighborList->get().empty()) {
+                    // Two cases reach here:
+                    //   1. True sink node, or terminal traversal state: absorbing
+                    //      the full residual is correct.
+                    //   2. Budget exhausted, no cache entry: the (1-α)·r that
+                    //      should flow to neighbors has nowhere to go, so it gets
+                    //      absorbed into src's score instead.
+                    if (totalCachedNeighbors == 0) {
                         continue;
                     }
 
-                    int32_t dstNodeTypeId = _edgeTypeToDstNtypeId[edgeTypeId];
+                    double residualPerNeighbor =
+                        (1.0 - _alpha) * sourceResidual / static_cast<double>(totalCachedNeighbors);
 
-                    // c. Accumulate residual for each neighbor and re-enqueue if threshold
-                    // exceeded.
-                    auto& dstNodeTypeState = _state[seedIdx][dstNodeTypeId];
-                    for (int32_t neighborNodeId : neighborList->get()) {
-                        dstNodeTypeState.residuals[neighborNodeId] += residualPerNeighbor;
+                    for (const auto& transition : transitions) {
+                        int32_t edgeTypeId = std::get<0>(transition);
+                        int32_t nextTraversalStateId = std::get<1>(transition);
 
-                        double threshold = _requeueThresholdFactor *
-                                           static_cast<double>(getTotalDegree(neighborNodeId, dstNodeTypeId));
+                        // Neighbor list for this (src, edgeTypeId) pair, borrowed from whichever
+                        // map holds it.  reference_wrapper is used because std::optional cannot
+                        // hold a reference directly, and we want to avoid copying the vector —
+                        // the data already exists in _neighborCache and outlives this loop body.
+                        // Access via neighborList->get().
+                        std::optional<std::reference_wrapper<const std::vector<int32_t>>> neighborList;
+                        auto cachedEntry = _neighborCache.find(packKey(sourceNodeId, edgeTypeId));
+                        if (cachedEntry != _neighborCache.end()) {
+                            neighborList = std::cref(cachedEntry->second);
+                        }
+                        if (!neighborList || neighborList->get().empty()) {
+                            continue;
+                        }
 
-                        if (dstNodeTypeState.queue.find(neighborNodeId) == dstNodeTypeState.queue.end() &&
-                            dstNodeTypeState.residuals[neighborNodeId] >= threshold) {
-                            dstNodeTypeState.queue.insert(neighborNodeId);
-                            ++_numNodesInQueue;
+                        int32_t dstNodeTypeId = _edgeTypeToDstNtypeId[edgeTypeId];
+
+                        // c. Accumulate residual for each neighbor and re-enqueue
+                        // in the transition's destination state if threshold exceeded.
+                        auto& dstNodeTypeState = _state[seedIdx][nextTraversalStateId][dstNodeTypeId];
+                        for (int32_t neighborNodeId : neighborList->get()) {
+                            dstNodeTypeState.residuals[neighborNodeId] += residualPerNeighbor;
+
+                            double threshold =
+                                _requeueThresholdFactor * static_cast<double>(getTraversalDegree(
+                                                              neighborNodeId, dstNodeTypeId, nextTraversalStateId));
+
+                            if (dstNodeTypeState.queue.find(neighborNodeId) == dstNodeTypeState.queue.end() &&
+                                dstNodeTypeState.residuals[neighborNodeId] >= threshold) {
+                                dstNodeTypeState.queue.insert(neighborNodeId);
+                                ++_numNodesInQueue;
+                            }
                         }
                     }
                 }
@@ -673,7 +774,7 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPPRNode
         std::vector<int64_t> validCounts;
 
         for (int32_t seedIdx = 0; seedIdx < _batchSize; ++seedIdx) {
-            const auto& nodeTypeState = _state[seedIdx][nodeTypeId];
+            auto nodeTypeState = collectEmittingNodeTypeState(seedIdx, nodeTypeId);
             auto selectedPairs = selectFinalizedPPRPairs(nodeTypeState, maxPPRNodes);
             if (enableResidualTopUp) {
                 addResidualMassToPPRPairs(nodeTypeState, selectedPairs);
@@ -756,7 +857,7 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
                 static_cast<size_t>(numChannels));
 
             for (int32_t channelIndex = 0; channelIndex < numChannels; ++channelIndex) {
-                const auto& nodeTypeState = states[channelIndex]->_state[seedIdx][nodeTypeId];
+                auto nodeTypeState = states[channelIndex]->collectEmittingNodeTypeState(seedIdx, nodeTypeId);
                 auto outputNodesAndScores = selectFinalizedPPRPairs(nodeTypeState, maxPPRNodes);
 
                 if (enableResidualTopUp) {
@@ -829,6 +930,57 @@ int32_t PPRForwardPush::getTotalDegree(int32_t nodeId, int32_t nodeTypeId) const
                 degreeTensor.scalar_type(),
                 ". Expected torch.int32 or torch.int64.");
     return 0; // unreachable; suppresses compiler warning
+}
+
+int32_t PPRForwardPush::getTraversalDegree(int32_t nodeId, int32_t nodeTypeId, int32_t traversalStateId) const {
+    TORCH_CHECK(
+        traversalStateId >= 0, "traversalStateId ", traversalStateId, " is negative, which indicates a sampler bug.");
+    TORCH_CHECK(traversalStateId < _numTraversalStates,
+                "traversalStateId ",
+                traversalStateId,
+                " out of range [0, ",
+                _numTraversalStates,
+                "). This indicates a sampler bug.");
+    TORCH_CHECK(nodeTypeId >= 0, "nodeTypeId ", nodeTypeId, " is negative, which indicates a sampler bug.");
+    TORCH_CHECK(nodeTypeId < _numNodeTypes,
+                "nodeTypeId ",
+                nodeTypeId,
+                " out of range [0, ",
+                _numNodeTypes,
+                "). This indicates a sampler bug.");
+    if (_traversalProgram[traversalStateId][nodeTypeId].empty()) {
+        return 0;
+    }
+    return getTotalDegree(nodeId, nodeTypeId);
+}
+
+SeedNodeTypeState PPRForwardPush::collectEmittingNodeTypeState(int32_t seedIdx, int32_t nodeTypeId) const {
+    TORCH_CHECK(seedIdx >= 0, "seedIdx ", seedIdx, " is negative, which indicates a sampler bug.");
+    TORCH_CHECK(seedIdx < _batchSize,
+                "seedIdx ",
+                seedIdx,
+                " out of range [0, ",
+                _batchSize,
+                "). This indicates a sampler bug.");
+    TORCH_CHECK(nodeTypeId >= 0, "nodeTypeId ", nodeTypeId, " is negative, which indicates a sampler bug.");
+    TORCH_CHECK(nodeTypeId < _numNodeTypes,
+                "nodeTypeId ",
+                nodeTypeId,
+                " out of range [0, ",
+                _numNodeTypes,
+                "). This indicates a sampler bug.");
+
+    SeedNodeTypeState mergedState;
+    for (int32_t traversalStateId : _emittingTraversalStateIds) {
+        const auto& nodeTypeState = _state[seedIdx][traversalStateId][nodeTypeId];
+        for (const auto& [nodeId, score] : nodeTypeState.pprScores) {
+            mergedState.pprScores[nodeId] += score;
+        }
+        for (const auto& [nodeId, residual] : nodeTypeState.residuals) {
+            mergedState.residuals[nodeId] += residual;
+        }
+    }
+    return mergedState;
 }
 
 } // namespace gigl

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -21,13 +21,21 @@ using NeighborFetchMap = std::unordered_map<int32_t, NeighborFetchTensors>;
 using PPRExtractTensors = std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>;
 using PPRExtractResult = std::unordered_map<int32_t, PPRExtractTensors>;
 
-// Per-seed, per-node-type PPR algorithm state.
+// Traversal program for one PPR state.
+//
+// A transition is (edge_type_id, next_traversal_state_id).  The full program is
+// indexed as:
+//   traversalProgram[traversal_state_id][node_type_id] -> transitions.
+using PPRTraversalTransition = std::tuple<int32_t, int32_t>;
+using PPRTraversalProgram = std::vector<std::vector<std::vector<PPRTraversalTransition>>>;
+
+// Per-seed, per-traversal-state, per-node-type PPR algorithm state.
 // Grouping all four tables into one struct is a logical convenience: a single
-// _state[seedIdx][nodeTypeId] access reaches all four tables for a given (seed, ntype)
-// pair, rather than indexing four separate 2D arrays.  Note that unordered_map and
-// unordered_set heap-allocate their bucket storage, so the actual key-value data is
-// not co-located in memory — only the control-plane metadata (size, bucket pointer)
-// lives inside the struct.
+// _state[seedIdx][traversalStateId][nodeTypeId] access reaches all four tables
+// for a given (seed, traversal state, node type) tuple, rather than indexing
+// four separate arrays.  Note that unordered_map and unordered_set heap-allocate
+// their bucket storage, so the actual key-value data is not co-located in
+// memory — only the control-plane metadata lives inside the struct.
 struct SeedNodeTypeState {
     std::unordered_map<int32_t, double> pprScores; // absorbed PPR mass
     std::unordered_map<int32_t, double> residuals; // unabsorbed mass waiting to push
@@ -88,6 +96,15 @@ public:
                    std::vector<int32_t> edgeTypeToDstNtypeId,
                    std::vector<torch::Tensor> degreeTensors);
 
+    PPRForwardPush(const torch::Tensor& seedNodes,
+                   int32_t seedNodeTypeId,
+                   double alpha,
+                   double requeueThresholdFactor,
+                   PPRTraversalProgram traversalProgram,
+                   std::vector<int32_t> emittingTraversalStateIds,
+                   std::vector<int32_t> edgeTypeToDstNtypeId,
+                   std::vector<torch::Tensor> degreeTensors);
+
     // Drain queued nodes and return {etype_id: int64 node tensor} for neighbor lookup.
     // Returns nullopt when the queue is empty (convergence). Empty map means all nodes
     // were cache-hits; call pushResiduals({}) to continue.
@@ -120,6 +137,8 @@ public:
 private:
     // Total out-degree of a node across all edge types. Returns 0 for sink nodes.
     [[nodiscard]] int32_t getTotalDegree(int32_t nodeId, int32_t nodeTypeId) const;
+    [[nodiscard]] int32_t getTraversalDegree(int32_t nodeId, int32_t nodeTypeId, int32_t traversalStateId) const;
+    [[nodiscard]] SeedNodeTypeState collectEmittingNodeTypeState(int32_t seedIdx, int32_t nodeTypeId) const;
 
     double _alpha;
     double _requeueThresholdFactor; // alpha * eps; per-node requeue threshold = factor * degree
@@ -130,27 +149,31 @@ private:
     // scale ever approaches that threshold, these should be widened to int64_t.
     int32_t _batchSize;          // number of seed nodes in the current batch
     int32_t _numNodeTypes;       // total distinct node types (1 for homogeneous graphs)
-    int32_t _numNodesInQueue{0}; // running count of queued nodes across all seeds and types
+    int32_t _numTraversalStates; // total states in this channel's traversal program
+    int32_t _numNodesInQueue{0}; // running count of queued nodes across all seeds, traversal states, and types
 
     // Graph structure — set at construction, read-only during the algorithm.
-    // _nodeTypeToEdgeTypeIds[ntype_id] → list of edge type IDs that originate from that node type.
-    // _edgeTypeToDstNtypeId[etype_id]  → destination node type ID for that edge type.
-    // _degreeTensors[ntype_id]         → int32 tensor of total out-degrees, indexed by node ID.
-    std::vector<std::vector<int32_t>> _nodeTypeToEdgeTypeIds;
+    // _traversalProgram[state_id][ntype_id] → (edge type ID, next state ID) transitions.
+    // _emittingTraversalStateIds            → traversal states whose scores are emitted.
+    // _edgeTypeToDstNtypeId[etype_id]       → destination node type ID for that edge type.
+    // _degreeTensors[ntype_id]              → int32 tensor of total out-degrees, indexed by node ID.
+    PPRTraversalProgram _traversalProgram;
+    std::vector<int32_t> _emittingTraversalStateIds;
     std::vector<int32_t> _edgeTypeToDstNtypeId;
     std::vector<torch::Tensor> _degreeTensors;
 
-    // Per-seed, per-node-type PPR state.  Indexed as _state[seedIdx][nodeTypeId].
-    // 2D vector: both dimensions are dense sequential integers bounded at construction,
-    // so array indexing is O(1) with no hashing (contrast with _neighborCache below).
+    // Per-seed, per-traversal-state, per-node-type PPR state.
+    // Indexed as _state[seedIdx][traversalStateId][nodeTypeId].
+    // All dimensions are dense sequential integers bounded at construction, so
+    // array indexing is O(1) with no hashing (contrast with _neighborCache below).
     //
     // int32_t is used for node and type IDs throughout to match PyG/GLT's signed-integer
     // convention (torch.int32 / torch.int64).  Signed types also make nodeId >= 0 checks
     // meaningful — an unsigned type would make that guard tautological.
     //
-    // Sized [_batchSize][_numNodeTypes] at construction and never resized,
-    // so [seedIdx][nodeTypeId] indexing is always safe within the loop bounds.
-    std::vector<std::vector<SeedNodeTypeState>> _state;
+    // Sized [_batchSize][_numTraversalStates][_numNodeTypes] at construction
+    // and never resized, so indexing is always safe within the loop bounds.
+    std::vector<std::vector<std::vector<SeedNodeTypeState>>> _state;
 
     // Neighbor lists keyed by packKey(nodeId, edgeTypeId).
     // Hash map: nodeId is a sparse graph ID from a large graph, so a dense array is

--- a/gigl-core/core/sampling/python_ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/python_ppr_forward_push.cpp
@@ -134,6 +134,17 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
              // Constructor argument conversion happens before the C++ body; the
              // body only initializes PPR state and can run without the GIL.
              py::call_guard<py::gil_scoped_release>())
+        .def(py::init<torch::Tensor,
+                      int32_t,
+                      double,
+                      double,
+                      gigl::PPRTraversalProgram,
+                      std::vector<int32_t>,
+                      std::vector<int32_t>,
+                      std::vector<torch::Tensor>>(),
+             // Constructor argument conversion happens before the C++ body; the
+             // body only initializes PPR state and can run without the GIL.
+             py::call_guard<py::gil_scoped_release>())
         .def("drain_queue", gigl::drainQueueWrapper)
         .def("push_residuals", gigl::pushResidualsWrapper)
         .def("extract_top_k_with_residual_top_up",

--- a/gigl-core/src/gigl_core/ppr_forward_push.pyi
+++ b/gigl-core/src/gigl_core/ppr_forward_push.pyi
@@ -1,8 +1,11 @@
-from typing import Sequence
+from typing import Sequence, overload
 
 import torch
 
+PPRTraversalProgram = list[list[list[tuple[int, int]]]]
+
 class PPRForwardPush:
+    @overload
     def __init__(
         self,
         seed_nodes: torch.Tensor,
@@ -10,6 +13,18 @@ class PPRForwardPush:
         alpha: float,
         requeue_threshold_factor: float,
         node_type_to_edge_type_ids: list[list[int]],
+        edge_type_to_dst_ntype_id: list[int],
+        degree_tensors: list[torch.Tensor],
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        seed_nodes: torch.Tensor,
+        seed_node_type_id: int,
+        alpha: float,
+        requeue_threshold_factor: float,
+        traversal_program: PPRTraversalProgram,
+        emitting_traversal_state_ids: list[int],
         edge_type_to_dst_ntype_id: list[int],
         degree_tensors: list[torch.Tensor],
     ) -> None: ...

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -3,11 +3,13 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 using gigl::drainTypedPPRChannelQueues;
 using gigl::extractTypedTopKWithResidualTopUp;
 using gigl::NeighborFetchMap;
 using gigl::PPRForwardPush;
+using gigl::PPRTraversalProgram;
 
 // Builds a single-edge-type, single-node-type PPRForwardPush.
 static PPRForwardPush makeState(const std::vector<int64_t>& seeds,
@@ -20,6 +22,23 @@ static PPRForwardPush makeState(const std::vector<int64_t>& seeds,
                           requeueThresholdFactor,
                           /*nodeTypeToEdgeTypeIds=*/{{0}},
                           /*edgeTypeToDstNtypeId=*/{0},
+                          {torch::tensor(degrees, torch::kInt)});
+}
+
+static PPRForwardPush makeTraversalState(const std::vector<int64_t>& seeds,
+                                         double alpha,
+                                         double requeueThresholdFactor,
+                                         PPRTraversalProgram traversalProgram,
+                                         const std::vector<int32_t>& emittingTraversalStateIds,
+                                         const std::vector<int32_t>& edgeTypeToDstNtypeId,
+                                         const std::vector<int32_t>& degrees) {
+    return PPRForwardPush(torch::tensor(seeds, torch::kLong),
+                          /*seedNodeTypeId=*/0,
+                          alpha,
+                          requeueThresholdFactor,
+                          std::move(traversalProgram),
+                          emittingTraversalStateIds,
+                          edgeTypeToDstNtypeId,
                           {torch::tensor(degrees, torch::kInt)});
 }
 
@@ -130,6 +149,48 @@ TEST(PPRForwardPush, NeighborCacheAvoidsRefetchingPreviouslyFetchedNode) {
     auto iter3 = state.drainQueue();
     ASSERT_TRUE(iter3.has_value());
     EXPECT_TRUE(iter3->empty());
+}
+
+TEST(PPRForwardPush, TraversalProgramEmitsOnlyAfterMetapathCompletion) {
+    PPRTraversalProgram traversalProgram = {
+        {{{0, 1}}},
+        {{{1, 2}}},
+        {{}},
+    };
+    auto state = makeTraversalState(/*seeds=*/{0},
+                                    /*alpha=*/0.5,
+                                    /*requeueThresholdFactor=*/1e-9,
+                                    std::move(traversalProgram),
+                                    /*emittingTraversalStateIds=*/{2},
+                                    /*edgeTypeToDstNtypeId=*/{0, 0},
+                                    /*degrees=*/{1, 1, 0});
+
+    auto iter1 = state.drainQueue();
+    ASSERT_TRUE(iter1.has_value());
+    ASSERT_NE(iter1->find(0), iter1->end());
+    EXPECT_EQ(tensorToInt64Vector(iter1->at(0)), std::vector<int64_t>({0}));
+    EXPECT_EQ(iter1->find(1), iter1->end());
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/0, /*nodeIds=*/{0}, /*flatNeighborIds=*/{1}, /*counts=*/{1}));
+
+    auto iter2 = state.drainQueue();
+    ASSERT_TRUE(iter2.has_value());
+    ASSERT_NE(iter2->find(1), iter2->end());
+    EXPECT_EQ(tensorToInt64Vector(iter2->at(1)), std::vector<int64_t>({1}));
+    EXPECT_EQ(iter2->find(0), iter2->end());
+    state.pushResiduals(makeFetched(/*edgeTypeId=*/1, /*nodeIds=*/{1}, /*flatNeighborIds=*/{2}, /*counts=*/{1}));
+
+    auto iter3 = state.drainQueue();
+    ASSERT_TRUE(iter3.has_value());
+    EXPECT_TRUE(iter3->empty());
+    state.pushResiduals({});
+    EXPECT_FALSE(state.drainQueue().has_value());
+
+    auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*enableResidualTopUp=*/false);
+    ASSERT_NE(topk.find(0), topk.end());
+    const auto& [ids, weights, counts] = topk.at(0);
+    EXPECT_EQ(tensorToInt64Vector(ids), std::vector<int64_t>({2}));
+    EXPECT_EQ(tensorToInt64Vector(counts), std::vector<int64_t>({1}));
+    EXPECT_NEAR(weights[0].item<float>(), 0.125F, 1e-5F);
 }
 
 TEST(PPRForwardPush, DrainTypedPPRChannelQueuesUnionsChannelFrontiers) {

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -22,11 +22,12 @@ from graphlearn_torch.utils import merge_dict
 
 from gigl.distributed.base_sampler import BaseDistNeighborSampler
 from gigl.distributed.utils.dist_typed_sampler import (
+    TypedPPRChannelEmittingStateIds,
     TypedPPRChannelKey,
-    TypedPPRChannelTraversalMaps,
-    build_edge_type_channel_group_edge_type_ids,
+    TypedPPRChannelTraversalPrograms,
+    build_typed_ppr_channel_traversal_programs,
     compute_typed_channel_target_counts,
-    parse_typed_channel_ratio_groups,
+    parse_typed_channel_ratio_specs,
 )
 from gigl.types.graph import DEFAULT_HOMOGENEOUS_NODE_TYPE, is_label_edge_type
 
@@ -136,11 +137,13 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             traversal channels. If not provided, PPR treats all eligible edge
             types as one shared traversal space and emits a single scalar PPR
             score per output row.
-            Keys may be either a single canonical edge type
-            ``(src_type, relation, dst_type)`` or a tuple of canonical edge
-            types. Each key defines one traversal channel that may use only
-            those exact edge types. Edge types may appear in multiple channels
-            when those channels intentionally overlap.
+            Keys may be a single canonical edge type
+            ``(src_type, relation, dst_type)``, a tuple of canonical edge
+            types, or a ``PPRMetaPath``. Single edge-type and tuple keys keep
+            the original allowlist semantics: the channel may use any of those
+            edge types at every step. ``PPRMetaPath`` uses PyG's metapath shape
+            from ``AddMetaPaths`` and ``MetaPath2Vec``: an ordered sequence of
+            canonical edge-type tuples.
             Channel order follows the insertion order of this mapping, and
             typed ``edge_attr`` channel columns use that same order. If the
             mapping is produced from an unordered config source, construct it
@@ -158,17 +161,24 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
 
                 typed_channel_ratios = {
                     ("user", "views", "item"): 0.6,
-                    (
-                        ("user", "likes", "item"),
-                        ("user", "shares", "item"),
+                    PPRMetaPath(
+                        path=(
+                            (
+                                ("user", "likes", "item"),
+                                ("user", "shares", "item"),
+                            ),
+                            ("item", "bought_by", "user"),
+                        ),
+                        cyclic_from=0,
                     ): 0.4,
                 }
 
             With ``max_ppr_nodes=200``, this example targets 120 nodes
-            attributed to the views channel and 80 nodes attributed to the
-            grouped likes/shares channel. The views channel traverses only
-            ``("user", "views", "item")`` edges. The grouped likes/shares
-            channel traverses either likes or shares edges as one channel.
+            attributed to the views allowlist channel and 80 nodes attributed
+            to the ordered metapath channel. The metapath follows
+            ``(likes|shares) -> bought_by`` and repeats the whole path;
+            the grouped first step is a GiGL extension and requires all
+            alternatives to share traversal source and destination node types.
             Both finalized PPR rows and residual top-up rows fill those same
             targets. The targets are best-effort rather than strict per-seed
             guarantees: if a channel cannot provide enough unique candidates,
@@ -238,8 +248,8 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             ]
             self._is_homogeneous = True
 
-        typed_channel_groups, typed_channel_ratio_list = (
-            parse_typed_channel_ratio_groups(typed_channel_ratios)
+        typed_channel_specs, typed_channel_ratio_list = parse_typed_channel_ratio_specs(
+            typed_channel_ratios
         )
         self._typed_ppr_channel_target_counts = (
             compute_typed_channel_target_counts(
@@ -317,15 +327,18 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             for node_type in all_node_types
         ]
 
-        self._typed_ppr_channel_to_node_type_id_to_edge_type_ids: TypedPPRChannelTraversalMaps = []
-        if typed_channel_groups is not None:
-            self._typed_ppr_channel_to_node_type_id_to_edge_type_ids = (
-                build_edge_type_channel_group_edge_type_ids(
-                    edge_type_groups=typed_channel_groups,
-                    edge_type_to_edge_type_id=self._etype_to_etype_id,
-                    node_type_to_edge_types=self._node_type_to_edge_types,
-                    node_types=self._ntype_id_to_ntype,
-                )
+        self._typed_ppr_channel_traversal_programs: TypedPPRChannelTraversalPrograms = []
+        self._typed_ppr_channel_emitting_state_ids: TypedPPRChannelEmittingStateIds = []
+        if typed_channel_specs is not None:
+            (
+                self._typed_ppr_channel_traversal_programs,
+                self._typed_ppr_channel_emitting_state_ids,
+            ) = build_typed_ppr_channel_traversal_programs(
+                channel_specs=typed_channel_specs,
+                edge_type_to_edge_type_id=self._etype_to_etype_id,
+                node_type_to_edge_types=self._node_type_to_edge_types,
+                node_types=self._ntype_id_to_ntype,
+                edge_dir=self.edge_dir,
             )
 
     def _convert_degree_tensors_to_dict(
@@ -658,7 +671,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             seed_nodes: Global node IDs for the seed batch.
             seed_node_type: Heterogeneous node type for ``seed_nodes``.
             typed_ppr_channel_target_counts: Per-channel target output counts, aligned
-                with ``self._typed_ppr_channel_to_node_type_id_to_edge_type_ids``.
+                with ``self._typed_ppr_channel_traversal_programs``.
 
         Returns:
             Heterogeneous PPR extraction output with typed edge-attribute
@@ -669,7 +682,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
 
         # Build one Forward Push state per typed channel. All states use the
         # same seeds, restart probability, degree tensors, and destination-type
-        # map; only the per-node-type edge traversal allowlist differs.
+        # map; only the traversal program and emitting states differ.
         def build_ppr_states() -> list[PPRForwardPush]:
             return [
                 PPRForwardPush(
@@ -677,12 +690,15 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
                     self._node_type_to_id[seed_node_type],
                     self._alpha,
                     self._requeue_threshold_factor,
-                    node_type_id_to_edge_type_ids,
+                    traversal_program,
+                    emitting_state_ids,
                     self._edge_type_id_to_dst_ntype_id,
                     self._degree_tensors_for_cpp,
                 )
-                for node_type_id_to_edge_type_ids in (
-                    self._typed_ppr_channel_to_node_type_id_to_edge_type_ids
+                for traversal_program, emitting_state_ids in zip(
+                    self._typed_ppr_channel_traversal_programs,
+                    self._typed_ppr_channel_emitting_state_ids,
+                    strict=True,
                 )
             ]
 

--- a/gigl/distributed/sampler_options.py
+++ b/gigl/distributed/sampler_options.py
@@ -13,9 +13,17 @@ from typing import Optional, Union
 from graphlearn_torch.typing import EdgeType
 
 from gigl.common.logger import Logger
-from gigl.distributed.utils.dist_typed_sampler import TypedPPRChannelKey
+from gigl.distributed.utils.dist_typed_sampler import PPRMetaPath, TypedPPRChannelKey
 
 logger = Logger()
+
+__all__ = [
+    "KHopNeighborSamplerOptions",
+    "PPRMetaPath",
+    "PPRSamplerOptions",
+    "SamplerOptions",
+    "resolve_sampler_options",
+]
 
 
 @dataclass(frozen=True)
@@ -82,12 +90,13 @@ class PPRSamplerOptions:
             through cached neighbors at negligible cost. ``None`` (default) means
             no fetch limit.
         typed_channel_ratios: Optional target proportions for typed PPR
-            traversal channels defined by canonical edge-type allowlists. Keys
-            may be either a single canonical edge type
-            ``(src_type, relation, dst_type)`` or a tuple of canonical edge
-            types. Each key defines one traversal channel that may use only
-            those exact edge types. Edge types may appear in multiple channels
-            when those channels intentionally overlap.
+            traversal channels. Keys may be a single canonical edge type
+            ``(src_type, relation, dst_type)``, a tuple of canonical edge
+            types, or a ``PPRMetaPath``. Single edge-type and tuple keys keep
+            the original allowlist semantics: the channel may use any of those
+            edge types at every step. ``PPRMetaPath`` uses PyG's metapath shape
+            from ``AddMetaPaths`` and ``MetaPath2Vec``: an ordered sequence of
+            canonical edge-type tuples.
             If not provided, PPR treats all eligible edge types as one shared
             traversal space and emits a single scalar PPR score per output row.
             Channel order follows the insertion order of this mapping, and
@@ -107,21 +116,28 @@ class PPRSamplerOptions:
 
                 typed_channel_ratios = {
                     ("user", "views", "item"): 0.6,
-                    (
-                        ("user", "likes", "item"),
-                        ("user", "shares", "item"),
+                    PPRMetaPath(
+                        path=(
+                            (
+                                ("user", "likes", "item"),
+                                ("user", "shares", "item"),
+                            ),
+                            ("item", "bought_by", "user"),
+                        ),
+                        cyclic_from=0,
                     ): 0.4,
                 }
 
             This example creates two traversal channels. The first channel can
             traverse only ``("user", "views", "item")`` edges. With
             ``max_ppr_nodes=200``, the ``0.6`` ratio targets 120 nodes
-            attributed to this channel. The second channel groups
-            ``("user", "likes", "item")`` and ``("user", "shares", "item")``
-            into one traversal channel; the ``0.4`` ratio targets 80 nodes
-            attributed to that combined likes/shares channel. These targets are
-            best-effort rather than strict per-seed guarantees because channels
-            may be sparse or overlapping.
+            attributed to this channel. The second channel follows the ordered
+            metapath ``(likes|shares) -> bought_by`` and repeats the whole path;
+            the grouped first step is a GiGL extension and requires all
+            alternatives to share traversal source and destination node types.
+            The ``0.4`` ratio targets 80 nodes attributed to that metapath
+            channel. These targets are best-effort rather than strict per-seed
+            guarantees because channels may be sparse or overlapping.
 
             If residual top-up is enabled, discovered-but-unpushed residual
             candidates from the same completed PPR traversals are included on the

--- a/gigl/distributed/utils/dist_typed_sampler.py
+++ b/gigl/distributed/utils/dist_typed_sampler.py
@@ -1,50 +1,105 @@
-"""Construction-time typed-PPR option parsing for distributed samplers.
-
-The helpers in this module validate typed-channel edge-type keys, convert
-public edge-type keys into the compact integer traversal maps consumed by the
-C++ forward-push kernel, and derive integer channel target counts from public
-ratios. They run once during ``DistPPRNeighborSampler`` initialization, not in
-the per-batch PPR sampling hot loop.
-"""
+"""Construction-time typed-PPR option parsing for distributed samplers."""
 
 import math
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import Optional, Union, cast
 
 from graphlearn_torch.typing import EdgeType, NodeType
 
-# Public typed_channel_ratios keys can be a single edge type or a grouped
-# channel containing multiple edge types.
-TypedPPRChannelKey = Union[EdgeType, tuple[EdgeType, ...]]
+TypedPPRMetaPathStep = Union[EdgeType, tuple[EdgeType, ...]]
 
-"""TypedPPRChannelKey describes one public typed-PPR traversal channel key.
 
-A single canonical edge type creates one channel restricted to that edge type.
-A tuple of canonical edge types creates one channel whose PPR traversal may use
-any edge type in the group. When typed PPR emits multi-column
-``edge_attr`` tensors, channel columns follow the insertion order of the
-``typed_channel_ratios`` mapping.
-"""
-# Parsed typed-channel edge-type allowlists, ordered to match the insertion
-# order of typed_channel_ratios.
-TypedPPRChannelEdgeTypeGroups = list[tuple[EdgeType, ...]]
-# One channel's traversal map. The outer list is indexed by integer node-type
-# ID; each inner list contains the integer edge-type IDs that channel may
-# traverse from that node type.
+@dataclass(frozen=True)
+class PPRMetaPath:
+    """Ordered typed-PPR channel pattern using PyG's metapath convention.
+
+    This follows the existing PyG API shape: ``AddMetaPaths`` accepts
+    ``metapaths`` as a list of lists of ``(src_type, rel_type, dst_type)``
+    tuples, and ``MetaPath2Vec`` accepts one ``metapath`` as an ordered list of
+    those same canonical edge-type tuples. ``PPRMetaPath`` keeps that ordered
+    edge-type-sequence model for typed PPR channels: the path is traversed in
+    order, and each output channel column corresponds to one user-provided key
+    in ``typed_channel_ratios``.
+
+    A plain PyG metapath has one canonical edge type at each step. GiGL extends
+    that only where typed channels already support grouping: one step may be a
+    tuple of canonical edge types, meaning the PPR walk may choose any of those
+    relations at that exact position in the ordered path. Grouped alternatives
+    must share the same traversal source and destination node types after
+    applying the sampler's ``edge_dir``.
+
+    ``cyclic_from`` makes the suffix beginning at that step repeat. This mirrors
+    the intuitive cyclic metapath behavior used by random-walk APIs: a complete
+    repeated segment can run for as long as PPR residual mass remains. For
+    example, ``PPRMetaPath((A_TO_B, B_TO_A), cyclic_from=0)`` represents
+    ``(A_TO_B, B_TO_A)*`` and emits only after at least one full cycle.
+
+    Args:
+        path: Ordered metapath steps. Each step is either one canonical edge
+            type or a non-empty tuple of canonical edge types that are
+            alternatives for that step.
+        cyclic_from: Optional step index where the repeated suffix begins.
+            ``None`` means the metapath is finite and emits only after the full
+            path. ``0`` repeats the entire path. Values greater than ``0`` run
+            the prefix once and then repeat the suffix.
+    """
+
+    path: tuple[TypedPPRMetaPathStep, ...]
+    cyclic_from: Optional[int] = None
+
+
+TypedPPRChannelKey = Union[EdgeType, tuple[EdgeType, ...], PPRMetaPath]
+TypedPPRChannelSpec = Union[tuple[EdgeType, ...], PPRMetaPath]
+TypedPPRChannelSpecs = list[TypedPPRChannelSpec]
 TypedPPRChannelTraversalMap = list[list[int]]
-# All typed-channel traversal maps, ordered to match typed-channel order.
 TypedPPRChannelTraversalMaps = list[TypedPPRChannelTraversalMap]
+TypedPPRTraversalTransition = tuple[int, int]
+TypedPPRChannelTraversalProgram = list[list[list[TypedPPRTraversalTransition]]]
+TypedPPRChannelTraversalPrograms = list[TypedPPRChannelTraversalProgram]
+TypedPPRChannelEmittingStateIds = list[list[int]]
 
 
-def parse_typed_channel_ratio_groups(
+def _is_canonical_edge_type(value: object) -> bool:
+    """Return whether ``value`` has PyG's canonical edge-type shape."""
+    return (
+        isinstance(value, tuple)
+        and len(value) == 3
+        and all(isinstance(part, str) for part in value)
+    )
+
+
+def _normalize_metapath_step(step: TypedPPRMetaPathStep) -> tuple[EdgeType, ...]:
+    """Normalize a metapath step to a non-empty tuple of edge-type alternatives."""
+    if _is_canonical_edge_type(step):
+        return (cast(EdgeType, step),)
+    if (
+        isinstance(step, tuple)
+        and step
+        and all(_is_canonical_edge_type(edge_type) for edge_type in step)
+    ):
+        return cast(tuple[EdgeType, ...], step)
+    raise ValueError(
+        "PPRMetaPath path steps must be canonical edge types or non-empty "
+        f"tuples of canonical edge types, got {step!r}."
+    )
+
+
+def parse_typed_channel_ratio_specs(
     typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]],
-) -> tuple[Optional[TypedPPRChannelEdgeTypeGroups], Optional[list[float]]]:
+) -> tuple[Optional[TypedPPRChannelSpecs], Optional[list[float]]]:
     """Parse typed-PPR channel keys and split keys from ratios.
 
     Public options allow each channel key to be either one canonical edge type
-    or a non-empty tuple of canonical edge types. Internally, traversal setup
-    needs only the edge-type groups while merge selection needs the aligned
-    ratio values, so this helper returns those two parallel lists.
+    or a non-empty tuple of canonical edge types. These existing key shapes keep
+    their allowlist semantics: a channel may use any edge type in the group at
+    each step.
+
+    ``PPRMetaPath`` keys opt into ordered metapath semantics.
+
+    Internally, traversal setup needs the ordered channel specs while merge
+    selection needs the aligned ratio values, so this helper returns those two
+    parallel lists.
 
     This is construction-time option parsing and is not part of the per-batch
     PPR sampling hot loop.
@@ -55,42 +110,54 @@ def parse_typed_channel_ratio_groups(
 
     Returns:
         ``(None, None)`` when typed PPR is disabled. Otherwise returns
-        ``(typed_channel_groups, typed_channel_ratio_list)``, both ordered by
+        ``(typed_channel_specs, typed_channel_ratio_list)``, both ordered by
         the input mapping insertion order.
 
     Raises:
-        ValueError: If a channel key is not a canonical edge type or non-empty
-            tuple of canonical edge types, or if ratios are not positive and
-            summing to 1.0.
+        ValueError: If a channel key is invalid, or if ratios are not positive
+            and summing to 1.0.
     """
     if not typed_channel_ratios:
         return None, None
 
-    typed_channel_groups: TypedPPRChannelEdgeTypeGroups = []
+    typed_channel_specs: TypedPPRChannelSpecs = []
     typed_channel_ratio_list: list[float] = []
 
-    def is_canonical_edge_type(value: object) -> bool:
-        """Return whether ``value`` has PyG's canonical edge-type shape."""
-        return (
-            isinstance(value, tuple)
-            and len(value) == 3
-            and all(isinstance(part, str) for part in value)
-        )
-
     for edge_type_key, ratio in typed_channel_ratios.items():
-        if is_canonical_edge_type(edge_type_key):
-            edge_types = (cast(EdgeType, edge_type_key),)
+        if _is_canonical_edge_type(edge_type_key):
+            channel_spec: TypedPPRChannelSpec = (cast(EdgeType, edge_type_key),)
         elif (
             isinstance(edge_type_key, tuple)
             and edge_type_key
-            and all(is_canonical_edge_type(edge_type) for edge_type in edge_type_key)
+            and all(_is_canonical_edge_type(edge_type) for edge_type in edge_type_key)
         ):
-            edge_types = cast(tuple[EdgeType, ...], edge_type_key)
+            channel_spec = cast(tuple[EdgeType, ...], edge_type_key)
+        elif isinstance(edge_type_key, PPRMetaPath):
+            if not edge_type_key.path:
+                raise ValueError("PPRMetaPath path must be non-empty.")
+            normalized_path = tuple(
+                _normalize_metapath_step(step) for step in edge_type_key.path
+            )
+            cyclic_from = edge_type_key.cyclic_from
+            if cyclic_from is not None and (
+                isinstance(cyclic_from, bool)
+                or cyclic_from < 0
+                or cyclic_from >= len(normalized_path)
+            ):
+                raise ValueError(
+                    "PPRMetaPath cyclic_from must be None or a valid path step "
+                    f"index, got {cyclic_from!r} for path {edge_type_key.path!r}."
+                )
+            channel_spec = PPRMetaPath(
+                path=normalized_path,
+                cyclic_from=cyclic_from,
+            )
         else:
             raise ValueError(
                 "typed_channel_ratios keys must be a canonical edge type "
                 "(src_type, relation, dst_type) or a non-empty tuple of "
-                f"canonical edge types, got {edge_type_key!r}."
+                "canonical edge types, or a PPRMetaPath, "
+                f"got {edge_type_key!r}."
             )
         if (
             not isinstance(ratio, (int, float))
@@ -102,7 +169,7 @@ def parse_typed_channel_ratio_groups(
                 "typed_channel_ratios values must be positive ratios in (0, 1], "
                 f"got {ratio!r} for channel {edge_type_key!r}."
             )
-        typed_channel_groups.append(edge_types)
+        typed_channel_specs.append(channel_spec)
         typed_channel_ratio_list.append(float(ratio))
 
     ratio_sum = sum(typed_channel_ratio_list)
@@ -112,6 +179,33 @@ def parse_typed_channel_ratio_groups(
             f"got {ratio_sum} from ratios {typed_channel_ratio_list}."
         )
 
+    return typed_channel_specs, typed_channel_ratio_list
+
+
+def parse_typed_channel_ratio_groups(
+    typed_channel_ratios: Optional[dict[TypedPPRChannelKey, float]],
+) -> tuple[Optional[list[tuple[EdgeType, ...]]], Optional[list[float]]]:
+    """Parse legacy allowlist typed-channel keys.
+
+    This compatibility wrapper is kept for callers that expect only the
+    pre-metapath edge-type group representation.
+
+    Raises:
+        ValueError: If ``typed_channel_ratios`` includes a ``PPRMetaPath`` key.
+    """
+    typed_channel_specs, typed_channel_ratio_list = parse_typed_channel_ratio_specs(
+        typed_channel_ratios
+    )
+    if typed_channel_specs is None:
+        return None, None
+    typed_channel_groups: list[tuple[EdgeType, ...]] = []
+    for typed_channel_spec in typed_channel_specs:
+        if isinstance(typed_channel_spec, PPRMetaPath):
+            raise ValueError(
+                "parse_typed_channel_ratio_groups cannot return PPRMetaPath "
+                "channels; use parse_typed_channel_ratio_specs instead."
+            )
+        typed_channel_groups.append(typed_channel_spec)
     return typed_channel_groups, typed_channel_ratio_list
 
 
@@ -153,8 +247,243 @@ def compute_typed_channel_target_counts(
     return target_counts
 
 
+def _get_traversal_source_and_destination(
+    edge_type: EdgeType,
+    edge_dir: str,
+) -> tuple[NodeType, NodeType]:
+    """Return the traversal source and destination node types for an edge type."""
+    if edge_dir == "in":
+        return edge_type[-1], edge_type[0]
+    if edge_dir == "out":
+        return edge_type[0], edge_type[-1]
+    raise ValueError(f"Expected edge_dir to be 'in' or 'out', got {edge_dir!r}.")
+
+
+def _validate_metapath_steps_chain(
+    metapath: PPRMetaPath,
+    edge_dir: str,
+) -> list[tuple[NodeType, NodeType]]:
+    """Validate a metapath and return each step's traversal endpoint types."""
+    step_endpoint_types: list[tuple[NodeType, NodeType]] = []
+    for step in metapath.path:
+        step_edge_types = _normalize_metapath_step(step)
+        first_endpoint_types = _get_traversal_source_and_destination(
+            step_edge_types[0],
+            edge_dir,
+        )
+        for edge_type in step_edge_types[1:]:
+            endpoint_types = _get_traversal_source_and_destination(
+                edge_type,
+                edge_dir,
+            )
+            if endpoint_types != first_endpoint_types:
+                raise ValueError(
+                    "PPRMetaPath grouped-step alternatives must share the same "
+                    "traversal source and destination node types, got "
+                    f"{step_edge_types!r}."
+                )
+        step_endpoint_types.append(first_endpoint_types)
+
+    for step_index in range(1, len(step_endpoint_types)):
+        previous_destination_type = step_endpoint_types[step_index - 1][1]
+        current_source_type = step_endpoint_types[step_index][0]
+        if previous_destination_type != current_source_type:
+            raise ValueError(
+                "PPRMetaPath steps must chain by traversal node type, got "
+                f"step {step_index - 1} ending at {previous_destination_type!r} "
+                f"and step {step_index} starting at {current_source_type!r}."
+            )
+
+    if metapath.cyclic_from is not None:
+        repeat_source_type = step_endpoint_types[metapath.cyclic_from][0]
+        final_destination_type = step_endpoint_types[-1][1]
+        if final_destination_type != repeat_source_type:
+            raise ValueError(
+                "PPRMetaPath cyclic suffix must return to the repeat start "
+                "node type, got final destination "
+                f"{final_destination_type!r} and cyclic_from source "
+                f"{repeat_source_type!r}."
+            )
+
+    return step_endpoint_types
+
+
+def _add_transition(
+    program: TypedPPRChannelTraversalProgram,
+    state_id: int,
+    source_node_type_id: int,
+    edge_type_id: int,
+    destination_state_id: int,
+) -> None:
+    """Add one transition unless the same edge transition already exists."""
+    transition = (edge_type_id, destination_state_id)
+    transitions = program[state_id][source_node_type_id]
+    if transition not in transitions:
+        transitions.append(transition)
+
+
+def _build_allowlist_channel_program(
+    edge_types: tuple[EdgeType, ...],
+    edge_type_to_edge_type_id: dict[EdgeType, int],
+    node_type_to_edge_types: dict[NodeType, list[EdgeType]],
+    node_types: Sequence[NodeType],
+) -> tuple[TypedPPRChannelTraversalProgram, list[int]]:
+    """Build a one-state self-loop program for an edge-type allowlist channel."""
+    known_edge_types = set(edge_type_to_edge_type_id.keys())
+    unknown_edge_types = set(edge_types) - known_edge_types
+    if unknown_edge_types:
+        raise ValueError(
+            "Typed PPR channels include non-traversable edge types "
+            f"{sorted(unknown_edge_types)!r}. Known traversable edge "
+            f"types are {sorted(known_edge_types)!r}."
+        )
+
+    channel_edge_type_set = set(edge_types)
+    program: TypedPPRChannelTraversalProgram = [[[] for _node_type in node_types]]
+    for node_type_id, node_type in enumerate(node_types):
+        for edge_type in node_type_to_edge_types.get(node_type, []):
+            if edge_type in channel_edge_type_set:
+                _add_transition(
+                    program=program,
+                    state_id=0,
+                    source_node_type_id=node_type_id,
+                    edge_type_id=edge_type_to_edge_type_id[edge_type],
+                    destination_state_id=0,
+                )
+    if not any(program[0]):
+        raise ValueError(
+            "Typed PPR channels include edge-type "
+            f"channel={edge_types!r}, "
+            "but no traversable edge types exist for that channel."
+        )
+    return program, [0]
+
+
+def _build_metapath_channel_program(
+    metapath: PPRMetaPath,
+    edge_type_to_edge_type_id: dict[EdgeType, int],
+    node_type_to_node_type_id: dict[NodeType, int],
+    edge_dir: str,
+) -> tuple[TypedPPRChannelTraversalProgram, list[int]]:
+    """Build a traversal-state program for one ordered metapath channel."""
+    known_edge_types = set(edge_type_to_edge_type_id.keys())
+    normalized_steps = [_normalize_metapath_step(step) for step in metapath.path]
+    unknown_edge_types = {
+        edge_type
+        for step_edge_types in normalized_steps
+        for edge_type in step_edge_types
+        if edge_type not in known_edge_types
+    }
+    if unknown_edge_types:
+        raise ValueError(
+            "PPRMetaPath includes non-traversable edge types "
+            f"{sorted(unknown_edge_types)!r}. Known traversable edge "
+            f"types are {sorted(known_edge_types)!r}."
+        )
+
+    step_endpoint_types = _validate_metapath_steps_chain(metapath, edge_dir)
+    for source_type, destination_type in step_endpoint_types:
+        if source_type not in node_type_to_node_type_id:
+            raise ValueError(
+                f"PPRMetaPath source node type {source_type!r} is not traversable."
+            )
+        if destination_type not in node_type_to_node_type_id:
+            raise ValueError(
+                f"PPRMetaPath destination node type {destination_type!r} is unknown."
+            )
+
+    num_steps = len(normalized_steps)
+    if metapath.cyclic_from is None:
+        num_states = num_steps + 1
+        emitting_state_ids = [num_steps]
+    elif metapath.cyclic_from == 0:
+        num_states = num_steps + 1
+        emitting_state_ids = [num_steps]
+    else:
+        num_states = num_steps
+        emitting_state_ids = [metapath.cyclic_from]
+
+    program: TypedPPRChannelTraversalProgram = [
+        [[] for _node_type in node_type_to_node_type_id] for _state in range(num_states)
+    ]
+
+    for step_index, step_edge_types in enumerate(normalized_steps):
+        source_type = step_endpoint_types[step_index][0]
+        source_node_type_id = node_type_to_node_type_id[source_type]
+        if metapath.cyclic_from is not None and step_index == num_steps - 1:
+            destination_state_id = (
+                num_steps if metapath.cyclic_from == 0 else metapath.cyclic_from
+            )
+        else:
+            destination_state_id = step_index + 1
+
+        for edge_type in step_edge_types:
+            _add_transition(
+                program=program,
+                state_id=step_index,
+                source_node_type_id=source_node_type_id,
+                edge_type_id=edge_type_to_edge_type_id[edge_type],
+                destination_state_id=destination_state_id,
+            )
+
+    if metapath.cyclic_from == 0:
+        source_type = step_endpoint_types[0][0]
+        source_node_type_id = node_type_to_node_type_id[source_type]
+        destination_state_id = 1 if num_steps > 1 else num_steps
+        for edge_type in normalized_steps[0]:
+            _add_transition(
+                program=program,
+                state_id=num_steps,
+                source_node_type_id=source_node_type_id,
+                edge_type_id=edge_type_to_edge_type_id[edge_type],
+                destination_state_id=destination_state_id,
+            )
+
+    return program, emitting_state_ids
+
+
+def build_typed_ppr_channel_traversal_programs(
+    channel_specs: TypedPPRChannelSpecs,
+    edge_type_to_edge_type_id: dict[EdgeType, int],
+    node_type_to_edge_types: dict[NodeType, list[EdgeType]],
+    node_types: Sequence[NodeType],
+    edge_dir: str,
+) -> tuple[TypedPPRChannelTraversalPrograms, TypedPPRChannelEmittingStateIds]:
+    """Convert typed-channel specs to C++ traversal programs.
+
+    Existing allowlist channels compile to a single emitting self-loop state.
+    ``PPRMetaPath`` channels compile to ordered traversal states and emit only
+    from the state(s) that satisfy the metapath pattern.
+    """
+    node_type_to_node_type_id = {
+        node_type: node_type_id for node_type_id, node_type in enumerate(node_types)
+    }
+
+    traversal_programs: TypedPPRChannelTraversalPrograms = []
+    emitting_state_ids_by_channel: TypedPPRChannelEmittingStateIds = []
+    for channel_spec in channel_specs:
+        if isinstance(channel_spec, PPRMetaPath):
+            traversal_program, emitting_state_ids = _build_metapath_channel_program(
+                metapath=channel_spec,
+                edge_type_to_edge_type_id=edge_type_to_edge_type_id,
+                node_type_to_node_type_id=node_type_to_node_type_id,
+                edge_dir=edge_dir,
+            )
+        else:
+            traversal_program, emitting_state_ids = _build_allowlist_channel_program(
+                edge_types=channel_spec,
+                edge_type_to_edge_type_id=edge_type_to_edge_type_id,
+                node_type_to_edge_types=node_type_to_edge_types,
+                node_types=node_types,
+            )
+        traversal_programs.append(traversal_program)
+        emitting_state_ids_by_channel.append(emitting_state_ids)
+
+    return traversal_programs, emitting_state_ids_by_channel
+
+
 def build_edge_type_channel_group_edge_type_ids(
-    edge_type_groups: TypedPPRChannelEdgeTypeGroups,
+    edge_type_groups: list[tuple[EdgeType, ...]],
     edge_type_to_edge_type_id: dict[EdgeType, int],
     node_type_to_edge_types: dict[NodeType, list[EdgeType]],
     node_types: Sequence[NodeType],

--- a/tests/unit/distributed/dist_ppr_sampler_test.py
+++ b/tests/unit/distributed/dist_ppr_sampler_test.py
@@ -40,7 +40,7 @@ from torch_geometric.data import Data, HeteroData
 
 from gigl.distributed.dist_ablp_neighborloader import DistABLPLoader
 from gigl.distributed.distributed_neighborloader import DistNeighborLoader
-from gigl.distributed.sampler_options import PPRSamplerOptions
+from gigl.distributed.sampler_options import PPRMetaPath, PPRSamplerOptions
 from gigl.types.graph import (
     DEFAULT_HOMOGENEOUS_EDGE_TYPE,
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
@@ -600,6 +600,35 @@ def _run_typed_ppr_loader_shape_check(_: int) -> None:
     )
     empty_story_edge_attr = empty_story_datum[(str(USER), "ppr", STORY)].edge_attr
     assert tuple(empty_story_edge_attr.shape) == (0, 5)
+
+    metapath_loader = DistNeighborLoader(
+        dataset=dataset,
+        input_nodes=(USER, node_ids[USER][:1]),  # ty: ignore[invalid-argument-type] TODO(ty-torch-keyed-access): fix ty false positives for torch-backed keyed container access.
+        num_neighbors=[],
+        sampler_options=PPRSamplerOptions(
+            alpha=_TEST_ALPHA,
+            eps=_TEST_EPS,
+            max_ppr_nodes=_TEST_MAX_PPR_NODES,
+            typed_channel_ratios={
+                PPRMetaPath(path=(USER_TO_STORY, STORY_TO_USER), cyclic_from=0): 1.0,
+            },
+        ),
+        pin_memory_device=torch.device("cpu"),
+        batch_size=1,
+    )
+    metapath_datum = next(iter(metapath_loader))
+    assert isinstance(metapath_datum, HeteroData)
+    _assert_typed_ppr_edge_attrs(
+        datum=metapath_datum,
+        seed_type=str(USER),
+        node_types=[USER, STORY],
+        num_channels=1,
+    )
+    metapath_user_edge_attr = metapath_datum[(str(USER), "ppr", USER)].edge_attr
+    metapath_story_edge_attr = metapath_datum[(str(USER), "ppr", STORY)].edge_attr
+    assert metapath_user_edge_attr.size(0) > 0
+    assert (metapath_user_edge_attr[:, 2] == 1).all()
+    assert tuple(metapath_story_edge_attr.shape) == (0, 3)
 
     shutdown_rpc()
 

--- a/tests/unit/distributed/dist_typed_sampler_test.py
+++ b/tests/unit/distributed/dist_typed_sampler_test.py
@@ -3,9 +3,12 @@
 from absl.testing import absltest
 
 from gigl.distributed.utils.dist_typed_sampler import (
+    PPRMetaPath,
     build_edge_type_channel_group_edge_type_ids,
+    build_typed_ppr_channel_traversal_programs,
     compute_typed_channel_target_counts,
     parse_typed_channel_ratio_groups,
+    parse_typed_channel_ratio_specs,
 )
 from tests.test_assets.distributed.test_dataset import (
     STORY,
@@ -14,6 +17,10 @@ from tests.test_assets.distributed.test_dataset import (
     USER_TO_STORY,
 )
 from tests.test_assets.test_case import TestCase
+
+USER_TO_STORY_ALT = (USER, "shares", STORY)
+USER_TO_USER_EDGE_1 = (USER, "edge_1", USER)
+USER_TO_USER_EDGE_2 = (USER, "edge_2", USER)
 
 
 class DistTypedSamplerTest(TestCase):
@@ -82,6 +89,145 @@ class DistTypedSamplerTest(TestCase):
                 node_type_to_edge_types=node_type_to_edge_types,
                 node_types=node_types,
             )
+
+    def test_typed_ppr_metapath_channels_parse_and_build_traversal_programs(
+        self,
+    ) -> None:
+        """Verify typed-PPR can use PyG-style ordered metapath channels."""
+        node_type_to_edge_types = {
+            USER: [USER_TO_STORY, USER_TO_STORY_ALT],
+            STORY: [STORY_TO_USER],
+        }
+        node_types = [USER, STORY]
+        edge_type_to_edge_type_id = {
+            USER_TO_STORY: 0,
+            USER_TO_STORY_ALT: 1,
+            STORY_TO_USER: 2,
+        }
+
+        typed_channel_specs, typed_channel_ratio_list = parse_typed_channel_ratio_specs(
+            {
+                PPRMetaPath(
+                    path=((USER_TO_STORY, USER_TO_STORY_ALT), STORY_TO_USER),
+                    cyclic_from=0,
+                ): 1.0,
+            }
+        )
+        assert typed_channel_specs is not None
+        assert typed_channel_ratio_list is not None
+
+        self.assertEqual(
+            typed_channel_specs,
+            [
+                PPRMetaPath(
+                    path=((USER_TO_STORY, USER_TO_STORY_ALT), (STORY_TO_USER,)),
+                    cyclic_from=0,
+                )
+            ],
+        )
+        self.assertEqual(typed_channel_ratio_list, [1.0])
+
+        traversal_programs, emitting_state_ids = (
+            build_typed_ppr_channel_traversal_programs(
+                channel_specs=typed_channel_specs,
+                edge_type_to_edge_type_id=edge_type_to_edge_type_id,
+                node_type_to_edge_types=node_type_to_edge_types,
+                node_types=node_types,
+                edge_dir="out",
+            )
+        )
+
+        self.assertEqual(
+            traversal_programs,
+            [
+                [
+                    [[(0, 1), (1, 1)], []],
+                    [[], [(2, 2)]],
+                    [[(0, 1), (1, 1)], []],
+                ]
+            ],
+        )
+        self.assertEqual(emitting_state_ids, [[2]])
+
+    def test_typed_ppr_metapath_channels_support_prefix_then_repeat(
+        self,
+    ) -> None:
+        """Verify cyclic_from can model edge_1 followed by edge_2 indefinitely."""
+        node_type_to_edge_types = {
+            USER: [USER_TO_USER_EDGE_1, USER_TO_USER_EDGE_2],
+        }
+        node_types = [USER]
+        edge_type_to_edge_type_id = {
+            USER_TO_USER_EDGE_1: 0,
+            USER_TO_USER_EDGE_2: 1,
+        }
+
+        traversal_programs, emitting_state_ids = (
+            build_typed_ppr_channel_traversal_programs(
+                channel_specs=[
+                    PPRMetaPath(
+                        path=(USER_TO_USER_EDGE_1, USER_TO_USER_EDGE_2),
+                        cyclic_from=1,
+                    )
+                ],
+                edge_type_to_edge_type_id=edge_type_to_edge_type_id,
+                node_type_to_edge_types=node_type_to_edge_types,
+                node_types=node_types,
+                edge_dir="out",
+            )
+        )
+
+        self.assertEqual(
+            traversal_programs,
+            [
+                [
+                    [[(0, 1)]],
+                    [[(1, 1)]],
+                ]
+            ],
+        )
+        self.assertEqual(emitting_state_ids, [[1]])
+
+    def test_typed_ppr_metapath_channels_validate_branching_steps(
+        self,
+    ) -> None:
+        """Grouped alternatives must be same-source and same-destination."""
+        with self.assertRaisesRegex(ValueError, "grouped-step alternatives"):
+            build_typed_ppr_channel_traversal_programs(
+                channel_specs=[
+                    PPRMetaPath(path=((USER_TO_STORY, USER_TO_USER_EDGE_1),))
+                ],
+                edge_type_to_edge_type_id={
+                    USER_TO_STORY: 0,
+                    USER_TO_USER_EDGE_1: 1,
+                },
+                node_type_to_edge_types={
+                    USER: [USER_TO_STORY, USER_TO_USER_EDGE_1],
+                    STORY: [],
+                },
+                node_types=[USER, STORY],
+                edge_dir="out",
+            )
+
+        with self.assertRaisesRegex(ValueError, "cyclic suffix"):
+            build_typed_ppr_channel_traversal_programs(
+                channel_specs=[
+                    PPRMetaPath(path=(USER_TO_STORY, STORY_TO_USER), cyclic_from=1)
+                ],
+                edge_type_to_edge_type_id={
+                    USER_TO_STORY: 0,
+                    STORY_TO_USER: 1,
+                },
+                node_type_to_edge_types={
+                    USER: [USER_TO_STORY],
+                    STORY: [STORY_TO_USER],
+                },
+                node_types=[USER, STORY],
+                edge_dir="out",
+            )
+
+        with self.assertRaisesRegex(ValueError, "cannot return PPRMetaPath"):
+            parse_typed_channel_ratio_groups({PPRMetaPath(path=(USER_TO_STORY,)): 1.0})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `PPRMetaPath` typed-channel keys to support PyG-style ordered metapath traversal without adding a second public ratios knob.
- Preserve existing typed-channel allowlist behavior for canonical edge-type keys and tuple-of-edge-types keys.
- Compile typed channels into C++ traversal programs with emitting traversal states, enabling exact paths, whole-path cycles, and prefix-then-repeat patterns like `edge_1 -> edge_2*`.
- Ground the public docstrings in PyG's `AddMetaPaths` / `MetaPath2Vec` metapath API shape.

## Notes

- A grouped metapath step is a GiGL extension over PyG's singular-step metapath convention. It allows alternatives at one ordered position, but only when those alternatives share the same traversal source and destination node types under `edge_dir`.
- Branching to multiple next node types is intentionally not included in this first pass; use separate channel keys for that case.
