### PR TITLE
Add host memory introspection utilities

### DIFF
--- a/gigl/utils/host_memory.py
+++ b/gigl/utils/host_memory.py
@@ -7,11 +7,11 @@ the smaller.
 
 Most callers want :func:`available_memory_bytes`. The public API:
 
-- :func:`available_memory_bytes` — bytes this process can still allocate; the number to budget against.
-- :func:`cgroup_limit_and_usage` — the binding cgroup ``(limit, current)`` in bytes, or None when unlimited.
-- :func:`cgroup_memory_breakdown` — current usage split by reclaimability (anon, shmem, file, dirty, writeback).
-- :func:`log_stage_memory` — log the memory position after a pipeline stage.
-- :func:`describe_memory` — one line covering both views, for logs where a budget is decided.
+- :func:`available_memory_bytes` -- bytes this process can still allocate; the number to budget against.
+- :func:`cgroup_limit_and_usage` -- the binding cgroup ``(limit, current)`` in bytes, or None when unlimited.
+- :func:`cgroup_memory_breakdown` -- current usage split by reclaimability (anon, shmem, file, dirty, writeback).
+- :func:`log_stage_memory` -- log the memory position after a pipeline stage.
+- :func:`describe_memory` -- one line covering both views, for logs where a budget is decided.
 
 Everything else in the module is the ``/proc`` and cgroup plumbing behind those five.
 """
@@ -58,12 +58,14 @@ def _cgroup_paths() -> list[str]:
     try:
         with open("/proc/self/cgroup") as handle:
             for line in handle:
+                # Each line is `hierarchy-id:controllers:path`. v2 lines are `0::<path>`; v1 lines
+                # name their controllers, and only the one carrying `memory` is relevant here:
+                #   0::/kubepods/burstable/pod1234/5678
+                #   9:memory:/docker/5678
                 fields = line.strip().split(":", 2)
                 if len(fields) != 3:
                     continue
                 hierarchy_id, controllers, path = fields
-                # v2 lines are `0::<path>`; v1 lines name their controllers, and only the one
-                # carrying `memory` is relevant here.
                 if hierarchy_id == "0" or "memory" in controllers.split(","):
                     paths.append(path or "/")
     except OSError:
@@ -246,9 +248,11 @@ def log_stage_memory(stage: str) -> None:
         parts.append("cgroup=unlimited")
     else:
         limit, current = limits
+        # A cgroup can report a limit of 0; skip the percentage rather than divide by it.
+        percent = f"({100.0 * current / limit:.0f}%) " if limit else ""
         parts.append(
             f"cgroup {current / 2**30:.1f}/{limit / 2**30:.1f} GiB "
-            f"({100.0 * current / limit:.0f}%) headroom {(limit - current) / 2**30:.1f} GiB"
+            f"{percent}headroom {(limit - current) / 2**30:.1f} GiB"
         )
     breakdown = cgroup_memory_breakdown()
     if breakdown:

--- a/gigl/utils/host_memory.py
+++ b/gigl/utils/host_memory.py
@@ -1,0 +1,293 @@
+"""How much host memory this process may still allocate.
+
+``psutil.virtual_memory().available`` reads ``/proc/meminfo``, which inside a container reports the
+HOST's memory rather than the container's limit, so a budget check trusting it alone can pass
+immediately before the container is killed. The cgroup knows the real limit; read both and believe
+the smaller.
+"""
+
+import os
+from typing import Optional
+
+import psutil
+
+from gigl.common.logger import Logger
+
+logger = Logger()
+
+# cgroup v1 spells "unlimited" as a sentinel near the top of the int64/page range rather than with a
+# word, so anything at or above this is treated as no limit.
+_CGROUP_V1_UNLIMITED_THRESHOLD = 1 << 62
+
+
+def _read_int(path: str) -> Optional[int]:
+    try:
+        with open(path) as handle:
+            text = handle.read().strip()
+    except OSError:
+        return None
+    if text == "max":
+        return None
+    try:
+        value = int(text)
+    except ValueError:
+        return None
+    return None if value >= _CGROUP_V1_UNLIMITED_THRESHOLD else value
+
+
+def _cgroup_paths() -> list[str]:
+    """This process's cgroup path per controller, from ``/proc/self/cgroup``.
+
+    Reading ``/sys/fs/cgroup/memory.max`` directly is wrong: that is the hierarchy root, which has no
+    limit, while the process lives below it.
+
+    Returns the paths to try, most specific first, each expanded up its ancestors, ending at the
+    root.
+    """
+    paths: list[str] = []
+    try:
+        with open("/proc/self/cgroup") as handle:
+            for line in handle:
+                fields = line.strip().split(":", 2)
+                if len(fields) != 3:
+                    continue
+                hierarchy_id, controllers, path = fields
+                # v2 lines are `0::<path>`; v1 lines name their controllers, and only the one
+                # carrying `memory` is relevant here.
+                if hierarchy_id == "0" or "memory" in controllers.split(","):
+                    paths.append(path or "/")
+    except OSError:
+        pass
+    paths.append("/")
+    # A container may be limited at an ancestor rather than at its own leaf, so walk upward.
+    expanded: list[str] = []
+    for path in paths:
+        parts = [part for part in path.split("/") if part]
+        while True:
+            candidate = "/" + "/".join(parts)
+            if candidate not in expanded:
+                expanded.append(candidate)
+            if not parts:
+                break
+            parts.pop()
+    return expanded
+
+
+def _cgroup_mounts() -> list[tuple[str, str, str]]:
+    """``(mount root, mount point, type)`` for every cgroup mount, from ``/proc/self/mountinfo``.
+
+    The mount root is not always ``/``: a container often bind-mounts its own subtree, so the path
+    from ``/proc/self/cgroup`` is relative to that root and joining the two naively yields a
+    directory that does not exist.
+    """
+    mounts: list[tuple[str, str, str]] = []
+    try:
+        with open("/proc/self/mountinfo") as handle:
+            for line in handle:
+                fields = line.split(" - ")
+                if len(fields) != 2:
+                    continue
+                before = fields[0].split()
+                if len(before) < 5:
+                    continue
+                mount_root, mount_point = before[3], before[4]
+                filesystem = fields[1].split()[0]
+                if filesystem in ("cgroup2", "cgroup"):
+                    mounts.append((mount_root, mount_point, filesystem))
+    except OSError:
+        pass
+    if not mounts:
+        mounts = [("/", "/sys/fs/cgroup", "cgroup2")]
+    return mounts
+
+
+def _relative_to_mount_root(path: str, mount_root: str) -> Optional[str]:
+    """Translate a cgroup path into one relative to ``mount_root``, or None if it is outside it."""
+    if mount_root in ("", "/"):
+        return path
+    if path == mount_root:
+        return "/"
+    if path.startswith(mount_root.rstrip("/") + "/"):
+        return path[len(mount_root.rstrip("/")) :]
+    return None
+
+
+def _tightest_cgroup() -> Optional[tuple[int, int, str, str]]:
+    """``(limit, current, directory, filesystem)`` for the cgroup with the least headroom.
+
+    ``None`` when no limit can be read, the normal case on an unconstrained host.
+
+    The directory is returned so ``memory.stat`` can be read from the same cgroup as the limit;
+    mixing levels yields a breakdown that does not add up to the usage. The filesystem is returned
+    because a v1 ancestor's ``memory.usage_in_bytes`` includes descendants while its bare
+    ``rss``/``cache``/``dirty`` fields do not -- the hierarchical figures live under ``total_*``.
+    """
+    mounts = _cgroup_mounts()
+    tightest: Optional[tuple[int, int, str, str]] = None
+    for path in _cgroup_paths():
+        for mount_root, mount_point, filesystem in mounts:
+            relative = _relative_to_mount_root(path, mount_root)
+            if relative is None:
+                continue
+            base = f"{mount_point}{relative}".rstrip("/") or mount_point
+            if filesystem == "cgroup2":
+                candidates = [(f"{base}/memory.max", f"{base}/memory.current", base)]
+            else:
+                # v1 puts each controller in its own directory under the mount point.
+                controller_base = f"{mount_point}/memory{relative}".replace("//", "/")
+                candidates = [
+                    (
+                        f"{controller_base}/memory.limit_in_bytes",
+                        f"{controller_base}/memory.usage_in_bytes",
+                        controller_base,
+                    ),
+                    (
+                        f"{base}/memory.limit_in_bytes",
+                        f"{base}/memory.usage_in_bytes",
+                        base,
+                    ),
+                ]
+            for max_path, current_path, directory in candidates:
+                limit = _read_int(max_path)
+                if limit is None:
+                    continue
+                current = _read_int(current_path)
+                if current is None:
+                    continue
+                if tightest is None or (limit - current) < (tightest[0] - tightest[1]):
+                    tightest = (limit, current, directory, filesystem)
+                break
+    return tightest
+
+
+def cgroup_limit_and_usage() -> Optional[tuple[int, int]]:
+    """The tightest ``(limit, current)`` in bytes over every cgroup constraining this process.
+
+    Every ancestor constrains the process, so the first finite limit found walking upward is not
+    necessarily the binding one: a leaf with 63 GiB of headroom under a parent with 1 GiB is really
+    limited to 1 GiB. All applicable levels are read and the least headroom wins.
+
+    Returns None when no limit can be read.
+    """
+    tightest = _tightest_cgroup()
+    return None if tightest is None else (tightest[0], tightest[1])
+
+
+# v2 name -> v1 name. Only the fields that decide whether a peak is survivable are read. The v1
+# hierarchical `total_*` variants are preferred, because `_tightest_cgroup` can select an ancestor
+# whose usage includes descendants that its bare fields exclude. v2's memory.stat is already
+# hierarchical.
+_BREAKDOWN_FIELDS = {
+    "anon": "rss",
+    "file": "cache",
+    "shmem": "shmem",
+    "file_dirty": "dirty",
+    "file_writeback": "writeback",
+}
+
+
+def cgroup_memory_breakdown() -> dict[str, int]:
+    """``memory.stat`` split into the categories that behave differently under pressure.
+
+    ``memory.current`` alone cannot say whether a peak is survivable: ``file_dirty`` bytes are
+    reclaimable once written back, so the kernel throttles the writer, while the same fraction held
+    as ``anon`` is fatal.
+
+    Returns an empty dict when no cgroup or no ``memory.stat`` can be read.
+    """
+    tightest = _tightest_cgroup()
+    if tightest is None:
+        return {}
+    try:
+        with open(f"{tightest[2]}/memory.stat") as handle:
+            raw = dict(
+                (fields[0], int(fields[1]))
+                for fields in (line.split() for line in handle)
+                if len(fields) == 2 and fields[1].isdigit()
+            )
+    except OSError:
+        return {}
+    filesystem = tightest[3]
+    breakdown: dict[str, int] = {}
+    for v2_name, v1_name in _BREAKDOWN_FIELDS.items():
+        if filesystem == "cgroup2":
+            if v2_name in raw:
+                breakdown[v2_name] = raw[v2_name]
+            continue
+        # v1: the hierarchical figure first, because the usage beside it is hierarchical too.
+        if f"total_{v1_name}" in raw:
+            breakdown[v2_name] = raw[f"total_{v1_name}"]
+        elif v1_name in raw:
+            breakdown[v2_name] = raw[v1_name]
+    return breakdown
+
+
+def log_stage_memory(stage: str) -> None:
+    """Log the memory position after a pipeline stage, split by reclaimability.
+
+    Reads three small proc files, so call it at phase boundaries rather than in loops.
+
+    Args:
+        stage: What just finished, e.g. ``"assembled node features"``.
+    """
+    parts = [f"[mem] after {stage}:"]
+    limits = cgroup_limit_and_usage()
+    if limits is None:
+        parts.append("cgroup=unlimited")
+    else:
+        limit, current = limits
+        parts.append(
+            f"cgroup {current / 2**30:.1f}/{limit / 2**30:.1f} GiB "
+            f"({100.0 * current / limit:.0f}%) headroom {(limit - current) / 2**30:.1f} GiB"
+        )
+    breakdown = cgroup_memory_breakdown()
+    if breakdown:
+        # anon is the number that kills; dirty is the number that merely slows things down.
+        parts.append(
+            "| anon {:.1f} shmem {:.1f} file {:.1f} (dirty {:.1f}, writeback {:.1f}) GiB".format(
+                breakdown.get("anon", 0) / 2**30,
+                breakdown.get("shmem", 0) / 2**30,
+                breakdown.get("file", 0) / 2**30,
+                breakdown.get("file_dirty", 0) / 2**30,
+                breakdown.get("file_writeback", 0) / 2**30,
+            )
+        )
+    parts.append(
+        f"| rss {psutil.Process(os.getpid()).memory_info().rss / 2**30:.1f} GiB"
+    )
+    logger.info(" ".join(parts))
+
+
+def available_memory_bytes() -> int:
+    """Bytes this process can still allocate, as the minimum of OS-free and cgroup-remaining.
+
+    Both are needed: the OS figure misses a container limit below the machine's RAM, and the cgroup
+    figure misses pressure from other processes on a shared host.
+    """
+    available = int(psutil.virtual_memory().available)
+    limits = cgroup_limit_and_usage()
+    if limits is None:
+        return available
+    limit, current = limits
+    return min(available, max(limit - current, 0))
+
+
+def describe_memory() -> str:
+    """One line covering both views, for logging where a budget is being decided."""
+    virtual = psutil.virtual_memory()
+    parts = [
+        f"meminfo total={virtual.total / 2**30:.1f} GiB "
+        f"available={virtual.available / 2**30:.1f} GiB",
+        f"rss={psutil.Process(os.getpid()).memory_info().rss / 2**30:.1f} GiB",
+    ]
+    limits = cgroup_limit_and_usage()
+    if limits is None:
+        parts.append("cgroup=unlimited")
+    else:
+        limit, current = limits
+        parts.append(
+            f"cgroup limit={limit / 2**30:.1f} GiB current={current / 2**30:.1f} GiB "
+            f"headroom={(limit - current) / 2**30:.1f} GiB"
+        )
+    parts.append(f"effective available={available_memory_bytes() / 2**30:.1f} GiB")
+    return " | ".join(parts)

--- a/gigl/utils/host_memory.py
+++ b/gigl/utils/host_memory.py
@@ -4,6 +4,16 @@
 HOST's memory rather than the container's limit, so a budget check trusting it alone can pass
 immediately before the container is killed. The cgroup knows the real limit; read both and believe
 the smaller.
+
+Most callers want :func:`available_memory_bytes`. The public API:
+
+- :func:`available_memory_bytes` — bytes this process can still allocate; the number to budget against.
+- :func:`cgroup_limit_and_usage` — the binding cgroup ``(limit, current)`` in bytes, or None when unlimited.
+- :func:`cgroup_memory_breakdown` — current usage split by reclaimability (anon, shmem, file, dirty, writeback).
+- :func:`log_stage_memory` — log the memory position after a pipeline stage.
+- :func:`describe_memory` — one line covering both views, for logs where a budget is decided.
+
+Everything else in the module is the ``/proc`` and cgroup plumbing behind those five.
 """
 
 import os

