### PR TITLE
Move the Dataproc CI pools from n2d to n2

### DIFF
--- a/deployment/configs/e2e_cicd_resource_config.yaml
+++ b/deployment/configs/e2e_cicd_resource_config.yaml
@@ -33,11 +33,6 @@ preprocessor_config:
     max_num_workers: 128
     machine_type: "n2d-highmem-64"
     disk_size_gb: 300
-# n2 rather than n2d for both Dataproc stages: n2d stocks out in us-central1 often
-# enough to fail cluster creation, and every stockout costs a 20-minute retry.
-# Same vCPU and memory, so Spark parallelism and executor sizing are unchanged.
-# Local SSD rules out c3/c4 (their only local-SSD variants end in `-lssd`, which
-# NumCores.scala's trailing-digit regex cannot parse) and e2/n4 (no local SSD).
 subgraph_sampler_config:
   machine_type: "n2-highmem-16"
   num_local_ssds: 2

--- a/deployment/configs/e2e_cicd_resource_config.yaml
+++ b/deployment/configs/e2e_cicd_resource_config.yaml
@@ -33,12 +33,17 @@ preprocessor_config:
     max_num_workers: 128
     machine_type: "n2d-highmem-64"
     disk_size_gb: 300
+# n2 rather than n2d for both Dataproc stages: n2d stocks out in us-central1 often
+# enough to fail cluster creation, and every stockout costs a 20-minute retry.
+# Same vCPU and memory, so Spark parallelism and executor sizing are unchanged.
+# Local SSD rules out c3/c4 (their only local-SSD variants end in `-lssd`, which
+# NumCores.scala's trailing-digit regex cannot parse) and e2/n4 (no local SSD).
 subgraph_sampler_config:
-  machine_type: "n2d-highmem-16"
+  machine_type: "n2-highmem-16"
   num_local_ssds: 2
   num_replicas: 4
 split_generator_config:
-  machine_type: n2d-standard-16
+  machine_type: n2-standard-16
   num_local_ssds: 2
   num_replicas: 4
 trainer_config:

--- a/deployment/configs/unittest_resource_config.yaml
+++ b/deployment/configs/unittest_resource_config.yaml
@@ -35,12 +35,14 @@ preprocessor_config:
     max_num_workers: 128
     machine_type: "n2d-highmem-64"
     disk_size_gb: 300
+# Kept in step with e2e_cicd_resource_config.yaml: n2 rather than n2d, since n2d
+# stocks out in us-central1. Same vCPU and memory.
 subgraph_sampler_config:
-  machine_type: "n2d-highmem-16"
+  machine_type: "n2-highmem-16"
   num_local_ssds: 2
   num_replicas: 4
 split_generator_config:
-  machine_type: n2d-standard-16
+  machine_type: n2-standard-16
   num_local_ssds: 2
   num_replicas: 4
 trainer_config:


### PR DESCRIPTION
n2d stocks out in us-central1 often enough to fail SubgraphSampler and SplitGenerator cluster creation, and each stockout is expensive: create_cluster retries six times with a fixed 20 minute sleep, so a run can burn two hours before giving up.

n2 has a deeper pool at the same shape. Both stages keep 16 vCPU and the same memory, so Spark parallelism (shuffle partitions are derived from vCPU count) and executor sizing do not move.

n2 rather than a newer family because local SSD constrains the choice: e2 and n4 have none, and c3/c4 only offer it on machine types ending in `-lssd`, which NumCores.scala derives vCPUs from with a trailing-digit regex and cannot parse. examples/toy_visual_example already runs n2-standard-16 with num_local_ssds: 2.

Only the two CI configs change. examples/MAG240M keeps n2d at 240 replicas, where the shape was chosen for a 240 million node graph.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
