### PR TITLE
Materialize graph transformer attribute-name lists

### DIFF
--- a/gigl/nn/graph_transformer.py
+++ b/gigl/nn/graph_transformer.py
@@ -1305,9 +1305,19 @@ class GraphTransformerEncoder(nn.Module):
                 "{'none', 'edge_type_linear', 'edge_type_attention'}, "
                 f"got '{relation_message_mode}'"
             )
-        anchor_bias_attr_names = anchor_based_attention_bias_attr_names or []
-        anchor_input_attr_names = anchor_based_input_attr_names or []
-        pairwise_bias_attr_names = pairwise_attention_bias_attr_names or []
+        # Config loaders may pass OmegaConf ListConfig objects, which TorchDynamo cannot
+        # trace. Plain lists iterate identically and keep the forward path traceable.
+        pe_attr_names = list(pe_attr_names or ())
+        anchor_based_attention_bias_attr_names = list(
+            anchor_based_attention_bias_attr_names or ()
+        )
+        anchor_based_input_attr_names = list(anchor_based_input_attr_names or ())
+        pairwise_attention_bias_attr_names = list(
+            pairwise_attention_bias_attr_names or ()
+        )
+        anchor_bias_attr_names = anchor_based_attention_bias_attr_names
+        anchor_input_attr_names = anchor_based_input_attr_names
+        pairwise_bias_attr_names = pairwise_attention_bias_attr_names
         if PPR_WEIGHT_FEATURE_NAME in pairwise_bias_attr_names:
             raise ValueError(
                 f"'{PPR_WEIGHT_FEATURE_NAME}' is an anchor-relative feature and "

--- a/tests/unit/nn/graph_transformer_test.py
+++ b/tests/unit/nn/graph_transformer_test.py
@@ -6,6 +6,7 @@ from typing import Callable, Literal, cast
 import torch
 import torch.nn as nn
 from absl.testing import absltest
+from omegaconf import ListConfig, OmegaConf
 from torch import Tensor
 from torch_geometric.data import HeteroData
 
@@ -967,6 +968,44 @@ class TestGraphTransformerEncoderPEModes(TestCase):
         self.assertEqual(attn_bias[0, 1, 0, 1].item(), 8.0)
         self.assertEqual(attn_bias[0, 0, 2, 2].item(), 27.0)
         self.assertEqual(attn_bias[0, 1, 2, 2].item(), 38.0)
+
+    def test_config_supplied_attr_names_become_plain_lists(self) -> None:
+        """Attribute-name sequences are stored as plain lists, never config containers.
+
+        TorchDynamo cannot trace OmegaConf containers, so none may reach the forward path.
+        Omitted names normalize to empty lists.
+        """
+        config = OmegaConf.create(
+            {
+                "pe_attr_names": ["random_walk_pe"],
+                "anchor_bias": ["hop_distance"],
+                "anchor_input": ["hop_distance"],
+                "pairwise_bias": ["pairwise_distance"],
+            }
+        )
+        self.assertIsInstance(config.pe_attr_names, ListConfig)
+
+        encoder = self._create_encoder(
+            pe_attr_names=config.pe_attr_names,
+            anchor_based_attention_bias_attr_names=config.anchor_bias,
+            anchor_based_input_attr_names=config.anchor_input,
+            pairwise_attention_bias_attr_names=config.pairwise_bias,
+        )
+
+        self.assertIs(type(encoder._pe_attr_names), list)
+        self.assertIs(type(encoder._anchor_based_attention_bias_attr_names), list)
+        self.assertIs(type(encoder._anchor_based_input_attr_names), list)
+        self.assertIs(type(encoder._pairwise_attention_bias_attr_names), list)
+        self.assertEqual(encoder._pe_attr_names, ["random_walk_pe"])
+        self.assertEqual(
+            encoder._pairwise_attention_bias_attr_names, ["pairwise_distance"]
+        )
+
+        default_encoder = self._create_encoder()
+        self.assertEqual(default_encoder._pe_attr_names, [])
+        self.assertEqual(default_encoder._anchor_based_attention_bias_attr_names, [])
+        self.assertEqual(default_encoder._anchor_based_input_attr_names, [])
+        self.assertEqual(default_encoder._pairwise_attention_bias_attr_names, [])
 
     def test_attention_bias_supports_anchor_relative_attrs_and_ppr_weights(
         self,


### PR DESCRIPTION
## What

`GraphTransformerEncoder.__init__` now materializes its four attribute-name parameters as plain Python lists: `pe_attr_names`, `anchor_based_attention_bias_attr_names`, `anchor_based_input_attr_names`, and `pairwise_attention_bias_attr_names`.

## Why

The encoder stores these parameters on the instance, and the forward path reads them from there. A configuration loader can supply OmegaConf `ListConfig` objects, which TorchDynamo cannot trace — so an encoder constructed from a config could not be compiled with `torch.compile`, even though nothing about the model itself prevents it.

Materializing at construction keeps config objects out of the forward path. Note that converting only the local `anchor_bias_attr_names` / `anchor_input_attr_names` / `pairwise_bias_attr_names` aliases would not fix this: those are used for validation, while it is the parameters themselves that are stored and later read.

## Behaviour

No functional change. Iteration semantics are identical, including the downstream list concatenation at the `ppr_weight` validation.

One normalization: omitted attribute names are now stored as `[]` rather than `None`. Every consumer already handled this — `self._pe_attr_names` and `self._pairwise_attention_bias_attr_names` are read via truthiness checks (1527, 1434), and the remaining reads apply an `or []` guard (1424, 1566, 1569, 1570). `heterodata_to_graph_transformer_input`, which receives three of them, applies the same `or []` to its own arguments. The redundant guards are left in place to keep the diff minimal.

## Testing

`make unit_test_py PY_TEST_FILES="graph_transformer_test.py"` — 99 tests pass. `ty` reports no diagnostics.

Adds `test_config_supplied_attr_names_become_plain_lists`, which builds the encoder from an OmegaConf config and asserts all four stored attributes are plain lists, plus the empty-default case. The existing tests pass plain lists, so they would not have caught a regression here.

Verified that the new test discriminates: constructing the pre-change encoder from the same config retains `ListConfig` in all four attributes, while the patched encoder stores a plain `list` in all four.
