### PR TITLE
Convert PPR sampling tuples/pairs to named structs

### DIFF
--- a/gigl-core/core/sampling/ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/ppr_forward_push.cpp
@@ -9,13 +9,22 @@
 #include <future>
 #include <numeric>
 #include <optional>
-#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
 
 namespace gigl {
+
+namespace {
+// Internal (nodeId, score) pair threaded through the extraction path, sorted by
+// score. Layout-identical to std::pair<int32_t, double>; named fields replace
+// positional .first/.second.
+struct NodeScore {
+    int32_t nodeId;
+    double score;
+};
+} // namespace
 
 // Pack (node_id, etype_id) into a single uint64 for use as a hash key.
 // Inputs are cast through uint32_t to avoid sign-extension of negative int32 values.
@@ -255,10 +264,10 @@ void PPRForwardPush::pushResiduals(const NeighborFetchMap& fetchedByEtypeId) {
     // fetched row here avoids re-fetching a (node, edge type) pair if it re-enters
     // the frontier later in the same PPR channel.
     for (const auto& [edgeTypeId, neighborTensors] : fetchedByEtypeId) {
-        const auto& nodeIdsTensor = std::get<0>(neighborTensors);
-        const auto& flatNeighborIdsTensor = std::get<1>(neighborTensors);
-        const auto& countsTensor = std::get<2>(neighborTensors);
-        const auto edgeIdsTensor = std::get<3>(neighborTensors).value_or(torch::Tensor());
+        const auto& nodeIdsTensor = neighborTensors.nodeIds;
+        const auto& flatNeighborIdsTensor = neighborTensors.flatNeighborIds;
+        const auto& countsTensor = neighborTensors.counts;
+        const auto edgeIdsTensor = neighborTensors.edgeIds.value_or(torch::Tensor());
 
         if (edgeIdsTensor.defined()) {
             TORCH_CHECK(edgeIdsTensor.dim() == 1, "edge_ids must be 1D.");
@@ -592,24 +601,28 @@ OriginalEdgeExtractResult extractOriginalEdgesFromPPRCaches(
 // Expected output: (node_id, raw_ppr_score) pairs selected by raw PPR score.
 // The order is unspecified; callers that emit these directly should sort the
 // returned vector before writing output tensors.
-static std::vector<std::pair<int32_t, double>> selectFinalizedPPRPairs(const SeedNodeTypeState& nodeTypeState,
-                                                                       int32_t finalizedPPRNodeLimit) {
+static std::vector<NodeScore> selectFinalizedPPRPairs(const SeedNodeTypeState& nodeTypeState,
+                                                      int32_t finalizedPPRNodeLimit) {
     const auto& scores = nodeTypeState.pprScores;
 
     const int32_t numReturnedPairs = std::min(finalizedPPRNodeLimit, static_cast<int32_t>(scores.size()));
-    std::vector<std::pair<int32_t, double>> selectedPairs;
+    std::vector<NodeScore> selectedPairs;
     selectedPairs.reserve(static_cast<size_t>(numReturnedPairs));
     if (numReturnedPairs > 0) {
-        std::vector<std::pair<int32_t, double>> scorePairs(scores.begin(), scores.end());
+        std::vector<NodeScore> scorePairs;
+        scorePairs.reserve(scores.size());
+        for (const auto& [nodeId, score] : scores) {
+            scorePairs.push_back(NodeScore{nodeId, score});
+        }
         if (numReturnedPairs < static_cast<int32_t>(scorePairs.size())) {
             std::nth_element(scorePairs.begin(),
                              scorePairs.begin() + numReturnedPairs,
                              scorePairs.end(),
-                             [](const auto& a, const auto& b) { return a.second > b.second; });
+                             [](const auto& a, const auto& b) { return a.score > b.score; });
         }
 
         for (int32_t rankIdx = 0; rankIdx < numReturnedPairs; ++rankIdx) {
-            selectedPairs.emplace_back(scorePairs[rankIdx].first, scorePairs[rankIdx].second);
+            selectedPairs.push_back(NodeScore{scorePairs[rankIdx].nodeId, scorePairs[rankIdx].score});
         }
     }
 
@@ -628,7 +641,7 @@ static std::vector<std::pair<int32_t, double>> selectFinalizedPPRPairs(const See
 // highest-scoring residual candidates that are not already selected. This helper
 // does not sort selectedPairs; callers sort only when their output needs it.
 static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
-                                     std::vector<std::pair<int32_t, double>>& selectedPairs,
+                                     std::vector<NodeScore>& selectedPairs,
                                      int32_t sequenceLength) {
     const int32_t residualTopUpBudget =
         std::max<int32_t>(0, sequenceLength - static_cast<int32_t>(selectedPairs.size()));
@@ -637,10 +650,10 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
         std::unordered_set<int32_t> selectedPPRNodeIds;
         selectedPPRNodeIds.reserve(selectedPairs.size());
         for (const auto& selectedPair : selectedPairs) {
-            selectedPPRNodeIds.insert(selectedPair.first);
+            selectedPPRNodeIds.insert(selectedPair.nodeId);
         }
 
-        std::vector<std::pair<int32_t, double>> residualPairs;
+        std::vector<NodeScore> residualPairs;
         residualPairs.reserve(nodeTypeState.residualStates.size());
         for (const auto& [nodeId, residualState] : nodeTypeState.residualStates) {
             double residual = residualState.residual;
@@ -654,7 +667,7 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
             auto pprScoreIter = pprScoresByNodeId.find(nodeId);
             double pprScore = (pprScoreIter != pprScoresByNodeId.end()) ? pprScoreIter->second : 0.0;
             double outputScore = pprScore + residual;
-            residualPairs.emplace_back(nodeId, outputScore);
+            residualPairs.push_back(NodeScore{nodeId, outputScore});
         }
 
         const int32_t residualTopK = std::min(residualTopUpBudget, static_cast<int32_t>(residualPairs.size()));
@@ -663,11 +676,11 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
                 std::nth_element(residualPairs.begin(),
                                  residualPairs.begin() + residualTopK,
                                  residualPairs.end(),
-                                 [](const auto& a, const auto& b) { return a.second > b.second; });
+                                 [](const auto& a, const auto& b) { return a.score > b.score; });
             }
 
             for (int32_t rankIdx = 0; rankIdx < residualTopK; ++rankIdx) {
-                selectedPairs.emplace_back(residualPairs[rankIdx].first, residualPairs[rankIdx].second);
+                selectedPairs.push_back(NodeScore{residualPairs[rankIdx].nodeId, residualPairs[rankIdx].score});
             }
         }
     }
@@ -682,8 +695,7 @@ static void appendResidualTopUpPairs(const SeedNodeTypeState& nodeTypeState,
 //
 // Expected output: selectedPairs scores are updated in-place to
 // ppr_score + residual(node) when residual mass exists for that node.
-static void addResidualMassToPPRPairs(const SeedNodeTypeState& nodeTypeState,
-                                      std::vector<std::pair<int32_t, double>>& selectedPairs) {
+static void addResidualMassToPPRPairs(const SeedNodeTypeState& nodeTypeState, std::vector<NodeScore>& selectedPairs) {
     for (auto& [nodeId, score] : selectedPairs) {
         auto residualStateIter = nodeTypeState.residualStates.find(nodeId);
         if (residualStateIter != nodeTypeState.residualStates.end()) {
@@ -722,12 +734,12 @@ static double getNodeHopProximity(const SeedNodeTypeState& nodeTypeState, int32_
 // Expected output: outputScoresByNodeId has this channel's score, proximity,
 // and presence features merged in, and channelOutputCandidates contains this channel's
 // candidates on the emitted PPR score scale.
-static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int32_t, double>>& nodesAndScores,
+static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<NodeScore>& nodesAndScores,
                                                  const SeedNodeTypeState& nodeTypeState,
                                                  int32_t channelIndex,
                                                  const TypedPPRFeatureLayout& featureLayout,
                                                  std::unordered_map<int32_t, std::vector<double>>& outputScoresByNodeId,
-                                                 std::vector<std::pair<int32_t, double>>& channelOutputCandidates) {
+                                                 std::vector<NodeScore>& channelOutputCandidates) {
     if (nodesAndScores.empty()) {
         return;
     }
@@ -746,7 +758,7 @@ static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int
 
         // Keep a per-channel sortable candidate list so target counts can be
         // applied after cross-channel attribution.
-        channelOutputCandidates.emplace_back(nodeId, score);
+        channelOutputCandidates.push_back(NodeScore{nodeId, score});
     }
 }
 
@@ -762,10 +774,9 @@ static void addTypedPPRSeedFeaturesAndCandidates(const std::vector<std::pair<int
 //   2. Fill each channel up to its target count.
 //   3. Redistribute unused slots to the remaining highest-scoring candidates.
 //   4. Return the selected nodes globally ranked by best score.
-static std::vector<int32_t> selectTypedPPRNodeIds(
-    std::vector<std::vector<std::pair<int32_t, double>>>& candidatesByChannel,
-    const std::vector<int32_t>& channelTargetCounts,
-    int32_t maxPPRNodes) {
+static std::vector<int32_t> selectTypedPPRNodeIds(std::vector<std::vector<NodeScore>>& candidatesByChannel,
+                                                  const std::vector<int32_t>& channelTargetCounts,
+                                                  int32_t maxPPRNodes) {
     struct AttributedCandidate {
         double bestScore;
         double channelScore;
@@ -923,7 +934,7 @@ PPRExtractResult PPRForwardPush::extractTopKWithResidualTopUp(int32_t maxPPRNode
             // together by emitted score, so top-up rows may interleave after selection.
             if (selectedPairs.size() > 1) {
                 std::sort(selectedPairs.begin(), selectedPairs.end(), [](const auto& a, const auto& b) {
-                    return a.second > b.second;
+                    return a.score > b.score;
                 });
             }
 
@@ -996,8 +1007,7 @@ PPRExtractResult extractTypedTopKWithResidualTopUp(const std::vector<PPRForwardP
             // residual-aware rows when top-up is enabled. Selection and emitted
             // features use this same view so both finalized and residual
             // candidates obey the per-channel target counts.
-            std::vector<std::vector<std::pair<int32_t, double>>> outputCandidatesByChannel(
-                static_cast<size_t>(numChannels));
+            std::vector<std::vector<NodeScore>> outputCandidatesByChannel(static_cast<size_t>(numChannels));
 
             for (int32_t channelIndex = 0; channelIndex < numChannels; ++channelIndex) {
                 const auto& nodeTypeState = states[channelIndex]->_state[seedIdx][nodeTypeId];

--- a/gigl-core/core/sampling/ppr_forward_push.h
+++ b/gigl-core/core/sampling/ppr_forward_push.h
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include <optional>
-#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -13,12 +12,21 @@ namespace gigl {
 
 // Neighbor fetch input from Python, keyed by integer edge type ID:
 //   node_ids[N], flat_neighbor_ids[sum(counts)], counts[N], optional edge_ids[sum(counts)].
-using NeighborFetchTensors = std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, std::optional<torch::Tensor>>;
+struct NeighborFetchTensors {
+    torch::Tensor nodeIds;                // node_ids[N]
+    torch::Tensor flatNeighborIds;        // flat_neighbor_ids[sum(counts)]
+    torch::Tensor counts;                 // counts[N]
+    std::optional<torch::Tensor> edgeIds; // optional edge_ids[sum(counts)]
+};
 using NeighborFetchMap = std::unordered_map<int32_t, NeighborFetchTensors>;
 
 // PPR extraction output, keyed by integer node type ID:
 //   ids, weights/edge_attr, valid_counts.
-using PPRExtractTensors = std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>;
+struct PPRExtractTensors {
+    torch::Tensor ids;         // int64 node IDs, flattened across seeds
+    torch::Tensor weights;     // double feature matrix / edge_attr
+    torch::Tensor validCounts; // int64 selected-node count per seed
+};
 using PPRExtractResult = std::unordered_map<int32_t, PPRExtractTensors>;
 
 // Original-edge extraction output, keyed by integer edge type ID:

--- a/gigl-core/core/sampling/python_ppr_forward_push.cpp
+++ b/gigl-core/core/sampling/python_ppr_forward_push.cpp
@@ -9,7 +9,6 @@
 
 #include <cstdint>
 #include <optional>
-#include <tuple>
 #include <unordered_map>
 
 #include "ppr_forward_push.h"
@@ -18,39 +17,19 @@ namespace py = pybind11;
 
 namespace gigl {
 
-// pushResiduals receives Python-owned containers, so convert them while the GIL
-// is held and release only around the C++ state update.
-static void pushResidualsWrapper(PPRForwardPush& state, const py::dict& fetchedByEtypeId) {
-    NeighborFetchMap neighborTensorsByEtypeId;
-    // Dict iteration touches Python objects — GIL must be held here.
-    for (auto item : fetchedByEtypeId) {
-        auto edgeTypeId = item.first.cast<int32_t>();
-        auto neighborTensors = item.second.cast<py::tuple>();
-        auto neighborTensorCount = neighborTensors.size();
-        if (neighborTensorCount != 3) {
-            TORCH_CHECK(neighborTensorCount == 4,
-                        "Expected neighbor fetch tuple of length 3 or 4, received ",
-                        neighborTensorCount,
-                        ".");
-        }
-        std::optional<torch::Tensor> edgeIds = std::nullopt;
-        if (neighborTensorCount == 4 && !neighborTensors[3].is_none()) {
-            edgeIds = neighborTensors[3].cast<torch::Tensor>();
-        }
-        neighborTensorsByEtypeId[edgeTypeId] = {neighborTensors[0].cast<torch::Tensor>(),
-                                                neighborTensors[1].cast<torch::Tensor>(),
-                                                neighborTensors[2].cast<torch::Tensor>(),
-                                                edgeIds};
-    }
+// pushResiduals receives Python-owned containers. pybind converts the
+// dict[int, NeighborFetchTensors] argument into NeighborFetchMap while the GIL
+// is held, before this wrapper runs; release only around the C++ state update.
+static void pushResidualsWrapper(PPRForwardPush& state, const NeighborFetchMap& fetchedByEtypeId) {
     // C++ push only uses tensor accessor/data_ptr APIs — GIL-safe to release.
     // Releasing here lets the asyncio event loop process RPC completion callbacks
     // from other concurrent PPR coroutines while this push runs.
-    // REQUIREMENT: no other thread may read or modify neighborTensorsByEtypeId or
-    // the underlying tensor data while the GIL is released.  The caller (Python)
-    // must not alias or mutate fetchedByEtypeId until push_residuals returns.
+    // REQUIREMENT: no other thread may read or modify fetchedByEtypeId or the
+    // underlying tensor data while the GIL is released.  The caller (Python) must
+    // not alias or mutate the fetched map until push_residuals returns.
     {
         py::gil_scoped_release release;
-        state.pushResiduals(neighborTensorsByEtypeId);
+        state.pushResiduals(fetchedByEtypeId);
     }
 }
 
@@ -79,9 +58,9 @@ static PPRExtractResult extractTopKWithResidualTopUpWrapper(PPRForwardPush& stat
     return result;
 }
 
-static py::tuple drainTypedPPRChannelQueuesWrapper(const py::sequence& states,
-                                                   const std::vector<int32_t>& fetchIterationCounts,
-                                                   int32_t maxFetchIterations) {
+static TypedPPRQueueDrainResult drainTypedPPRChannelQueuesWrapper(const py::sequence& states,
+                                                                  const std::vector<int32_t>& fetchIterationCounts,
+                                                                  int32_t maxFetchIterations) {
     std::vector<PPRForwardPush*> statePtrs;
     statePtrs.reserve(py::len(states));
     // Sequence iteration and casting touch Python objects, so keep the GIL
@@ -91,7 +70,7 @@ static py::tuple drainTypedPPRChannelQueuesWrapper(const py::sequence& states,
     }
 
     // C++ typed drain only reads/mutates PPRForwardPush states and builds C++
-    // containers. Reacquire the GIL before constructing the Python tuple.
+    // containers. Reacquire the GIL before pybind converts the returned struct.
     // REQUIREMENT: no other thread may read or mutate these channel states
     // while the GIL is released. The typed sampler drains and pushes each
     // channel in a single sequenced loop iteration.
@@ -100,13 +79,10 @@ static py::tuple drainTypedPPRChannelQueuesWrapper(const py::sequence& states,
         py::gil_scoped_release release;
         queueDrainResult = drainTypedPPRChannelQueues(statePtrs, fetchIterationCounts, maxFetchIterations);
     }
-    // Pybind converts the temporary C++ containers into Python objects. Tensor
-    // values are handles, so this does not copy tensor storage across the
+    // Pybind converts the returned struct's C++ containers into Python objects.
+    // Tensor values are handles, so this does not copy tensor storage across the
     // Python/C++ boundary.
-    return py::make_tuple(queueDrainResult.drainedChannelIndices,
-                          queueDrainResult.fetchChannelIndices,
-                          queueDrainResult.edgeTypeIdsByFetchChannel,
-                          queueDrainResult.unionedNodeIdsByEdgeTypeId);
+    return queueDrainResult;
 }
 
 static PPRExtractResult extractTypedTopKWithResidualTopUpWrapper(const py::sequence& states,
@@ -130,9 +106,9 @@ static PPRExtractResult extractTypedTopKWithResidualTopUpWrapper(const py::seque
     return result;
 }
 
-static py::dict extractOriginalEdgesFromPPRCachesWrapper(const py::sequence& states,
-                                                         const py::dict& selectedNodeIdsByNodeTypeId,
-                                                         bool includeEdgeIds) {
+static OriginalEdgeExtractResult extractOriginalEdgesFromPPRCachesWrapper(const py::sequence& states,
+                                                                          const py::dict& selectedNodeIdsByNodeTypeId,
+                                                                          bool includeEdgeIds) {
     std::vector<const PPRForwardPush*> statePtrs;
     statePtrs.reserve(py::len(states));
     for (py::handle stateObj : states) {
@@ -144,24 +120,15 @@ static py::dict extractOriginalEdgesFromPPRCachesWrapper(const py::sequence& sta
         selectedNodeTensorsByNodeTypeId[item.first.cast<int32_t>()] = item.second.cast<torch::Tensor>();
     }
 
+    // Pybind converts the returned map into dict[int, OriginalEdgeExtractTensors];
+    // the optional edge_ids field becomes None when absent. Tensor values are
+    // handles, so no storage is copied across the Python/C++ boundary.
     OriginalEdgeExtractResult result;
     {
         py::gil_scoped_release release;
         result = extractOriginalEdgesFromPPRCaches(statePtrs, selectedNodeTensorsByNodeTypeId, includeEdgeIds);
     }
-
-    // Building py::dict/py::tuple objects and pybind tensor wrappers touches the
-    // Python C API, so the GIL must be held after the C++ extraction completes.
-    py::dict pyResult;
-    for (const auto& [edgeTypeId, tensors] : result) {
-        py::object edgeIdsObject = py::none();
-        const auto edgeIdsTensor = tensors.edgeIds.value_or(torch::Tensor());
-        if (edgeIdsTensor.defined()) {
-            edgeIdsObject = py::cast(edgeIdsTensor);
-        }
-        pyResult[py::int_(edgeTypeId)] = py::make_tuple(tensors.rows, tensors.cols, edgeIdsObject);
-    }
-    return pyResult;
+    return result;
 }
 
 } // namespace gigl
@@ -169,6 +136,44 @@ static py::dict extractOriginalEdgesFromPPRCachesWrapper(const py::sequence& sta
 // TORCH_EXTENSION_NAME is set by PyTorch's build system to match the Python
 // module name derived from this file's path (e.g. "ppr_forward_push").
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    // Input databag: one edge type's fetched neighbor payload. Constructible from
+    // Python with edge_ids defaulting to None for callers that omit edge IDs.
+    py::class_<gigl::NeighborFetchTensors>(m, "NeighborFetchTensors")
+        .def(py::init([](torch::Tensor nodeIds,
+                         torch::Tensor flatNeighborIds,
+                         torch::Tensor counts,
+                         std::optional<torch::Tensor> edgeIds) {
+                 return gigl::NeighborFetchTensors{
+                     std::move(nodeIds), std::move(flatNeighborIds), std::move(counts), std::move(edgeIds)};
+             }),
+             py::arg("node_ids"),
+             py::arg("flat_neighbor_ids"),
+             py::arg("counts"),
+             py::arg("edge_ids") = py::none())
+        .def_readonly("node_ids", &gigl::NeighborFetchTensors::nodeIds)
+        .def_readonly("flat_neighbor_ids", &gigl::NeighborFetchTensors::flatNeighborIds)
+        .def_readonly("counts", &gigl::NeighborFetchTensors::counts)
+        .def_readonly("edge_ids", &gigl::NeighborFetchTensors::edgeIds);
+
+    // Output databag: one node type's PPR extraction output.
+    py::class_<gigl::PPRExtractTensors>(m, "PPRExtractTensors")
+        .def_readonly("ids", &gigl::PPRExtractTensors::ids)
+        .def_readonly("weights", &gigl::PPRExtractTensors::weights)
+        .def_readonly("valid_counts", &gigl::PPRExtractTensors::validCounts);
+
+    // Output databag: one edge type's original-edge extraction output.
+    py::class_<gigl::OriginalEdgeExtractTensors>(m, "OriginalEdgeExtractTensors")
+        .def_readonly("rows", &gigl::OriginalEdgeExtractTensors::rows)
+        .def_readonly("cols", &gigl::OriginalEdgeExtractTensors::cols)
+        .def_readonly("edge_ids", &gigl::OriginalEdgeExtractTensors::edgeIds);
+
+    // Output databag: batched typed-PPR channel drain result.
+    py::class_<gigl::TypedPPRQueueDrainResult>(m, "TypedPPRQueueDrainResult")
+        .def_readonly("drained_channel_indices", &gigl::TypedPPRQueueDrainResult::drainedChannelIndices)
+        .def_readonly("fetch_channel_indices", &gigl::TypedPPRQueueDrainResult::fetchChannelIndices)
+        .def_readonly("edge_type_ids_by_fetch_channel", &gigl::TypedPPRQueueDrainResult::edgeTypeIdsByFetchChannel)
+        .def_readonly("unioned_node_ids_by_edge_type_id", &gigl::TypedPPRQueueDrainResult::unionedNodeIdsByEdgeTypeId);
+
     py::class_<gigl::PPRForwardPush>(m, "PPRForwardPush")
         .def(py::init<torch::Tensor,
                       int32_t,

--- a/gigl-core/src/gigl_core/__init__.py
+++ b/gigl-core/src/gigl_core/__init__.py
@@ -1,12 +1,20 @@
 from gigl_core.ppr_forward_push import (
+    NeighborFetchTensors,
+    OriginalEdgeExtractTensors,
+    PPRExtractTensors,
     PPRForwardPush,
+    TypedPPRQueueDrainResult,
     drain_typed_ppr_channel_queues,
     extract_original_edges_from_ppr_caches,
     extract_typed_top_k_with_residual_top_up,
 )
 
 __all__ = [
+    "NeighborFetchTensors",
+    "OriginalEdgeExtractTensors",
+    "PPRExtractTensors",
     "PPRForwardPush",
+    "TypedPPRQueueDrainResult",
     "drain_typed_ppr_channel_queues",
     "extract_original_edges_from_ppr_caches",
     "extract_typed_top_k_with_residual_top_up",

--- a/gigl-core/src/gigl_core/ppr_forward_push.pyi
+++ b/gigl-core/src/gigl_core/ppr_forward_push.pyi
@@ -3,6 +3,20 @@ from typing import Sequence
 import torch
 
 class NeighborFetchTensors:
+    """One edge type's fetched neighbor payload passed from Python into ``push_residuals``.
+
+    At the call boundary these are collected into a ``dict`` keyed by integer edge type ID.
+
+    Attributes:
+        node_ids: int64 source node IDs, shape ``[N]``.
+        flat_neighbor_ids: int64 neighbor IDs concatenated across all source nodes,
+            shape ``[sum(counts)]``.
+        counts: int64 per-source-node neighbor count, shape ``[N]``; segments
+            ``flat_neighbor_ids`` back into per-node adjacency.
+        edge_ids: optional int64 edge IDs aligned with ``flat_neighbor_ids``. ``None``
+            when edge features are not requested.
+    """
+
     node_ids: torch.Tensor
     flat_neighbor_ids: torch.Tensor
     counts: torch.Tensor
@@ -16,22 +30,80 @@ class NeighborFetchTensors:
     ) -> None: ...
 
 class PPRExtractTensors:
+    """One node type's PPR extraction output.
+
+    Returned inside a ``dict`` keyed by integer node type ID from the extract functions.
+
+    Attributes:
+        ids: int64 selected node IDs, flattened across seeds.
+        weights: double feature matrix (``edge_attr``). For untyped PPR the columns are
+            ``[ppr_score, hop_proximity]``; for typed PPR they are
+            ``[best_score, hop_proximity, (channel_score, channel_hop_proximity, channel_presence), ...]``.
+            Hop proximity is ``1 / (1 + hop)`` (anchor ``1.0``, 1-hop ``0.5``, ...).
+        valid_counts: int64 count of selected nodes per seed.
+    """
+
     ids: torch.Tensor
     weights: torch.Tensor
     valid_counts: torch.Tensor
 
 class OriginalEdgeExtractTensors:
+    """One edge type's extracted original graph edges.
+
+    Returned inside a ``dict`` keyed by integer edge type ID.
+
+    Attributes:
+        rows: int64 source-side local node indices.
+        cols: int64 destination-side local node indices.
+        edge_ids: optional int64 edge IDs aligned with ``rows``/``cols``. ``None`` when
+            edge IDs were not requested.
+    """
+
     rows: torch.Tensor
     cols: torch.Tensor
     edge_ids: torch.Tensor | None
 
 class TypedPPRQueueDrainResult:
+    """Batched drain result for one typed-PPR iteration across channels.
+
+    Typed PPR keeps one ``PPRForwardPush`` state per channel. Each channel drains its own
+    queue, but Python issues at most one shared neighbor fetch per edge type. This result
+    carries both which channel states still need ``push_residuals`` and the unioned frontier
+    to fetch once for all channels that requested it.
+
+    Attributes:
+        drained_channel_indices: Channels whose ``drain_queue`` returned a value this
+            iteration; these need ``push_residuals`` even when no fetch budget remains.
+            Channel IDs are positional indices, appended in ascending order.
+        fetch_channel_indices: Subset of ``drained_channel_indices`` that still have fetch
+            budget and at least one non-empty uncached frontier.
+        edge_type_ids_by_fetch_channel: Edge types requested by each fetch channel, aligned
+            with ``fetch_channel_indices``.
+        unioned_node_ids_by_edge_type_id: Unioned node frontier for one shared distributed
+            neighbor fetch, keyed by integer edge type ID (edge-type scoped, not node-type
+            scoped). Tensor values are int64 source node IDs to fetch.
+    """
+
     drained_channel_indices: list[int]
     fetch_channel_indices: list[int]
     edge_type_ids_by_fetch_channel: list[list[int]]
     unioned_node_ids_by_edge_type_id: dict[int, torch.Tensor]
 
 class PPRForwardPush:
+    """C++ kernel for PPR Forward Push (Andersen et al., 2006).
+
+    Hot-loop PPR state lives in C++; distributed neighbor fetches are driven from Python.
+
+    The per-batch call sequence is::
+
+        state = PPRForwardPush(seed_nodes, ...)
+        while True:
+            frontier = state.drain_queue()          # nodes needing neighbor lookup
+            # <Python: fetch neighbors for `frontier`>
+            state.push_residuals(fetched_by_etype_id)
+        results = state.extract_top_k_with_residual_top_up(max_ppr_nodes, enable_residual_topup)
+    """
+
     def __init__(
         self,
         seed_nodes: torch.Tensor,
@@ -41,30 +113,138 @@ class PPRForwardPush:
         node_type_to_edge_type_ids: list[list[int]],
         edge_type_to_dst_ntype_id: list[int],
         degree_tensors: list[torch.Tensor],
-    ) -> None: ...
-    def drain_queue(self) -> dict[int, torch.Tensor] | None: ...
+    ) -> None:
+        """Initialize PPR state for one batch of seed nodes.
+
+        Args:
+            seed_nodes: int tensor of seed node IDs for this batch.
+            seed_node_type_id: Node type ID shared by all seeds.
+            alpha: PPR teleport probability.
+            requeue_threshold_factor: ``alpha * eps``; the per-node requeue threshold is
+                ``factor * degree``.
+            node_type_to_edge_type_ids: For each node type ID, the edge type IDs that
+                originate from that node type.
+            edge_type_to_dst_ntype_id: For each edge type ID, its destination node type ID.
+            degree_tensors: Per node type, an int32 tensor of total out-degrees indexed by
+                node ID.
+        """
+        ...
+
+    def drain_queue(self) -> dict[int, torch.Tensor] | None:
+        """Drain queued nodes needing a neighbor lookup.
+
+        Returns:
+            ``{edge_type_id: int64 node tensor}`` of nodes to look up, or ``None`` when the
+            queue is empty (convergence). An empty (non-``None``) map means every queued
+            node was a cache hit; call ``push_residuals({})`` to continue.
+        """
+        ...
+
     def push_residuals(
         self,
         fetched_by_etype_id: dict[int, NeighborFetchTensors],
-    ) -> None: ...
+    ) -> None:
+        """Push residual mass using freshly fetched neighbor data.
+
+        Args:
+            fetched_by_etype_id: Fetched neighbor payloads keyed by integer edge type ID.
+                Pass an empty map to continue on cache hits alone (see ``drain_queue``).
+        """
+        ...
+
     def extract_top_k_with_residual_top_up(
         self,
         max_ppr_nodes: int,
         enable_residual_topup: bool,
-    ) -> dict[int, PPRExtractTensors]: ...
+    ) -> dict[int, PPRExtractTensors]:
+        """Return top-k PPR nodes plus residual-mass top-up nodes, sorted by score.
+
+        Residual top-up issues no new neighbor fetches; it only reads the residual table
+        already built by Forward Push, letting callers fill short sequences with discovered
+        nodes that never crossed the requeue threshold. Top-up scores use the same mass
+        scale as PPR scores (``ppr_score(node) + residual(node)``). Residual candidates only
+        fill the requested top-up budget and never displace finalized-PPR nodes.
+
+        Args:
+            max_ppr_nodes: Final per-seed cap across finalized PPR and residual top-up
+                candidates.
+            enable_residual_topup: Whether residual candidates may fill remaining budget.
+
+        Returns:
+            Per-node-type ``PPRExtractTensors`` keyed by integer node type ID.
+        """
+        ...
 
 def drain_typed_ppr_channel_queues(
     states: Sequence[PPRForwardPush],
     fetch_iteration_counts: Sequence[int],
     max_fetch_iterations: int = -1,
-) -> TypedPPRQueueDrainResult: ...
+) -> TypedPPRQueueDrainResult:
+    """Drain several independent channel states for one typed-PPR iteration.
+
+    Typed wrapper around ``PPRForwardPush.drain_queue``: it drains each channel state,
+    records every channel that still needs ``push_residuals``, and unions fetchable frontier
+    nodes by edge type so Python can issue one shared distributed fetch for duplicate channel
+    requests. Channel drains may run concurrently; the result merge happens in channel order
+    so the returned channel-index lists are deterministic.
+
+    Args:
+        states: One ``PPRForwardPush`` per typed channel; each is mutated by its
+            ``drain_queue`` call.
+        fetch_iteration_counts: Number of distributed fetches already issued per channel,
+            aligned with ``states``.
+        max_fetch_iterations: ``-1`` means unbounded; otherwise channels at this count still
+            need ``push_residuals`` but contribute no new fetch frontier.
+
+    Returns:
+        A ``TypedPPRQueueDrainResult`` describing the channels to push and the shared fetch
+        request.
+    """
+    ...
+
 def extract_typed_top_k_with_residual_top_up(
     states: Sequence[PPRForwardPush],
     channel_target_counts: Sequence[int],
     enable_residual_topup: bool,
-) -> dict[int, PPRExtractTensors]: ...
+) -> dict[int, PPRExtractTensors]:
+    """Extract and merge completed typed-PPR channel states in one C++ step.
+
+    For each seed/node-type, one candidate view is built per channel (including residual
+    candidates when enabled). The merge selects by emitted PPR score, deduplicates nodes seen
+    through multiple channels by attributing each to the channel where it scores highest,
+    fills each channel target, redistributes unused slots globally by score, and emits
+    per-node-type tensors.
+
+    Args:
+        states: Completed ``PPRForwardPush`` states, one per typed channel.
+        channel_target_counts: Per-channel target output counts, aligned with ``states``;
+            their sum is the maximum number of deduplicated nodes returned per seed.
+        enable_residual_topup: Whether residual candidates may participate in target filling
+            alongside finalized PPR candidates.
+
+    Returns:
+        Per-node-type ``PPRExtractTensors`` keyed by integer node type ID, matching the
+        ``extract_top_k_with_residual_top_up`` contract.
+    """
+    ...
+
 def extract_original_edges_from_ppr_caches(
     states: Sequence[PPRForwardPush],
     selected_node_ids_by_node_type_id: dict[int, torch.Tensor],
     include_edge_ids: bool,
-) -> dict[int, OriginalEdgeExtractTensors]: ...
+) -> dict[int, OriginalEdgeExtractTensors]:
+    """Extract original graph edges from one or more completed PPR states.
+
+    Multiple states are used for typed PPR, where each channel owns its own cache. Duplicate
+    emitted edges shared by channels are emitted once.
+
+    Args:
+        states: Completed ``PPRForwardPush`` states whose neighbor caches supply the edges.
+        selected_node_ids_by_node_type_id: Selected node IDs keyed by integer node type ID;
+            only edges among these nodes are emitted.
+        include_edge_ids: Whether to populate ``OriginalEdgeExtractTensors.edge_ids``.
+
+    Returns:
+        Per-edge-type ``OriginalEdgeExtractTensors`` keyed by integer edge type ID.
+    """
+    ...

--- a/gigl-core/src/gigl_core/ppr_forward_push.pyi
+++ b/gigl-core/src/gigl_core/ppr_forward_push.pyi
@@ -2,6 +2,35 @@ from typing import Sequence
 
 import torch
 
+class NeighborFetchTensors:
+    node_ids: torch.Tensor
+    flat_neighbor_ids: torch.Tensor
+    counts: torch.Tensor
+    edge_ids: torch.Tensor | None
+    def __init__(
+        self,
+        node_ids: torch.Tensor,
+        flat_neighbor_ids: torch.Tensor,
+        counts: torch.Tensor,
+        edge_ids: torch.Tensor | None = None,
+    ) -> None: ...
+
+class PPRExtractTensors:
+    ids: torch.Tensor
+    weights: torch.Tensor
+    valid_counts: torch.Tensor
+
+class OriginalEdgeExtractTensors:
+    rows: torch.Tensor
+    cols: torch.Tensor
+    edge_ids: torch.Tensor | None
+
+class TypedPPRQueueDrainResult:
+    drained_channel_indices: list[int]
+    fetch_channel_indices: list[int]
+    edge_type_ids_by_fetch_channel: list[list[int]]
+    unioned_node_ids_by_edge_type_id: dict[int, torch.Tensor]
+
 class PPRForwardPush:
     def __init__(
         self,
@@ -16,30 +45,26 @@ class PPRForwardPush:
     def drain_queue(self) -> dict[int, torch.Tensor] | None: ...
     def push_residuals(
         self,
-        fetched_by_etype_id: dict[
-            int,
-            tuple[torch.Tensor, torch.Tensor, torch.Tensor]
-            | tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None],
-        ],
+        fetched_by_etype_id: dict[int, NeighborFetchTensors],
     ) -> None: ...
     def extract_top_k_with_residual_top_up(
         self,
         max_ppr_nodes: int,
         enable_residual_topup: bool,
-    ) -> dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: ...
+    ) -> dict[int, PPRExtractTensors]: ...
 
 def drain_typed_ppr_channel_queues(
     states: Sequence[PPRForwardPush],
     fetch_iteration_counts: Sequence[int],
     max_fetch_iterations: int = -1,
-) -> tuple[list[int], list[int], list[list[int]], dict[int, torch.Tensor]]: ...
+) -> TypedPPRQueueDrainResult: ...
 def extract_typed_top_k_with_residual_top_up(
     states: Sequence[PPRForwardPush],
     channel_target_counts: Sequence[int],
     enable_residual_topup: bool,
-) -> dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]]: ...
+) -> dict[int, PPRExtractTensors]: ...
 def extract_original_edges_from_ppr_caches(
     states: Sequence[PPRForwardPush],
     selected_node_ids_by_node_type_id: dict[int, torch.Tensor],
     include_edge_ids: bool,
-) -> dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]]: ...
+) -> dict[int, OriginalEdgeExtractTensors]: ...

--- a/gigl-core/tests/ppr_forward_push_test.cpp
+++ b/gigl-core/tests/ppr_forward_push_test.cpp
@@ -543,11 +543,11 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpLimitsResultsWithoutResidualTop
 
     auto topk1 = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/1, /*enableResidualTopUp=*/false);
     ASSERT_NE(topk1.find(0), topk1.end());
-    EXPECT_EQ(std::get<2>(topk1.at(0))[0].item<int64_t>(), 1);
+    EXPECT_EQ(topk1.at(0).validCounts[0].item<int64_t>(), 1);
 
     auto topk10 = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*enableResidualTopUp=*/false);
     ASSERT_NE(topk10.find(0), topk10.end());
-    EXPECT_EQ(std::get<2>(topk10.at(0))[0].item<int64_t>(), 2);
+    EXPECT_EQ(topk10.at(0).validCounts[0].item<int64_t>(), 2);
 }
 
 // Residual top-up includes discovered nodes whose residual never crossed the
@@ -562,8 +562,8 @@ TEST(PPRForwardPush, ExtractTopKWithResidualTopUpIncludesUnpushedResiduals) {
 
     auto topk = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/10, /*enableResidualTopUp=*/false);
     ASSERT_NE(topk.find(0), topk.end());
-    EXPECT_EQ(std::get<2>(topk.at(0))[0].item<int64_t>(), 1);
-    EXPECT_EQ(std::get<0>(topk.at(0))[0].item<int64_t>(), 0);
+    EXPECT_EQ(topk.at(0).validCounts[0].item<int64_t>(), 1);
+    EXPECT_EQ(topk.at(0).ids[0].item<int64_t>(), 0);
 
     auto topkWithResiduals = state.extractTopKWithResidualTopUp(/*maxPPRNodes=*/3, /*enableResidualTopUp=*/true);
     ASSERT_NE(topkWithResiduals.find(0), topkWithResiduals.end());

--- a/gigl/distributed/dist_ppr_sampler.py
+++ b/gigl/distributed/dist_ppr_sampler.py
@@ -8,6 +8,8 @@ import torch
 # TODO: Once gigl_core has a stable Python interface, re-export PPRForwardPush
 # under a gigl.core namespace rather than importing directly from the C++ extension.
 from gigl_core import (
+    NeighborFetchTensors,
+    PPRExtractTensors,
     PPRForwardPush,
     drain_typed_ppr_channel_queues,
     extract_original_edges_from_ppr_caches,
@@ -49,12 +51,6 @@ _PPR_HOMOGENEOUS_EDGE_TYPE = (
     DEFAULT_HOMOGENEOUS_NODE_TYPE,
 )
 
-# Python normalizes neighbor fetches to four items. The C++ binding also accepts
-# a three-item tuple from callers that omit edge IDs and treats it as None.
-PPRForwardPushFetchTensors = tuple[
-    torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor]
-]
-PPRForwardPushFetchMap = dict[int, PPRForwardPushFetchTensors]
 PPRTensorOutput = Union[torch.Tensor, dict[NodeType, torch.Tensor]]
 PPRCacheState = Optional[Union[PPRForwardPush, list[PPRForwardPush]]]
 
@@ -399,7 +395,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
     async def _batch_fetch_neighbors(
         self,
         nodes_by_edge_type_id: dict[int, torch.Tensor],
-    ) -> PPRForwardPushFetchMap:
+    ) -> dict[int, NeighborFetchTensors]:
         """Batch fetch neighbors for nodes grouped by integer edge type ID.
 
         Issues one one-hop request per edge type in the frontier. Each node's
@@ -453,11 +449,11 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
             )
         outputs: list[NeighborOutput] = await asyncio.gather(*sample_tasks)
         return {
-            edge_type_id: (
-                nodes_by_edge_type_id[edge_type_id],
-                output.nbr,
-                output.nbr_num,
-                output.edge if self._include_sampled_edges else None,
+            edge_type_id: NeighborFetchTensors(
+                node_ids=nodes_by_edge_type_id[edge_type_id],
+                flat_neighbor_ids=output.nbr,
+                counts=output.nbr_num,
+                edge_ids=output.edge if self._include_sampled_edges else None,
             )
             for edge_type_id, output in zip(edge_type_ids, outputs)
         }
@@ -512,7 +508,7 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
 
     def _translate_top_k_extraction_results(
         self,
-        extracted_results: dict[int, tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+        extracted_results: dict[int, PPRExtractTensors],
     ) -> tuple[
         dict[NodeType, torch.Tensor],
         dict[NodeType, torch.Tensor],
@@ -522,15 +518,11 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         node_type_to_flat_ids: dict[NodeType, torch.Tensor] = {}
         node_type_to_flat_weights: dict[NodeType, torch.Tensor] = {}
         node_type_to_valid_counts: dict[NodeType, torch.Tensor] = {}
-        for node_type_id, (
-            flat_ids,
-            flat_weights,
-            valid_counts,
-        ) in extracted_results.items():
+        for node_type_id, extracted in extracted_results.items():
             node_type = self._ntype_id_to_ntype[node_type_id]
-            node_type_to_flat_ids[node_type] = flat_ids
-            node_type_to_flat_weights[node_type] = flat_weights
-            node_type_to_valid_counts[node_type] = valid_counts
+            node_type_to_flat_ids[node_type] = extracted.ids
+            node_type_to_flat_weights[node_type] = extracted.weights
+            node_type_to_valid_counts[node_type] = extracted.valid_counts
         return (
             node_type_to_flat_ids,
             node_type_to_flat_weights,
@@ -736,23 +728,26 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         )
 
         while True:
-            (
-                drained_channel_indices,
-                fetch_channel_indices,
-                edge_type_ids_by_fetch_channel,
-                unioned_node_ids_by_edge_type_id,
-            ) = await loop.run_in_executor(
+            queue_drain_result = await loop.run_in_executor(
                 None,
                 drain_typed_ppr_channel_queues,
                 ppr_states,
                 fetch_iteration_counts,
                 max_fetch_iterations,
             )
+            drained_channel_indices = queue_drain_result.drained_channel_indices
+            fetch_channel_indices = queue_drain_result.fetch_channel_indices
+            edge_type_ids_by_fetch_channel = (
+                queue_drain_result.edge_type_ids_by_fetch_channel
+            )
+            unioned_node_ids_by_edge_type_id = (
+                queue_drain_result.unioned_node_ids_by_edge_type_id
+            )
             if not drained_channel_indices:
                 break
 
-            fetched_by_channel: list[PPRForwardPushFetchMap] = [
-                PPRForwardPushFetchMap() for _ in ppr_states
+            fetched_by_channel: list[dict[int, NeighborFetchTensors]] = [
+                {} for _ in ppr_states
             ]
 
             if unioned_node_ids_by_edge_type_id:
@@ -829,15 +824,15 @@ class DistPPRNeighborSampler(BaseDistNeighborSampler):
         rows_dict: dict[EdgeType, torch.Tensor] = {}
         cols_dict: dict[EdgeType, torch.Tensor] = {}
         edge_dict: dict[EdgeType, torch.Tensor] = {}
-        for edge_type_id, (rows, cols, edge_ids) in extracted_edges.items():
+        for edge_type_id, extracted in extracted_edges.items():
             edge_type = self._etype_id_to_etype[edge_type_id]
             output_edge_type = (
                 reverse_edge_type(edge_type) if self.edge_dir == "in" else edge_type
             )
-            rows_dict[output_edge_type] = rows
-            cols_dict[output_edge_type] = cols
-            if edge_ids is not None:
-                edge_dict[output_edge_type] = edge_ids
+            rows_dict[output_edge_type] = extracted.rows
+            cols_dict[output_edge_type] = extracted.cols
+            if extracted.edge_ids is not None:
+                edge_dict[output_edge_type] = extracted.edge_ids
 
         if not rows_dict:
             empty_edge_dict = {} if self.with_edge else None


### PR DESCRIPTION
Replace the load-bearing std::tuple/std::pair types in the PPR sampling path with named structs and expose the C++ result structs to Python as pybind11 databags (attribute access) instead of positional tuples.

- Header: NeighborFetchTensors and PPRExtractTensors become structs (map using-aliases kept); internal std::pair<int32_t,double> becomes an anonymous-namespace NodeScore, with comparators reading named fields.
- Bindings: bind NeighborFetchTensors (with edge_ids=None ctor), PPRExtractTensors, OriginalEdgeExtractTensors, and TypedPPRQueueDrainResult; wrappers return the structs/maps directly. GIL-release strategy is unchanged (convert under GIL, compute released).
- Python consumer: construct NeighborFetchTensors at the fetch site and use attribute access at the unpack sites; drop the mirror tuple aliases.
- Update the .pyi stub and gigl_core exports to match.

No behavior change; existing C++ and Python correctness tests pass.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