--- a/tests/unit/utils/host_memory_test.py
+++ b/tests/unit/utils/host_memory_test.py
@@ -12,12 +12,8 @@ from tests.test_assets.test_case import TestCase
 _GIB = 2**30
 
 
-class CgroupResolutionTest(TestCase):
-    """The limit must be read from the process's own cgroup, not the hierarchy root.
-
-    Reading ``/sys/fs/cgroup/memory.max`` directly reports "unlimited", or nothing, and falls back to
-    host memory.
-    """
+class _CgroupFixtureTestCase(TestCase):
+    """Fake cgroup tree helpers shared by the test classes below; holds no test methods itself."""
 
     def setUp(self) -> None:
         self._root = tempfile.TemporaryDirectory()
@@ -47,6 +43,14 @@ class CgroupResolutionTest(TestCase):
                 return_value=[(mount_root, str(self.root), filesystem)],
             ),
         )
+
+
+class CgroupResolutionTest(_CgroupFixtureTestCase):
+    """The limit must be read from the process's own cgroup, not the hierarchy root.
+
+    Reading ``/sys/fs/cgroup/memory.max`` directly reports "unlimited", or nothing, and falls back to
+    host memory.
+    """
 
     def test_reads_the_limit_from_a_nested_v2_cgroup(self):
         self._write_v2(
@@ -236,7 +240,7 @@ class AvailableMemoryTest(TestCase):
         self.assertLessEqual(available, host_memory.psutil.virtual_memory().total)
 
 
-class MemoryBreakdownTest(CgroupResolutionTest):
+class MemoryBreakdownTest(_CgroupFixtureTestCase):
     """``memory.current`` alone cannot say whether a peak is survivable.
 
     A process near its limit lives when the bytes are dirty page cache and dies when they are
@@ -362,6 +366,18 @@ class MemoryBreakdownTest(CgroupResolutionTest):
         self.assertIn("90.0/100.0 GiB (90%)", line)
         self.assertIn("anon 10.0", line)
         self.assertIn("dirty 60.0", line)
+
+    def test_log_stage_memory_survives_a_zero_limit(self):
+        """A cgroup can report a limit of 0; the log line must skip the percentage, not divide."""
+        self._write_v2("/leaf", limit="0", current=str(1 * _GIB))
+        paths, mounts = self._patch("/leaf")
+
+        with paths, mounts, mock.patch.object(host_memory.logger, "info") as info:
+            host_memory.log_stage_memory("assembled features")
+
+        line = info.call_args[0][0]
+        self.assertIn("1.0/0.0 GiB", line)
+        self.assertNotIn("%", line)
 
     def test_log_stage_memory_says_so_when_there_is_no_limit(self):
         paths, mounts = self._patch("/absent")

--- a/tests/unit/utils/host_memory_test.py
+++ b/tests/unit/utils/host_memory_test.py
@@ -1,0 +1,388 @@
+import tempfile
+from pathlib import Path
+from typing import Optional
+from unittest import mock
+
+from absl.testing import absltest
+from parameterized import param, parameterized
+
+from gigl.utils import host_memory
+from tests.test_assets.test_case import TestCase
+
+_GIB = 2**30
+
+
+class CgroupResolutionTest(TestCase):
+    """The limit must be read from the process's own cgroup, not the hierarchy root.
+
+    Reading ``/sys/fs/cgroup/memory.max`` directly reports "unlimited", or nothing, and falls back to
+    host memory.
+    """
+
+    def setUp(self) -> None:
+        self._root = tempfile.TemporaryDirectory()
+        self.addCleanup(self._root.cleanup)
+        self.root = Path(self._root.name)
+
+    def _write_v2(self, relative: str, limit: Optional[str], current: str) -> None:
+        directory = self.root / relative.strip("/")
+        directory.mkdir(parents=True, exist_ok=True)
+        if limit is not None:
+            (directory / "memory.max").write_text(f"{limit}\n")
+        (directory / "memory.current").write_text(f"{current}\n")
+
+    def _patch(
+        self,
+        cgroup_path: str,
+        filesystem: str = "cgroup2",
+        mount_root: str = "/",
+    ):
+        return (
+            mock.patch.object(
+                host_memory, "_cgroup_paths", return_value=_expand(cgroup_path)
+            ),
+            mock.patch.object(
+                host_memory,
+                "_cgroup_mounts",
+                return_value=[(mount_root, str(self.root), filesystem)],
+            ),
+        )
+
+    def test_reads_the_limit_from_a_nested_v2_cgroup(self):
+        self._write_v2(
+            "/kubepods/pod123/container", limit=str(64 * _GIB), current=str(10 * _GIB)
+        )
+        paths, mounts = self._patch("/kubepods/pod123/container")
+
+        with paths, mounts:
+            result = host_memory.cgroup_limit_and_usage()
+
+        self.assertEqual(result, (64 * _GIB, 10 * _GIB))
+
+    def test_walks_up_to_a_limit_set_on_an_ancestor(self):
+        """A container is often limited at the pod, not at its own leaf."""
+        self._write_v2("/kubepods/pod123", limit=str(32 * _GIB), current=str(4 * _GIB))
+        self._write_v2("/kubepods/pod123/container", limit=None, current=str(1 * _GIB))
+        paths, mounts = self._patch("/kubepods/pod123/container")
+
+        with paths, mounts:
+            result = host_memory.cgroup_limit_and_usage()
+
+        self.assertEqual(result, (32 * _GIB, 4 * _GIB))
+
+    @parameterized.expand(
+        [
+            param("v2 literal max", limit="max"),
+            # cgroup v1 spells unlimited as a huge sentinel rather than a word.
+            param("v1 sentinel", limit=str(1 << 63)),
+        ]
+    )
+    def test_unlimited_reads_as_no_limit(self, _, limit: str):
+        self._write_v2("/leaf", limit=limit, current=str(1 * _GIB))
+        paths, mounts = self._patch("/leaf")
+
+        with paths, mounts:
+            self.assertIsNone(host_memory.cgroup_limit_and_usage())
+
+    def test_missing_files_read_as_no_limit(self):
+        paths, mounts = self._patch("/absent")
+
+        with paths, mounts:
+            self.assertIsNone(host_memory.cgroup_limit_and_usage())
+
+    def test_reads_a_v1_controller_directory(self):
+        directory = self.root / "memory" / "some" / "scope"
+        directory.mkdir(parents=True)
+        (directory / "memory.limit_in_bytes").write_text(f"{16 * _GIB}\n")
+        (directory / "memory.usage_in_bytes").write_text(f"{3 * _GIB}\n")
+        paths, mounts = self._patch("/some/scope", filesystem="cgroup")
+
+        with paths, mounts:
+            result = host_memory.cgroup_limit_and_usage()
+
+        self.assertEqual(result, (16 * _GIB, 3 * _GIB))
+
+    def test_the_tightest_ancestor_wins_not_the_first_found(self):
+        """A leaf with room under a parent without it is limited by the parent, so returning the
+        first finite limit found while walking up would report headroom that does not exist."""
+        self._write_v2("/pod", limit=str(8 * _GIB), current=str(7 * _GIB))  # 1 GiB left
+        self._write_v2(
+            "/pod/container", limit=str(64 * _GIB), current=str(1 * _GIB)
+        )  # 63 GiB left
+        paths, mounts = self._patch("/pod/container")
+
+        with paths, mounts:
+            result = host_memory.cgroup_limit_and_usage()
+
+        assert result is not None
+        limit, current = result
+        self.assertEqual((limit, current), (8 * _GIB, 7 * _GIB))
+        self.assertEqual(limit - current, 1 * _GIB)
+
+    def test_a_mount_rooted_below_the_hierarchy_root_is_translated(self):
+        """A container often bind-mounts its own subtree, so the cgroup path is relative to
+        mountinfo's root; joining it to the mount point untranslated finds no directory."""
+        self._write_v2("/leaf", limit=str(4 * _GIB), current=str(1 * _GIB))
+        paths, mounts = self._patch(
+            "/kubepods/pod123/leaf", mount_root="/kubepods/pod123"
+        )
+
+        with paths, mounts:
+            result = host_memory.cgroup_limit_and_usage()
+
+        self.assertEqual(result, (4 * _GIB, 1 * _GIB))
+
+    def test_a_path_outside_the_mount_root_is_skipped(self):
+        self._write_v2("/leaf", limit=str(4 * _GIB), current=str(1 * _GIB))
+        paths, mounts = self._patch("/elsewhere/leaf", mount_root="/kubepods")
+
+        with paths, mounts:
+            self.assertIsNone(host_memory.cgroup_limit_and_usage())
+
+    @parameterized.expand(
+        [
+            param("root", path="/", mount_root="/", expected="/"),
+            param("plain", path="/a/b", mount_root="/", expected="/a/b"),
+            param("exact match", path="/a/b", mount_root="/a/b", expected="/"),
+            param("below root", path="/a/b/c", mount_root="/a/b", expected="/c"),
+            param("outside root", path="/x/y", mount_root="/a", expected=None),
+            # A prefix that is not a path component must not match.
+            param(
+                "prefix but not component", path="/ab/c", mount_root="/a", expected=None
+            ),
+        ]
+    )
+    def test_relative_to_mount_root(
+        self, _, path: str, mount_root: str, expected: Optional[str]
+    ):
+        self.assertEqual(
+            host_memory._relative_to_mount_root(path, mount_root), expected
+        )
+
+    def test_cgroup_paths_come_from_proc_and_end_at_the_root(self):
+        with mock.patch(
+            "builtins.open",
+            mock.mock_open(read_data="0::/kubepods/pod123/container\n"),
+        ):
+            paths = host_memory._cgroup_paths()
+
+        self.assertEqual(paths[0], "/kubepods/pod123/container")
+        self.assertEqual(paths[-1], "/")
+
+
+class AvailableMemoryTest(TestCase):
+    def test_cgroup_headroom_wins_when_it_is_the_tighter_limit(self):
+        """The point of the whole module: meminfo inside a container reports the HOST."""
+        with (
+            mock.patch.object(
+                host_memory.psutil,
+                "virtual_memory",
+                return_value=mock.Mock(available=200 * _GIB, total=256 * _GIB),
+            ),
+            mock.patch.object(
+                host_memory,
+                "cgroup_limit_and_usage",
+                return_value=(64 * _GIB, 60 * _GIB),
+            ),
+        ):
+            self.assertEqual(host_memory.available_memory_bytes(), 4 * _GIB)
+
+    def test_os_availability_wins_when_the_host_is_under_pressure(self):
+        with (
+            mock.patch.object(
+                host_memory.psutil,
+                "virtual_memory",
+                return_value=mock.Mock(available=2 * _GIB, total=256 * _GIB),
+            ),
+            mock.patch.object(
+                host_memory,
+                "cgroup_limit_and_usage",
+                return_value=(64 * _GIB, 10 * _GIB),
+            ),
+        ):
+            self.assertEqual(host_memory.available_memory_bytes(), 2 * _GIB)
+
+    def test_a_cgroup_over_its_limit_reports_no_headroom_rather_than_negative(self):
+        with (
+            mock.patch.object(
+                host_memory.psutil,
+                "virtual_memory",
+                return_value=mock.Mock(available=100 * _GIB, total=256 * _GIB),
+            ),
+            mock.patch.object(
+                host_memory,
+                "cgroup_limit_and_usage",
+                return_value=(64 * _GIB, 70 * _GIB),
+            ),
+        ):
+            self.assertEqual(host_memory.available_memory_bytes(), 0)
+
+    def test_describe_memory_names_both_views(self):
+        text = host_memory.describe_memory()
+
+        self.assertIn("meminfo", text)
+        self.assertIn("cgroup", text)
+        self.assertIn("effective available", text)
+
+    def test_available_memory_is_within_bounds_on_this_host(self):
+        """No mocks: on any host the answer must fall between zero and total memory.
+
+        Zero is a legitimate answer for a cgroup at its limit, and the upper bound is TOTAL rather
+        than a second reading of AVAILABLE, which moves between calls.
+        """
+        available = host_memory.available_memory_bytes()
+
+        self.assertGreaterEqual(available, 0)
+        self.assertLessEqual(available, host_memory.psutil.virtual_memory().total)
+
+
+class MemoryBreakdownTest(CgroupResolutionTest):
+    """``memory.current`` alone cannot say whether a peak is survivable.
+
+    A process near its limit lives when the bytes are dirty page cache and dies when they are
+    anonymous, and the two are indistinguishable on a usage graph.
+    """
+
+    def _write_stat(self, relative: str, lines: str) -> None:
+        directory = self.root / relative.strip("/")
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "memory.stat").write_text(lines)
+
+    def test_reads_the_v2_field_names(self):
+        self._write_v2("/leaf", limit=str(100 * _GIB), current=str(90 * _GIB))
+        self._write_stat(
+            "/leaf",
+            "anon 48318382080\nfile 45097156608\nshmem 1073741824\n"
+            "file_dirty 32212254720\nfile_writeback 1073741824\nslab 12345\n",
+        )
+        paths, mounts = self._patch("/leaf")
+
+        with paths, mounts:
+            breakdown = host_memory.cgroup_memory_breakdown()
+
+        self.assertEqual(breakdown["anon"], 45 * _GIB)
+        self.assertEqual(breakdown["file_dirty"], 30 * _GIB)
+        self.assertEqual(breakdown["shmem"], _GIB)
+        self.assertNotIn("slab", breakdown, "only the load-bearing fields are reported")
+
+    def _write_v1(self, relative: str, limit: int, usage: int, stat: str) -> None:
+        """A v1 memory-controller directory, the way `_tightest_cgroup` resolves one."""
+        directory = self.root / "memory" / relative.strip("/")
+        directory.mkdir(parents=True, exist_ok=True)
+        (directory / "memory.limit_in_bytes").write_text(f"{limit}\n")
+        (directory / "memory.usage_in_bytes").write_text(f"{usage}\n")
+        (directory / "memory.stat").write_text(stat)
+
+    def test_v1_prefers_hierarchical_totals_over_local_fields(self):
+        """A v1 ancestor's usage includes descendants while its bare rss/cache do not, so the
+        breakdown must use total_*. The local and total_* values here disagree deliberately."""
+        self._write_v1(
+            "/pod",
+            limit=100 * _GIB,
+            usage=90 * _GIB,
+            stat=(
+                f"rss {2 * _GIB}\ncache {1 * _GIB}\ndirty {_GIB // 4}\n"
+                f"total_rss {80 * _GIB}\ntotal_cache {10 * _GIB}\ntotal_dirty {5 * _GIB}\n"
+            ),
+        )
+        paths, mounts = self._patch("/pod", filesystem="cgroup")
+
+        with paths, mounts:
+            breakdown = host_memory.cgroup_memory_breakdown()
+
+        self.assertEqual(breakdown["anon"], 80 * _GIB, "must be total_rss, not rss")
+        self.assertEqual(breakdown["file"], 10 * _GIB)
+        self.assertEqual(breakdown["file_dirty"], 5 * _GIB)
+
+    def test_v1_falls_back_to_local_fields_when_totals_are_absent(self):
+        self._write_v1(
+            "/leaf",
+            limit=100 * _GIB,
+            usage=10 * _GIB,
+            stat=f"rss {8 * _GIB}\ncache {1 * _GIB}\ndirty {_GIB // 2}\n",
+        )
+        paths, mounts = self._patch("/leaf", filesystem="cgroup")
+
+        with paths, mounts:
+            breakdown = host_memory.cgroup_memory_breakdown()
+
+        self.assertEqual(breakdown["anon"], 8 * _GIB)
+        self.assertEqual(breakdown["file"], _GIB)
+        self.assertEqual(breakdown["file_dirty"], _GIB // 2)
+
+    def test_v2_ignores_v1_field_names(self):
+        """A v2 stat carrying stray v1-style names must not be misread as hierarchical."""
+        self._write_v2("/leaf", limit=str(100 * _GIB), current=str(10 * _GIB))
+        self._write_stat("/leaf", f"anon {6 * _GIB}\nrss {1 * _GIB}\n")
+        paths, mounts = self._patch("/leaf")
+
+        with paths, mounts:
+            breakdown = host_memory.cgroup_memory_breakdown()
+
+        self.assertEqual(breakdown["anon"], 6 * _GIB)
+
+    def test_the_breakdown_comes_from_the_cgroup_the_limit_came_from(self):
+        """A breakdown from a different level would not add up to the reported usage."""
+        # The leaf has the loose limit; the ancestor is the binding one, and they disagree.
+        self._write_v2("/pod/leaf", limit=str(100 * _GIB), current=str(1 * _GIB))
+        self._write_stat("/pod/leaf", "anon 1073741824\n")
+        self._write_v2("/pod", limit=str(50 * _GIB), current=str(49 * _GIB))
+        self._write_stat("/pod", "anon 52613349376\n")
+        paths, mounts = self._patch("/pod/leaf")
+
+        with paths, mounts:
+            breakdown = host_memory.cgroup_memory_breakdown()
+
+        self.assertEqual(
+            breakdown["anon"],
+            49 * _GIB,
+            "should read /pod's stat -- the BINDING cgroup, the one the limit came from -- not the "
+            "leaf's, whose 1 GiB would understate the position by 48 GiB",
+        )
+
+    def test_no_stat_file_reads_as_no_breakdown(self):
+        self._write_v2("/leaf", limit=str(100 * _GIB), current=str(10 * _GIB))
+        paths, mounts = self._patch("/leaf")
+
+        with paths, mounts:
+            self.assertEqual(host_memory.cgroup_memory_breakdown(), {})
+
+    def test_log_stage_memory_names_the_stage_and_both_categories(self):
+        self._write_v2("/leaf", limit=str(100 * _GIB), current=str(90 * _GIB))
+        self._write_stat(
+            "/leaf", "anon 10737418240\nfile 85899345920\nfile_dirty 64424509440\n"
+        )
+        paths, mounts = self._patch("/leaf")
+
+        with paths, mounts, mock.patch.object(host_memory.logger, "info") as info:
+            host_memory.log_stage_memory("built CSR")
+
+        line = info.call_args[0][0]
+        self.assertIn("after built CSR", line)
+        self.assertIn("90.0/100.0 GiB (90%)", line)
+        self.assertIn("anon 10.0", line)
+        self.assertIn("dirty 60.0", line)
+
+    def test_log_stage_memory_says_so_when_there_is_no_limit(self):
+        paths, mounts = self._patch("/absent")
+
+        with paths, mounts, mock.patch.object(host_memory.logger, "info") as info:
+            host_memory.log_stage_memory("loaded edges")
+
+        self.assertIn("cgroup=unlimited", info.call_args[0][0])
+
+
+def _expand(path: str) -> list[str]:
+    """The candidate list _cgroup_paths would produce for one path: itself, its ancestors, root."""
+    parts = [part for part in path.split("/") if part]
+    candidates = []
+    while True:
+        candidates.append("/" + "/".join(parts))
+        if not parts:
+            break
+        parts.pop()
+    return candidates
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
Adds `gigl/utils/host_memory.py` and its tests. Two new files; no existing code path changes.

## Why

`psutil.virtual_memory().available` reads `/proc/meminfo`, which inside a container reports the **host's** memory rather than the container's limit. A memory budget check that trusts it alone can pass moments before the container is OOM-killed. This module reads the cgroup limit alongside meminfo and believes the smaller.

## What it handles

- Resolves the process's own cgroup rather than the hierarchy root, translated through the mount root, trying v2 then v1.
- Picks the cgroup with the least headroom. Every ancestor constrains the process, so the first limit found walking up is not necessarily the binding one.
- `cgroup_memory_breakdown` separates anonymous memory from reclaimable page cache, which is what decides whether sitting near the limit is survivable.
- `log_stage_memory` logs that split at pipeline phase boundaries.

## Testing

45 tests pass; `ty` and `ruff` clean. The tests build real cgroup hierarchies in temporary directories and read them through the real code path, mocking only cgroup discovery and `psutil`.
