### PR TITLE
Add opt-in tensor spill to disk for colocated datasets

### DIFF
--- a/gigl/utils/share_memory.py
+++ b/gigl/utils/share_memory.py
@@ -1,10 +1,938 @@
+import errno
+import mmap
+import os
+import tempfile
+import weakref
 from collections import abc
-from typing import Optional, TypeVar, Union
+from dataclasses import dataclass
+from typing import Any, Optional, TypeVar, Union, cast
 
 import torch
 from graphlearn_torch.partition import PartitionBook, RangePartitionBook
 
+from gigl.common.logger import Logger
+from gigl.utils.host_memory import available_memory_bytes
+
+logger = Logger()
+
 _KeyType = TypeVar("_KeyType")  # Generic Key Type
+
+# Directory for spilling large tensors to disk instead of POSIX shared memory. When unset,
+# behaviour is exactly as before (everything goes to /dev/shm).
+#
+# Read from the ENVIRONMENT rather than passed as an argument on purpose: the dataset is
+# built inside `mp.spawn` (gigl/distributed/dataset_factory.py:468), which starts a fresh
+# interpreter. Module-level state set by a parent process does NOT survive that, but the
+# environment does -- it is inherited by the spawned child. An earlier attempt to control
+# this by monkey-patching from the trainer process was a silent no-op for exactly this
+# reason.
+_SPILL_DIR_ENV = "GIGL_TENSOR_SPILL_DIR"
+_SPILL_MIN_BYTES_ENV = "GIGL_TENSOR_SPILL_MIN_BYTES"
+# Set by whichever process cleans the spill directory, so its descendants know not to.
+_SPILL_PREPARED_ENV = "GIGL_TENSOR_SPILL_DIR_PREPARED"
+_DEFAULT_SPILL_MIN_BYTES = 2 * 2**30  # 2 GiB
+# Headroom left on the shared-memory mount when preallocating there. Other tensors, torch's own
+# queues and the sampling workers' channels all share it, and a shared storage that overruns the
+# mount takes SIGBUS on write rather than failing at allocation.
+_SHARED_MEMORY_RESERVE_BYTES = 2 * 2**30  # 2 GiB
+# Cgroup headroom to leave free when a scattered destination is placed in memory. Only what is
+# allocated AFTER this check runs belongs here -- at the measured worst case (the largest CSC of
+# a ~1B-node graph): the direct scatter's full-size cursor clone (indptr[:-1], 7.2 GiB anonymous)
+# and ~1 GiB of chunk/sort transients, ~8.2 GiB, so 16 leaves ~7.8 GiB of allocator/race margin.
+# The freshly written indptr's 7.2 GiB of dirty pages are NOT itemised: they are already charged
+# when this check reads the headroom. NOT covered: the next edge type; its own allocation re-runs
+# this check against whatever headroom is left, and falls back to the banded disk path if the
+# answer is no
+_DEFAULT_RANDOM_ACCESS_RESERVE_BYTES = 16 * 2**30  # 16 GiB
+
+_NUMPY_DTYPES = {
+    torch.float32: "float32",
+    torch.float16: "float16",
+    torch.int64: "int64",
+    torch.int32: "int32",
+    torch.uint8: "uint8",
+}
+
+
+def prepare_spill_dir() -> None:
+    """Clear leftover spill files, ONCE per run, before anything in the run can spill.
+
+    Cleanup is done at the START of a run, not with ``atexit``. The tensors are spilled inside the
+    ``mp.spawn`` dataset-building child (``dataset_factory._build_dataset_process``), and that
+    child **exits before the trainer uses the dataset** -- so unlinking on its exit would delete
+    files the trainer and its sampling workers still have mapped by path. Removing stale files up
+    front bounds disk use without that hazard.
+
+    Exactly one process may do this, and it must be a process that starts before any spilling
+    one. Per-process age-based cleanup is NOT a substitute and is actively wrong: with sequential
+    loading, the edge child spills and exits, then the node child starts, sees the edge files as
+    older than itself, and deletes files the parent has not mapped yet. The marker below is an
+    environment variable precisely because ``spawn`` children inherit the environment, so a child
+    can tell that its parent already did this.
+
+    Idempotent, and safe to call when spilling is disabled.
+    """
+    spill_dir = _spill_dir()
+    if spill_dir is None:
+        return
+    if os.environ.get(_SPILL_PREPARED_ENV) == "1":
+        logger.info(
+            f"share_memory: {spill_dir} was already prepared by an ancestor process; "
+            f"leaving its contents alone"
+        )
+        _cleared_spill_dirs.add(spill_dir)
+        return
+    _clear_spill_dir(spill_dir)
+    # Inherited by every process spawned from here on, which is how they know to skip cleanup.
+    os.environ[_SPILL_PREPARED_ENV] = "1"
+
+
+def _clear_spill_dir(spill_dir: str) -> None:
+    """Unlink every spill file this module could have written under ``spill_dir``."""
+    if spill_dir in _cleared_spill_dirs:
+        return
+    _cleared_spill_dirs.add(spill_dir)
+    removed = 0
+    freed = 0
+    try:
+        for entry in os.scandir(spill_dir):
+            if not (
+                entry.name.startswith(_SPILL_PREFIX) and entry.name.endswith(".bin")
+            ):
+                continue
+            try:
+                freed += entry.stat().st_size
+                os.unlink(entry.path)
+                removed += 1
+            except OSError:
+                pass
+    except FileNotFoundError:
+        return
+    if removed:
+        logger.info(
+            f"share_memory: removed {removed} stale spill file(s) from {spill_dir} "
+            f"({freed / 2**30:.1f} GiB)"
+        )
+
+
+def _ensure_spill_dir_prepared(spill_dir: str) -> None:
+    """Called before writing a spill file.
+
+    If some ancestor called :func:`prepare_spill_dir`, do nothing -- deleting anything here risks
+    removing a sibling's live file. Otherwise this process is the first in its run to spill, so it
+    takes on the cleanup itself; that covers standalone use and tests, where no orchestrator ran.
+    """
+    if os.environ.get(_SPILL_PREPARED_ENV) == "1":
+        return
+    _clear_spill_dir(spill_dir)
+    os.environ[_SPILL_PREPARED_ENV] = "1"
+
+
+_cleared_spill_dirs: set[str] = set()
+_SPILL_PREFIX = "spill_"
+
+# (start address, byte length, weak reference to the backing array, descriptor) for every live spill
+# mapping in this process. See _register_mapping for why this cannot be read back off the tensor.
+_spilled_mappings: list[tuple[int, int, "weakref.ref[Any]", "SpilledTensorHandle"]] = []
+
+
+def _spill_dir() -> Optional[str]:
+    d = os.environ.get(_SPILL_DIR_ENV)
+    return d or None
+
+
+def _env_bytes(name: str, default: int) -> int:
+    """A byte count from the environment, falling back to ``default`` when unset or unparseable."""
+    try:
+        return int(os.environ.get(name, default))
+    except ValueError:
+        return default
+
+
+def _spill_min_bytes() -> int:
+    return _env_bytes(_SPILL_MIN_BYTES_ENV, _DEFAULT_SPILL_MIN_BYTES)
+
+
+def is_tensor_spilling_enabled() -> bool:
+    """Whether ``GIGL_TENSOR_SPILL_DIR`` is set, i.e. large tensors should go to disk."""
+    return _spill_dir() is not None
+
+
+@dataclass(frozen=True)
+class SpilledTensorHandle:
+    """Where a spilled tensor lives, with no tensor attached, so it is cheap to pickle.
+
+    This is what crosses a process boundary in place of the tensor. Sending the tensor instead
+    silently undoes the spill: torch's multiprocessing reduction does not consider a numpy-owned
+    storage shareable, so pickling copies every byte into RAM-backed ``/dev/shm`` (measured: Shmem
+    +383 MiB on a 383 MiB tensor). Call :func:`load_spilled_tensor` on the far side.
+    """
+
+    path: str
+    dtype: torch.dtype
+    shape: tuple[int, ...]
+
+    def load(self) -> torch.Tensor:
+        """Re-map the tensor in the current process."""
+        return load_spilled_tensor(self.path, self.dtype, self.shape)
+
+
+@dataclass(frozen=True)
+class SpilledTensor:
+    """A tensor living in a file, plus everything needed to re-map it elsewhere.
+
+    ``tensor`` is an mmap view; ``handle`` is the part that is safe to send elsewhere.
+    """
+
+    tensor: torch.Tensor
+    path: str
+    dtype: torch.dtype
+    shape: tuple[int, ...]
+
+    @property
+    def handle(self) -> SpilledTensorHandle:
+        return SpilledTensorHandle(path=self.path, dtype=self.dtype, shape=self.shape)
+
+
+def load_spilled_tensor(
+    path: str, dtype: torch.dtype, shape: tuple[int, ...]
+) -> torch.Tensor:
+    """Re-map a spilled tensor in another process, without copying its bytes anywhere.
+
+    The counterpart to :func:`spill_tensor_to_disk`. Pass ``SpilledTensor``'s path, dtype and
+    shape through whatever IPC channel is available and call this on the far side.
+
+    Raises:
+        ValueError: If ``dtype`` has no numpy equivalent, or the file is the wrong size for
+            ``shape`` -- which would otherwise be read as silently wrong data.
+    """
+    import numpy as np
+
+    np_dtype = _NUMPY_DTYPES.get(dtype)
+    if np_dtype is None:
+        raise ValueError(f"Cannot map a spilled tensor of dtype {dtype}")
+    expected_bytes = int(np.prod(shape)) * torch.empty(0, dtype=dtype).element_size()
+    actual_bytes = os.path.getsize(path)
+    if actual_bytes != expected_bytes:
+        raise ValueError(
+            f"Spill file {path} is {actual_bytes} bytes but {shape} of {dtype} needs "
+            f"{expected_bytes}. Refusing to map it."
+        )
+    return _map_spill_file(path, np_dtype, tuple(shape))
+
+
+def _register_mapping(
+    array: Any, tensor: torch.Tensor, handle: SpilledTensorHandle
+) -> None:
+    """Remember that ``tensor``'s bytes live in a file, so ``share_memory`` can refuse to copy them.
+
+    Needed because the fact is not recoverable from the tensor: ``tensor.numpy().base`` is the
+    tensor itself, and ``untyped_storage().filename`` is None for a storage adopted from numpy
+    (both measured). Without a registry, ``share_memory_()`` on a spilled tensor silently relocates
+    it into ``/dev/shm`` -- measured at +16,128 kB for a 16 MiB tensor -- undoing the spill at a
+    point far from where it was made.
+
+    The reference to ``array`` is weak, so an entry disappears when the mapping does. Views of a
+    spilled tensor point inside the recorded range and are recognised too.
+    """
+    nbytes = tensor.numel() * tensor.element_size()
+    _spilled_mappings[:] = [
+        entry for entry in _spilled_mappings if entry[2]() is not None
+    ]
+    _spilled_mappings.append((tensor.data_ptr(), nbytes, weakref.ref(array), handle))
+
+
+def is_disk_backed(tensor: torch.Tensor) -> bool:
+    """Whether ``tensor`` (or a view of one) is an mmap over a spill file rather than RAM."""
+    if not isinstance(tensor, torch.Tensor) or tensor.device.type != "cpu":
+        return False
+    pointer = tensor.data_ptr()
+    for start, nbytes, reference, _ in _spilled_mappings:
+        if reference() is not None and start <= pointer < start + nbytes:
+            return True
+    return False
+
+
+def disk_backed_handle(tensor: torch.Tensor) -> Optional[SpilledTensorHandle]:
+    """The spill descriptor for a tensor that IS an entire spill mapping, else None.
+
+    A partial view does not qualify: a descriptor names a whole file, so it cannot describe a
+    slice of one. Lets a caller re-send an already-spilled tensor by path instead of spilling a
+    second copy of it.
+
+    Requires the tensor to be CONTIGUOUS with no storage offset, not merely to have the right start
+    address and element count. A transpose of a square mmap tensor has the same pointer, shape and
+    numel as the original but reads the file in the wrong order, so matching on those alone would
+    hand the receiver transposed data described as untransposed -- silently wrong values rather than
+    an error.
+    """
+    if not isinstance(tensor, torch.Tensor) or tensor.device.type != "cpu":
+        return None
+    if not tensor.is_contiguous() or tensor.storage_offset() != 0:
+        return None
+    for start, nbytes, reference, handle in _spilled_mappings:
+        if (
+            reference() is not None
+            and start == tensor.data_ptr()
+            and nbytes == tensor.numel() * tensor.element_size()
+            and tuple(tensor.shape) == tuple(handle.shape)
+            and tensor.dtype == handle.dtype
+        ):
+            return handle
+    return None
+
+
+def _map_spill_file(path: str, np_dtype: str, shape: tuple[int, ...]) -> torch.Tensor:
+    """mmap a spill file as a torch tensor, writable when the file permits it.
+
+    Prefers ``r+`` over ``r``. A read-only mapping is PROT_READ, and ``torch.from_numpy`` does not
+    enforce that -- an in-place write on the resulting tensor would reach the mapping and take a
+    SIGSEGV rather than raising. Downstream code (partitioning, label handling) is not audited for
+    in-place mutation of loaded tensors, so a writable mapping trades an unbounded crash risk for
+    dirtied page-cache pages, which is the cheaper failure. Unwritten pages stay clean and
+    evictable either way, which is the point of spilling.
+    """
+    import numpy as np
+
+    try:
+        mapped = np.memmap(path, dtype=np_dtype, mode="r+", shape=shape)
+    except OSError:
+        mapped = np.memmap(path, dtype=np_dtype, mode="r", shape=shape)
+    array = np.asarray(mapped)
+    tensor = torch.from_numpy(array)
+    _register_mapping(
+        array, tensor, SpilledTensorHandle(path=path, dtype=tensor.dtype, shape=shape)
+    )
+    return tensor
+
+
+def spill_tensor_to_disk(tensor: torch.Tensor) -> Optional[SpilledTensor]:
+    """Write ``tensor`` to disk and return a :class:`SpilledTensor`, or ``None`` to keep it.
+
+    ``None`` covers every reason not to spill -- spilling disabled, tensor below the threshold,
+    unsupported dtype, IO failure -- so callers can treat it as "keep what you had".
+
+    Exposed for callers that hold a tensor directly rather than inside a Mapping, which
+    :func:`share_memory` cannot substitute into. The partitioned node feature matrix is the case
+    that matters: it is created after loading, so the spill in ``load_torch_tensors`` never sees
+    it, and it is resident during the graph build.
+    """
+    spill_dir = _spill_dir()
+    if spill_dir is None:
+        return None
+    if 0 in tensor.shape:
+        return None
+    # Already living in a file -- most likely allocated by allocate_disk_backed rather than filled in
+    # memory and spilled. Copying it to a second file would double the disk use and the time for no
+    # benefit, so hand back a descriptor for the file it is already in.
+    existing = disk_backed_handle(tensor)
+    if existing is not None:
+        logger.info(
+            f"share_memory: {tuple(tensor.shape)} {tensor.dtype} is already on disk at "
+            f"{existing.path}; not writing a second copy"
+        )
+        return SpilledTensor(
+            tensor=tensor,
+            path=existing.path,
+            dtype=existing.dtype,
+            shape=existing.shape,
+        )
+    if tensor.numel() * tensor.element_size() < _spill_min_bytes():
+        return None
+    _ensure_spill_dir_prepared(spill_dir)
+    return _spill_to_mmap(tensor, spill_dir)
+
+
+def _reserve_file_blocks(fd: int, n_bytes: int, spill_dir: str) -> None:
+    """Reserve every block of a spill file now, or raise ``OSError``.
+
+    Running out of space must be an error HERE, not a SIGBUS on some later page write -- a signal,
+    not an exception, which no ``try`` can catch. A filesystem that cannot reserve at all
+    (``posix_fallocate`` unsupported) raises too: proceeding with an unreserved mapping would keep
+    the SIGBUS window open, so the caller falls back to memory instead.
+    """
+    while True:
+        try:
+            os.posix_fallocate(fd, 0, n_bytes)
+            return
+        except InterruptedError:
+            continue  # EINTR: the syscall was interrupted, not refused
+        except AttributeError as no_fallocate:
+            raise OSError(
+                errno.ENOSYS,
+                f"posix_fallocate is unavailable on this platform, so a "
+                f"{n_bytes / 2**30:.1f} GiB mapping under {spill_dir} cannot be made SIGBUS-safe",
+            ) from no_fallocate
+        except OSError as reserve_error:
+            if reserve_error.errno in (errno.EOPNOTSUPP, errno.ENOSYS, errno.EINVAL):
+                # The filesystem cannot reserve. An unreserved mapping faults with SIGBUS if the
+                # filesystem fills, so refuse rather than proceed without the guarantee
+                raise OSError(
+                    reserve_error.errno,
+                    f"{spill_dir} does not support reserving space ({reserve_error}); "
+                    f"refusing an unreserved {n_bytes / 2**30:.1f} GiB mapping",
+                ) from reserve_error
+            # ENOSPC, EDQUOT, EFBIG, EIO and anything else unexpected: the caller cleans up and
+            # uses memory instead
+            raise
+
+
+def allocate_disk_backed(
+    shape: tuple[int, ...], dtype: torch.dtype
+) -> Optional[torch.Tensor]:
+    """An EMPTY writable tensor whose bytes live in a file, or None to fall back to RAM.
+
+    The counterpart to :func:`spill_tensor_to_disk` for a buffer that does not exist yet. Spilling
+    fills RAM and then copies it out, so it needs the full size in anonymous memory at least once;
+    allocating the destination as the file from the start means those bytes never occupy anonymous
+    memory at all.
+
+    Blocks are RESERVED up front with ``posix_fallocate`` rather than left sparse, and reservation
+    is mandatory. ``np.memmap(mode="w+")`` gives the file its full apparent size without allocating
+    it, so a filesystem that fills later fails at the moment a page is written -- and a write to a
+    mapping that cannot be backed raises **SIGBUS**, which is a signal, not an exception: it
+    bypasses every ``try`` here and kills the process with no traceback. Reserving turns that into
+    an ``OSError`` at allocation time, where it can be reported and fallen back on; a filesystem
+    that cannot reserve at all gets None rather than an unreserved mapping.
+
+    Measured cost of writing a 251-column fp32 matrix through the mapping instead of RAM: 46.8 s vs
+    15.1 s at 8M rows, so ~3.1x, i.e. roughly 6 minutes at the production shape by linear
+    extrapolation -- an estimate, not an upper bound, since the production pattern scatters ~938k
+    rows per chunk under cgroup dirty-page throttling.
+
+    What it buys: the destination's own bytes, ~56.42 GiB for a rank's node feature matrix, stop
+    being unreclaimable anonymous memory. The mapped pages are still charged to the cgroup, but as
+    page cache the kernel can reclaim them under pressure instead of OOM-killing. Freed chunk arenas
+    retained by the allocator are unaffected, so this does not remove the whole measured 1.63x peak.
+
+    Returns None whenever a file-backed buffer is not available or not worth it -- spilling disabled,
+    below the size threshold, dtype with no numpy equivalent, no room to reserve, reservation
+    unsupported by the filesystem, IO failure -- so callers can simply fall back to ``torch.empty``.
+    """
+    spill_dir = _spill_dir()
+    if spill_dir is None:
+        return None
+    if 0 in shape:
+        return None
+    np_dtype = _NUMPY_DTYPES.get(dtype)
+    if np_dtype is None:
+        return None
+    element_size = torch.empty(0, dtype=dtype).element_size()
+    n_bytes = element_size
+    for extent in shape:
+        n_bytes *= extent
+    if n_bytes < _spill_min_bytes():
+        return None
+    _ensure_spill_dir_prepared(spill_dir)
+
+    import numpy as np
+
+    path: Optional[str] = None
+    try:
+        os.makedirs(spill_dir, exist_ok=True)
+        fd, path = tempfile.mkstemp(dir=spill_dir, prefix=_SPILL_PREFIX, suffix=".bin")
+        try:
+            _reserve_file_blocks(fd, n_bytes, spill_dir)
+        finally:
+            os.close(fd)
+        # "r+", NOT "w+": the file is already sized by the reservation, and numpy opens "w+" as
+        # `w+b`, which TRUNCATES the file and hands back every block just reserved -- leaving it
+        # sparse again and the SIGBUS risk exactly where it was
+        mapped = np.memmap(
+            path,
+            dtype=np_dtype,
+            mode="r+",
+            shape=tuple(shape),
+        )
+        array = np.asarray(mapped)
+        tensor = torch.from_numpy(array)
+        _register_mapping(
+            array,
+            tensor,
+            SpilledTensorHandle(path=path, dtype=dtype, shape=tuple(shape)),
+        )
+        logger.info(
+            f"share_memory: allocated {n_bytes / 2**30:.1f} GiB buffer {tuple(shape)} {dtype} "
+            f"on disk at {path} instead of in anonymous memory"
+        )
+        return tensor
+    except Exception as e:  # noqa: BLE001
+        if path is not None:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+        logger.error(
+            f"share_memory: could not allocate {n_bytes / 2**30:.1f} GiB on disk "
+            f"({type(e).__name__}: {e}); using memory"
+        )
+        return None
+
+
+def _spill_to_mmap(tensor: torch.Tensor, spill_dir: str) -> Optional[SpilledTensor]:
+    """Write ``tensor`` to a file under ``spill_dir`` and return an mmap view of it.
+
+    Returns None if the tensor cannot be spilled (unsupported dtype, reservation refused by the
+    filesystem, IO failure), in which case the caller should keep the tensor it already had.
+
+    Why this helps: ``/dev/shm`` is tmpfs, i.e. RAM. Node features for a ~1B-node graph approach
+    a terabyte at fp32; even split across replicas that is the largest resident tensor, and
+    ``share_memory_()`` costs 1x in tmpfs plus a transient 2x in RSS. Backing the bytes with
+    a real file turns them into evictable page cache instead.
+
+    NOTE the mapping only stays file-backed within this process. Torch's multiprocessing reduction
+    copies a numpy-owned storage into shared memory when the tensor is pickled, so anything that
+    ships this tensor to another process undoes the spill. Ship ``SpilledTensor.path`` and call
+    :func:`load_spilled_tensor` on the far side instead.
+    """
+    np_dtype = _NUMPY_DTYPES.get(tensor.dtype)
+    if np_dtype is None:
+        logger.warning(
+            f"share_memory: dtype {tensor.dtype} not spillable, using shared memory"
+        )
+        return None
+    import numpy as np
+
+    path: Optional[str] = None
+    try:
+        os.makedirs(spill_dir, exist_ok=True)
+        n_bytes = tensor.numel() * tensor.element_size()
+        # mkstemp, not a name derived from shape and byte count. A derived name collides for two
+        # tensors with the same shape and element width -- including different dtypes of the same
+        # width -- and reopening that path with mode="w+" TRUNCATES the file still backing the
+        # first tensor's live read-only mapping, silently replacing its contents. Nothing would
+        # raise; the features would simply be wrong.
+        fd, path = tempfile.mkstemp(dir=spill_dir, prefix=_SPILL_PREFIX, suffix=".bin")
+        try:
+            # Same SIGBUS-safety rule as allocate_disk_backed: every block is reserved before the
+            # copy starts, so a filesystem that fills mid-copy fails as OSError here, not as a
+            # signal on some later page write
+            _reserve_file_blocks(fd, n_bytes, spill_dir)
+        finally:
+            os.close(fd)
+        # "r+", not "w+": the reservation already sized the file, and "w+" would truncate the
+        # reserved blocks away
+        writable = np.memmap(path, dtype=np_dtype, mode="r+", shape=tuple(tensor.shape))
+        # Copy in ~1 GiB slices so we never hold a second full-size buffer.
+        row_bytes = (
+            max(1, int(tensor[0].numel()) * tensor.element_size())
+            if tensor.dim() > 1
+            else tensor.element_size()
+        )
+        rows = max(1, int(2**30 // row_bytes))
+        for start in range(0, tensor.shape[0], rows):
+            writable[start : start + rows] = tensor[start : start + rows].numpy()
+        writable.flush()
+        del writable
+        logger.info(
+            f"share_memory: spilled {n_bytes / 2**30:.1f} GiB to {path} instead of /dev/shm"
+        )
+        return SpilledTensor(
+            tensor=_map_spill_file(path, np_dtype, tuple(tensor.shape)),
+            path=path,
+            dtype=tensor.dtype,
+            shape=tuple(tensor.shape),
+        )
+    except Exception as e:  # noqa: BLE001
+        # Unlink the partial file. mkstemp has already created it, so a failure in the mmap, the
+        # copy, the flush or the remap would otherwise leave its bytes on disk with nothing
+        # referencing them. That matters most in the case that causes the failure: the spill
+        # filesystem is finite and node features are tens of GiB per replica, so a couple of failed
+        # attempts can exhaust the disk and push the tensors back into RAM -- turning a recoverable
+        # spill failure into the OOM this whole mechanism exists to avoid
+        if path is not None:
+            try:
+                os.unlink(path)
+                logger.info(f"share_memory: removed partial spill file {path}")
+            except OSError:
+                logger.warning(
+                    f"share_memory: could not remove partial spill file {path}"
+                )
+        logger.error(
+            f"share_memory: spill failed ({type(e).__name__}: {e}); using shared memory"
+        )
+        return None
+
+
+def _shared_memory_backing_dir() -> str:
+    """Where torch puts shared storages on Linux: ``/dev/shm``, under BOTH sharing strategies.
+
+    Measured rather than inferred, because the obvious reading of the docs is wrong. Under
+    ``file_system`` torch calls ``_new_using_filename_cpu``, which sounds like an ordinary temporary
+    file and is not: the storage lands in ``/dev/shm`` (observed:
+    ``/dev/shm/torch_<pid>_<random>_0``, 16,000,064 bytes for a 16 MB tensor), and ``TMPDIR`` receives
+    only a 4 KiB ``torch-shm-dir-*`` directory holding the libshm manager's socket. Under
+    ``file_descriptor`` the segment is ``shm_open``ed and immediately unlinked, so nothing is visible
+    in the directory listing while it still consumes the mount's capacity.
+
+    An earlier version of this returned ``TMPDIR`` for ``file_system``, which would have sized the
+    check against the wrong filesystem in precisely the case the check exists for.
+    """
+    return "/dev/shm"
+
+
+def _shared_memory_shortfall(n_bytes: int) -> Optional[str]:
+    """A human-readable reason a shared allocation of ``n_bytes`` would not fit, or None if it fits.
+
+    Returns None when the check cannot be made, so an unreadable mount does not block an allocation
+    that would have worked. The caller must still handle a failure from the allocation itself: this
+    cannot close the gap between checking and allocating, during which another process on the same
+    mount can take the space.
+    """
+    directory = _shared_memory_backing_dir()
+    try:
+        stats = os.statvfs(directory)
+    except OSError:
+        return None
+    free_bytes = stats.f_bavail * stats.f_frsize
+    # A margin, because this process is not the only user of that mount and the check races anything
+    # else allocating on it.
+    needed = n_bytes + _SHARED_MEMORY_RESERVE_BYTES
+    if free_bytes >= needed:
+        return None
+    return (
+        f"{directory} has {_human_bytes(free_bytes)} free, short of the "
+        f"{_human_bytes(n_bytes)} requested plus a {_human_bytes(_SHARED_MEMORY_RESERVE_BYTES)} "
+        f"reserve"
+    )
+
+
+def _human_bytes(n_bytes: int) -> str:
+    """A byte count in the unit that makes it readable, so small tensors do not log as "0.0 GiB"."""
+    if n_bytes >= 2**30:
+        return f"{n_bytes / 2**30:.1f} GiB"
+    if n_bytes >= 2**20:
+        return f"{n_bytes / 2**20:.1f} MiB"
+    return f"{n_bytes} B"
+
+
+def _random_access_headroom_reserve_bytes() -> int:
+    """Cgroup headroom to leave free when choosing memory over disk for a scattered destination."""
+    return _env_bytes(
+        "GIGL_RANDOM_ACCESS_HEADROOM_RESERVE_BYTES",
+        _DEFAULT_RANDOM_ACCESS_RESERVE_BYTES,
+    )
+
+
+def _memory_is_the_better_home(n_bytes: int) -> Optional[str]:
+    """None if ``n_bytes`` should go to memory rather than disk, else why it cannot.
+
+    Two independent limits, and both have to hold. ``/dev/shm`` has its own size, usually half of
+    RAM; the cgroup is what actually kills the process. Checking only the mount is not enough in a
+    container -- the mount is sized off the machine spec while the cgroup limit can sit well below
+    it.
+    """
+    shortfall = _shared_memory_shortfall(n_bytes)
+    if shortfall is not None:
+        return shortfall
+    reserve = _random_access_headroom_reserve_bytes()
+    available = available_memory_bytes()
+    if available < n_bytes + reserve:
+        return (
+            f"only {_human_bytes(available)} of cgroup headroom, short of the "
+            f"{_human_bytes(n_bytes)} requested plus a {_human_bytes(reserve)} reserve"
+        )
+    return None
+
+
+def allocate_preshared(
+    shape: tuple[int, ...], dtype: torch.dtype, random_access: bool = False
+) -> torch.Tensor:
+    """Allocate a large tensor in its FINAL home, so ``share_memory_()`` cannot duplicate it.
+
+    Args:
+        shape: Shape of the tensor.
+        dtype: Dtype of the tensor.
+        random_access: Set when the caller will write to SCATTERED offsets rather than stream
+            through in order. Then memory is preferred over a file and disk is a fallback, because
+            a file is catastrophically slower under that pattern -- see below. Defaults to False,
+            which keeps the disk-first behaviour that saves the most memory.
+
+    PLACEMENT
+        Disk-first is right for a destination written in order: one pass, sequential, and the bytes
+        become reclaimable page cache instead of unreclaimable anonymous memory.
+
+        It is badly wrong for a destination written by scatter. An 8-byte write to an uncached file
+        page costs a 4 KiB read-modify-write, and a chunked CSR build makes hundreds of passes over
+        the same millions of pages of a tens-of-GiB ``indices`` (measured: 251 passes over 8.2M
+        pages, 2.06 BILLION page touches, ~19 h at 60k IOPS). A production-scale run sat in exactly
+        that loop for over an hour at 4% CPU with memory flat, having logged nothing since the
+        allocation. The measured 3.1x cost of a file-backed destination came from a FEATURE matrix,
+        ~1000 contiguous bytes per row written once; carrying that ratio across to a scatter was an
+        extrapolation across a change in kind, not degree.
+
+        ``random_access=True`` therefore prefers shared memory, and falls back to a file only when
+        memory genuinely will not hold it -- logging the expected slowdown when it does, because a
+        silent fall back to disk here is a run that appears to hang.
+
+    WHY PRE-SHARED AT ALL
+    GLT's ``Graph.__init__`` calls ``Topology.share_memory_()`` unconditionally, and for an ordinary
+    anonymous tensor that copies every byte into ``/dev/shm``. The CSR therefore exists TWICE for the
+    duration of the copy. A production-scale run was killed one second after logging that its CSR was
+    built: indices 31.3 GiB + indptr 7.2 GiB duplicating to 77 GiB on top of an 84 GiB baseline,
+    against a limit under 160 GiB. No log line sits between the two, which is why it looked like the
+    CSR build itself.
+
+    Two backends, both immune to that copy:
+
+    * a file under ``GIGL_TENSOR_SPILL_DIR`` -- consumers that check :func:`is_disk_backed` before
+      sharing leave the tensor alone, and the bytes are reclaimable file pages rather than
+      unreclaimable anonymous memory (still cgroup-charged while resident);
+    * POSIX shared memory allocated directly -- ``share_memory_()`` then finds it already shared and
+      does nothing (verified: ``data_ptr`` unchanged across the call).
+
+    Below the spill threshold it returns a plain tensor, where a duplicate costs little.
+
+    Uninitialised in both cases, like ``torch.empty``.
+    """
+    n_bytes = torch.empty(0, dtype=dtype).element_size()
+    for extent in shape:
+        n_bytes *= extent
+
+    prefer_memory = random_access and _memory_is_the_better_home(n_bytes) is None
+    if not prefer_memory:
+        if random_access and n_bytes >= _spill_min_bytes() and 0 not in shape:
+            # Said out loud, with the reason: entering this branch is the run's most consequential
+            # placement decision, and a silently disk-backed scatter destination is a run that
+            # appears hung. A caller that detects the disk backing and switches to a banded
+            # scatter writes each destination page once instead of once per chunk -- slower than
+            # memory but bounded, and its own progress lines say how it is going
+            logger.warning(
+                f"share_memory: {_human_bytes(n_bytes)} {tuple(shape)} {dtype} will be scattered "
+                f"into but must live on disk -- {_memory_is_the_better_home(n_bytes)}. The caller "
+                f"is expected to use a banded writer; watch its progress lines rather than "
+                f"assuming a hang"
+            )
+        on_disk = allocate_disk_backed(shape, dtype)
+        if on_disk is not None:
+            return on_disk
+
+    if n_bytes < _spill_min_bytes() or 0 in shape:
+        return torch.empty(shape, dtype=dtype)
+
+    shortfall = _shared_memory_shortfall(n_bytes)
+    if shortfall is not None:
+        # Raised, not worked around, because there is NO safe fallback from here.
+        #
+        # Attempting the allocation is unsafe: sizing a tmpfs object does not reserve its pages, so
+        # `_new_shared` for 31.3 GiB against a 64 MiB /dev/shm -- Docker's default -- SUCCEEDS, and
+        # the first write past the limit takes SIGBUS, which no `except` can catch.
+        #
+        # Returning an anonymous tensor is equally unsafe, which is the part that is easy to get
+        # wrong: `_build_topology_without_edge_ids` would then pick a plain `Topology`, and
+        # `Graph.__init__` calls GLT's UNGUARDED `share_memory_()` on it -- attempting the very same
+        # oversized allocation on the very same full mount, a few seconds later and with no
+        # attribution back to here. A warning-and-continue only moves the SIGBUS somewhere harder to
+        # diagnose.
+        #
+        # So fail here, where the message can name both remedies. Reachable only for tensors at or
+        # above the spill threshold, and only when the disk backend was unavailable too.
+        raise RuntimeError(
+            f"Cannot allocate {_human_bytes(n_bytes)} {tuple(shape)} {dtype} without risking SIGBUS: "
+            f"{shortfall}. Continuing is not safe -- an anonymous tensor this size is relocated into "
+            f"the same full mount by graphlearn_torch's Graph.__init__, and that copy has OOM-killed "
+            f"real runs. Either set GIGL_TENSOR_SPILL_DIR to a filesystem with room "
+            f"(the intended configuration; the CSR is then file-backed and never copied), or raise "
+            f"the container's shared-memory limit."
+        )
+
+    # `torch.empty(...).share_memory_()` would defeat the purpose: it allocates anonymously and then
+    # copies, which is the duplication being avoided. Allocating the shared storage first means the
+    # bytes are only ever written once.
+    try:
+        storage = torch.UntypedStorage._new_shared(n_bytes)
+        tensor = torch.empty(0, dtype=dtype)
+        # Contiguous strides, computed rather than left to be inferred: the typed overload of `set_`
+        # that takes a size also requires a stride.
+        stride: list[int] = [1] * len(shape)
+        for axis in range(len(shape) - 2, -1, -1):
+            stride[axis] = stride[axis + 1] * int(shape[axis + 1])
+        tensor.set_(storage, 0, tuple(shape), tuple(stride))
+        logger.info(
+            f"share_memory: allocated {_human_bytes(n_bytes)} {tuple(shape)} {dtype} directly in "
+            f"shared memory, so share_memory_() will not copy it"
+        )
+        return tensor
+    except (AttributeError, OSError, RuntimeError) as e:
+        # Falling back IS safe here, unlike the shortfall branch above, and the difference is the
+        # whole point: capacity was just checked and found sufficient, so the duplicate that GLT's
+        # `share_memory_()` will make has somewhere to go. This branch is for the mechanism being
+        # unavailable -- `_new_shared` is private API and could be renamed -- not for the mount being
+        # full. Costs a duplicate, not a SIGBUS.
+        logger.warning(
+            f"share_memory: could not preallocate {_human_bytes(n_bytes)} in shared memory "
+            f"({type(e).__name__}: {e}); the mount has room, so a later share_memory_() will "
+            f"duplicate it rather than fail"
+        )
+        return torch.empty(shape, dtype=dtype)
+
+
+def has_live_mapping(path: str) -> bool:
+    """Whether some tensor in this process still maps ``path``.
+
+    Reads the spill registry, whose entries hold a weakref to the ``np.memmap``: a dead weakref means
+    the last tensor over that file was collected and the mapping is gone.
+    """
+    return any(
+        reference() is not None and handle.path == path
+        for _, _, reference, handle in _spilled_mappings
+    )
+
+
+def release_page_cache_by_path(path: str) -> bool:
+    """Request eviction of a spill file's page cache when nothing maps it any more.
+
+    The counterpart to :func:`release_page_cache` for a tensor that has already been dropped. Once no
+    mapping remains there are no page-table entries to clear, so ``FADV_DONTNEED`` alone is
+    sufficient -- the reason the tensor version needs ``MADV_DONTNEED`` first does not apply.
+
+    This is what a consumed input needs. ``del`` on an mmap-backed tensor unmaps it but leaves the
+    file's pages charged to the cgroup until the kernel reclaims them, so an input and an output of
+    the same size are both charged while the output is being written.
+
+    Refuses when a mapping is still live, because ``FADV_DONTNEED`` SILENTLY SKIPS pages that are in
+    any page table -- it would return success having freed nothing. One stale reference (a tuple
+    built for a call, a name the caller forgot to drop) is enough to turn this into a no-op, and
+    without this check the caller logs a saving it did not get. Use :func:`release_page_cache` on the
+    tensor itself in that case, which unmaps first.
+
+    Returns True if the eviction was REQUESTED -- ``FADV_DONTNEED`` is advisory and reports no
+    count, so "requested" is all success can mean without measuring residency. False if a mapping
+    is still live, the file could not be opened, or the platform lacks ``posix_fadvise``.
+    """
+    if has_live_mapping(path):
+        logger.warning(
+            f"share_memory: refusing to drop page cache for {path} -- a tensor still maps it, so "
+            f"FADV_DONTNEED would free nothing. Drop every reference first, or call "
+            f"release_page_cache(tensor) to unmap before discarding."
+        )
+        return False
+    try:
+        fd = os.open(path, os.O_RDWR)
+    except OSError as e:
+        logger.warning(f"share_memory: could not open {path} to drop its cache: {e}")
+        return False
+    try:
+        os.fsync(fd)
+        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+    except (AttributeError, OSError) as e:
+        logger.info(f"share_memory: could not drop page cache for {path}: {e}")
+        return False
+    finally:
+        os.close(fd)
+    return True
+
+
+def release_page_cache(tensor: torch.Tensor) -> bool:
+    """Write a disk-backed tensor's dirty pages out and ask the kernel to drop them from the cache.
+
+    Moving a tensor to a file changes the KIND of memory it occupies, not whether it is charged:
+    cgroup v2 counts page cache in ``memory.current``, so a 56.4 GiB feature matrix on the spill
+    filesystem still counts against the container's limit -- reclaimable rather than OOM-triggering,
+    but counted. A production-scale run died with exactly that 56.4 GiB charged alongside the CSR
+    build's anonymous allocations, within a few GiB of its limit.
+
+    Dropping the cache once the file is written releases the charge as the pages go (writeback can
+    briefly delay stragglers; the fsync below bounds that). The mapping stays
+    valid; pages fault back in on next access, so this costs a cold first read and nothing else.
+    Worth doing only for a tensor that is written now and not read until much later -- the
+    partitioned node features, which are written before the graph build and not touched again until
+    sampling starts.
+
+    Three steps, in this order, and every one is load-bearing:
+
+    1. ``msync`` through the backing memmap -- dirty pages cannot be dropped at all.
+    2. ``MADV_DONTNEED`` on the mapping -- removes this process's page-table entries.
+    3. ``fsync`` then ``POSIX_FADV_DONTNEED`` -- discards the now-unmapped clean page cache.
+
+    Step 2 is the one that is easy to omit and fatal to omit. Linux implements ``FADV_DONTNEED`` via
+    ``invalidate_mapping_pages()``, which SKIPS any page currently mapped into a page table, so
+    calling it alone on a live mapping leaves every page resident and charged while returning
+    success. ``MADV_DONTNEED`` is safe here only because the mapping is file-backed and has just been
+    flushed; on an anonymous mapping it would discard the data outright.
+
+    Returns True when every eviction step COMPLETED, which is not the same as proof that every page
+    went: ``FADV_DONTNEED`` is advisory and reports no count, and another process holding live PTEs on
+    the same file can keep pages resident. False means the sequence was incomplete -- not disk-backed,
+    no live mapping, or a failing step -- and note that a failure after step 2 leaves this process's
+    PTEs already dropped, so False does not mean nothing changed. To know what was actually evicted,
+    measure residency with ``mincore``; the tests do exactly that.
+    """
+    handle = disk_backed_handle(tensor)
+    if handle is None:
+        return False
+
+    # The numpy memmap that owns the mapping. `np.asarray(memmap)` keeps the memmap as its base, and
+    # torch keeps that array alive, so it is still reachable through the registry.
+    backing = None
+    for _, _, reference, registered in _spilled_mappings:
+        if registered is handle:
+            array = reference()
+            backing = getattr(array, "base", None) if array is not None else None
+            break
+    if backing is None or not hasattr(backing, "flush"):
+        logger.warning(
+            f"share_memory: no live mapping found for {handle.path}; cannot drop its cache"
+        )
+        return False
+
+    try:
+        backing.flush()  # msync: dirty pages cannot be dropped, so this is not optional.
+    except (OSError, ValueError) as e:
+        logger.warning(f"share_memory: could not msync {handle.path}: {e}")
+        return False
+
+    # STEP ORDER MATTERS, and getting it wrong makes this whole function a silent no-op.
+    #
+    # POSIX_FADV_DONTNEED alone does nothing here: Linux implements it via
+    # invalidate_mapping_pages(), which SKIPS any page currently mapped into a page table. With the
+    # tensor still mapped, every one of those pages stays resident and stays charged to the cgroup --
+    # while the call returns success. So the PTEs have to go first.
+    #
+    # MADV_DONTNEED on a shared FILE mapping only drops this process's page-table entries; the next
+    # access refaults from the file. (On an anonymous mapping it would discard the data -- this is
+    # only safe because the mapping is file-backed and has just been msync'd.)
+    mapping = getattr(backing, "_mmap", None)
+    if mapping is None or not hasattr(mapping, "madvise"):
+        logger.info(
+            f"share_memory: cannot unmap pages for {handle.path} (no madvise available); its "
+            f"pages stay charged to the cgroup until the kernel reclaims them"
+        )
+        return False
+    try:
+        mapping.madvise(mmap.MADV_DONTNEED)
+    except (AttributeError, OSError, ValueError) as e:
+        logger.info(
+            f"share_memory: MADV_DONTNEED failed for {handle.path} ({e}); page-cache eviction "
+            f"would be a no-op while the pages remain mapped, so nothing was dropped"
+        )
+        return False
+
+    try:
+        fd = os.open(handle.path, os.O_RDWR)
+    except OSError as e:
+        logger.warning(
+            f"share_memory: could not reopen {handle.path} to drop cache: {e}"
+        )
+        return False
+    try:
+        os.fsync(fd)
+        # length 0 means "to end of file".
+        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+    except (AttributeError, OSError) as e:
+        logger.info(
+            f"share_memory: could not drop page cache for {handle.path} ({e}); its pages stay "
+            f"charged to the cgroup until the kernel reclaims them"
+        )
+        return False
+    finally:
+        os.close(fd)
+    n_bytes = tensor.numel() * tensor.element_size()
+    logger.info(
+        f"share_memory: unmapped and requested eviction of {_human_bytes(n_bytes)} of page cache "
+        f"for {handle.path}; the mapping stays valid and refaults on next read"
+    )
+    return True
 
 
 def share_memory(
@@ -28,6 +956,17 @@ def share_memory(
     provide a ForkingPickler registration method for the `RangePartitionBook`, and the cost of not moving this to shared memory is minimal,
     since the size of this tensor is very small, being equal in length to the number of machines.
 
+    This function does NOT spill to disk, deliberately. Its callers hand the result to another
+    process, and a spill whose path is not carried alongside it is undone the moment the tensor is
+    pickled -- torch copies a numpy-owned storage into ``/dev/shm``, so spilling here would cost a
+    full disk write AND the full RAM copy it was meant to avoid. Spilling belongs where a
+    descriptor travels with the tensor: :func:`share_memory_for_ipc` and
+    :func:`spill_tensor_to_disk`.
+
+    A tensor that is ALREADY disk-backed is left alone for the same reason. ``share_memory_()`` on
+    such a tensor copies every byte into ``/dev/shm`` -- measured at +16,128 kB for a 16 MiB
+    tensor -- which would quietly undo a spill made earlier and elsewhere.
+
     Args:
         entity (Optional[Union[torch.Tensor, PartitionBook, dict[_KeyType, torch.Tensor], dict[_KeyType, PartitionBook]]]):
             Homogeneous or heterogeneous entity of tensors which is being moved to shared memory
@@ -36,11 +975,84 @@ def share_memory(
     if entity is None or isinstance(entity, RangePartitionBook):
         return
     elif isinstance(entity, abc.Mapping):
-        for entity_tensor in entity.values():
-            share_memory(entity_tensor)
+        for key in list(entity.keys()):
+            share_memory(entity[key])
+        return
     else:
         # If the tensor has a dimension which is 0, it is an empty tensor. As a result, we don't move this
         # to shared_memory, since share_memory_() is unsafe on empty tensors, which may cause processes to hang.
         if 0 in entity.shape:
             return
+        if is_disk_backed(entity):
+            logger.info(
+                f"share_memory: leaving a disk-backed tensor {tuple(entity.shape)} "
+                f"{entity.dtype} where it is; sharing it would copy "
+                f"{entity.numel() * entity.element_size() / 2**30:.1f} GiB into /dev/shm"
+            )
+            return
         entity.share_memory_()
+
+
+def share_memory_for_ipc(
+    entity: dict[_KeyType, torch.Tensor],
+) -> dict[_KeyType, Union[torch.Tensor, SpilledTensorHandle]]:
+    """Prepare a mapping of tensors to cross a process boundary, spilling instead of copying.
+
+    Same intent as :func:`share_memory`, but for values that will be **pickled to another
+    process**: a spilled tensor is replaced by a :class:`SpilledTensorHandle` rather than by its
+    mmap view. Sending the view would copy every byte back into ``/dev/shm``, which is RAM, and
+    silently undo the spill -- the reason this function exists separately.
+
+    Tensors that are not spilled (spilling disabled, below the size threshold, unsupported dtype)
+    go to POSIX shared memory exactly as before, which pickles by handle already.
+
+    Returns a NEW dict; the input is left alone, since the caller usually still holds the tensors
+    and dropping them is its decision.
+    """
+    prepared: dict[_KeyType, Union[torch.Tensor, SpilledTensorHandle]] = {}
+    for key, value in entity.items():
+        already_spilled = disk_backed_handle(value)
+        if already_spilled is not None:
+            # Spilled earlier by something else; send that file's descriptor rather than writing a
+            # second copy of the same bytes.
+            prepared[key] = already_spilled
+            continue
+        spilled = spill_tensor_to_disk(value)
+        if spilled is not None:
+            prepared[key] = spilled.handle
+            # Nothing here keeps the mmap view alive on purpose: the far side re-maps from the
+            # path, and holding a second mapping in this process buys nothing.
+            continue
+        share_memory(value)
+        prepared[key] = value
+    return prepared
+
+
+def resolve_spilled_handles(
+    value: Union[
+        torch.Tensor,
+        SpilledTensorHandle,
+        dict[_KeyType, Union[torch.Tensor, SpilledTensorHandle]],
+        None,
+    ],
+) -> Any:
+    """Turn any :class:`SpilledTensorHandle` back into a tensor, mapped in this process.
+
+    The receiving half of :func:`share_memory_for_ipc`. Accepts a bare value or a mapping of
+    values -- matching how the loader ships either a single tensor (homogeneous) or a dict keyed
+    by node/edge type (heterogeneous) -- and passes anything that is already a tensor straight
+    through.
+    """
+    if value is None:
+        return None
+    if isinstance(value, SpilledTensorHandle):
+        tensor = value.load()
+        logger.info(
+            f"share_memory: mapped spilled tensor {tuple(value.shape)} {value.dtype} from "
+            f"{value.path} ({tensor.numel() * tensor.element_size() / 2**30:.1f} GiB, no copy)"
+        )
+        return tensor
+    if isinstance(value, abc.Mapping):
+        by_type = cast(dict[Any, Union[torch.Tensor, SpilledTensorHandle]], value)
+        return {key: resolve_spilled_handles(item) for key, item in by_type.items()}
+    return value

--- a/gigl/utils/share_memory.py
+++ b/gigl/utils/share_memory.py
@@ -7,6 +7,7 @@ from collections import abc
 from dataclasses import dataclass
 from typing import Any, Optional, TypeVar, Union, cast
 
+import numpy as np
 import torch
 from graphlearn_torch.partition import PartitionBook, RangePartitionBook
 
@@ -59,11 +60,14 @@ def prepare_spill_dir() -> None:
     front bounds disk use without that hazard.
 
     Exactly one process may do this, and it must be a process that starts before any spilling
-    one. Per-process age-based cleanup is NOT a substitute and is actively wrong: with sequential
-    loading, the edge child spills and exits, then the node child starts, sees the edge files as
-    older than itself, and deletes files the parent has not mapped yet. The marker below is an
-    environment variable precisely because ``spawn`` children inherit the environment, so a child
-    can tell that its parent already did this.
+    one -- a run has several spilling children in sequence, and a later one cannot tell a
+    sibling's live files from a stale run's (the first spiller does clean up itself when no
+    ancestor did, which covers standalone use and tests). Per-process age-based cleanup is NOT a
+    substitute and is actively wrong: with sequential loading, the edge child spills and exits,
+    then the node child starts, sees the edge files as older than itself, and deletes files the
+    parent has not mapped yet. The marker below is an environment variable precisely because
+    ``spawn`` children inherit the environment, so a child can tell that its parent already did
+    this.
 
     Idempotent, and safe to call when spilling is disabled.
     """
@@ -176,7 +180,7 @@ class SpilledTensorHandle:
 class SpilledTensor:
     """A tensor living in a file, plus everything needed to re-map it elsewhere.
 
-    ``tensor`` is an mmap view; ``handle`` is the part that is safe to send elsewhere.
+    ``.tensor`` is an mmap view; ``.handle`` is the part that is safe to send elsewhere.
     """
 
     tensor: torch.Tensor
@@ -201,8 +205,6 @@ def load_spilled_tensor(
         ValueError: If ``dtype`` has no numpy equivalent, or the file is the wrong size for
             ``shape`` -- which would otherwise be read as silently wrong data.
     """
-    import numpy as np
-
     np_dtype = _NUMPY_DTYPES.get(dtype)
     if np_dtype is None:
         raise ValueError(f"Cannot map a spilled tensor of dtype {dtype}")
@@ -286,8 +288,6 @@ def _map_spill_file(path: str, np_dtype: str, shape: tuple[int, ...]) -> torch.T
     in-place mutation of loaded tensors, so a file that cannot be opened writable raises here,
     where the caller can fall back, instead of handing back storage that crashes on write.
     """
-    import numpy as np
-
     mapped = np.memmap(path, dtype=np_dtype, mode="r+", shape=shape)
     array = np.asarray(mapped)
     tensor = torch.from_numpy(array)
@@ -338,7 +338,8 @@ def _fadvise_dontneed(fd: int) -> None:
     """``POSIX_FADV_DONTNEED`` over the whole file (length 0 means to end of file).
 
     Raises ``OSError`` (ENOSYS) on platforms without ``posix_fadvise``, resolved with getattr
-    because the symbol does not exist off Linux, where the module must still import.
+    because the symbol does not exist off Linux, and macOS dev machines still import and
+    type-check this module (its tests skip there).
     """
     fadvise = getattr(os, "posix_fadvise", None)
     dontneed = getattr(os, "POSIX_FADV_DONTNEED", None)
@@ -427,8 +428,6 @@ def allocate_disk_backed(
         return None
     _ensure_spill_dir_prepared(spill_dir)
 
-    import numpy as np
-
     path: Optional[str] = None
     try:
         os.makedirs(spill_dir, exist_ok=True)
@@ -493,7 +492,6 @@ def _spill_to_mmap(tensor: torch.Tensor, spill_dir: str) -> Optional[SpilledTens
             f"share_memory: dtype {tensor.dtype} not spillable, using shared memory"
         )
         return None
-    import numpy as np
 
     path: Optional[str] = None
     try:
@@ -559,7 +557,9 @@ def _spill_to_mmap(tensor: torch.Tensor, spill_dir: str) -> Optional[SpilledTens
 def _shared_memory_backing_dir() -> str:
     """Where torch puts shared storages on Linux: ``/dev/shm``, under BOTH sharing strategies.
 
-    Measured rather than inferred, because the obvious reading of the docs is wrong. Under
+    Exists to point the free-space check below at the right mount: over-allocating tmpfs succeeds
+    and then SIGBUSes on the first write, so checking the wrong filesystem makes the guard
+    worthless. Measured rather than inferred, because the obvious reading of the docs is wrong. Under
     ``file_system`` torch calls ``_new_using_filename_cpu``, which sounds like an ordinary temporary
     file and is not: the storage lands in ``/dev/shm`` (observed:
     ``/dev/shm/torch_<pid>_<random>_0``, 16,000,064 bytes for a 16 MB tensor), and ``TMPDIR`` receives

--- a/gigl/utils/share_memory.py
+++ b/gigl/utils/share_memory.py
@@ -21,11 +21,9 @@ _KeyType = TypeVar("_KeyType")  # Generic Key Type
 # behaviour is exactly as before (everything goes to /dev/shm).
 #
 # Read from the ENVIRONMENT rather than passed as an argument on purpose: the dataset is
-# built inside `mp.spawn` (gigl/distributed/dataset_factory.py:468), which starts a fresh
-# interpreter. Module-level state set by a parent process does NOT survive that, but the
-# environment does -- it is inherited by the spawned child. An earlier attempt to control
-# this by monkey-patching from the trainer process was a silent no-op for exactly this
-# reason.
+# built inside `mp.spawn` (dataset_factory.py), which starts a fresh interpreter, so
+# module-level state set by a parent process does NOT survive but the environment does --
+# it is inherited by the spawned child
 _SPILL_DIR_ENV = "GIGL_TENSOR_SPILL_DIR"
 _SPILL_MIN_BYTES_ENV = "GIGL_TENSOR_SPILL_MIN_BYTES"
 # Set by whichever process cleans the spill directory, so its descendants know not to.
@@ -35,14 +33,11 @@ _DEFAULT_SPILL_MIN_BYTES = 2 * 2**30  # 2 GiB
 # queues and the sampling workers' channels all share it, and a shared storage that overruns the
 # mount takes SIGBUS on write rather than failing at allocation.
 _SHARED_MEMORY_RESERVE_BYTES = 2 * 2**30  # 2 GiB
-# Cgroup headroom to leave free when a scattered destination is placed in memory. Only what is
-# allocated AFTER this check runs belongs here -- at the measured worst case (the largest CSC of
-# a ~1B-node graph): the direct scatter's full-size cursor clone (indptr[:-1], 7.2 GiB anonymous)
-# and ~1 GiB of chunk/sort transients, ~8.2 GiB, so 16 leaves ~7.8 GiB of allocator/race margin.
-# The freshly written indptr's 7.2 GiB of dirty pages are NOT itemised: they are already charged
-# when this check reads the headroom. NOT covered: the next edge type; its own allocation re-runs
-# this check against whatever headroom is left, and falls back to the banded disk path if the
-# answer is no
+# Cgroup headroom to leave free when a scattered destination is placed in memory. Sized to what
+# is allocated AFTER this check runs (a CSR build's cursor clone and chunk/sort transients, which
+# together reach several GiB at large-graph scale) plus allocator and race margin. Already-charged
+# dirty pages are not itemised: the headroom read here reflects them. A later allocation re-runs
+# this check against whatever headroom is left and falls back to disk if the answer is no
 _DEFAULT_RANDOM_ACCESS_RESERVE_BYTES = 16 * 2**30  # 16 GiB
 
 _NUMPY_DTYPES = {
@@ -283,21 +278,17 @@ def disk_backed_handle(tensor: torch.Tensor) -> Optional[SpilledTensorHandle]:
 
 
 def _map_spill_file(path: str, np_dtype: str, shape: tuple[int, ...]) -> torch.Tensor:
-    """mmap a spill file as a torch tensor, writable when the file permits it.
+    """mmap a spill file as a torch tensor, always writable, or raise ``OSError``.
 
-    Prefers ``r+`` over ``r``. A read-only mapping is PROT_READ, and ``torch.from_numpy`` does not
-    enforce that -- an in-place write on the resulting tensor would reach the mapping and take a
-    SIGSEGV rather than raising. Downstream code (partitioning, label handling) is not audited for
-    in-place mutation of loaded tensors, so a writable mapping trades an unbounded crash risk for
-    dirtied page-cache pages, which is the cheaper failure. Unwritten pages stay clean and
-    evictable either way, which is the point of spilling.
+    Never falls back to a read-only mapping. A read-only mapping is PROT_READ, and
+    ``torch.from_numpy`` does not enforce that -- an in-place write on the resulting tensor would
+    reach the mapping and take a SIGSEGV rather than raising. Downstream code is not audited for
+    in-place mutation of loaded tensors, so a file that cannot be opened writable raises here,
+    where the caller can fall back, instead of handing back storage that crashes on write.
     """
     import numpy as np
 
-    try:
-        mapped = np.memmap(path, dtype=np_dtype, mode="r+", shape=shape)
-    except OSError:
-        mapped = np.memmap(path, dtype=np_dtype, mode="r", shape=shape)
+    mapped = np.memmap(path, dtype=np_dtype, mode="r+", shape=shape)
     array = np.asarray(mapped)
     tensor = torch.from_numpy(array)
     _register_mapping(
@@ -343,6 +334,19 @@ def spill_tensor_to_disk(tensor: torch.Tensor) -> Optional[SpilledTensor]:
     return _spill_to_mmap(tensor, spill_dir)
 
 
+def _fadvise_dontneed(fd: int) -> None:
+    """``POSIX_FADV_DONTNEED`` over the whole file (length 0 means to end of file).
+
+    Raises ``OSError`` (ENOSYS) on platforms without ``posix_fadvise``, resolved with getattr
+    because the symbol does not exist off Linux, where the module must still import.
+    """
+    fadvise = getattr(os, "posix_fadvise", None)
+    dontneed = getattr(os, "POSIX_FADV_DONTNEED", None)
+    if fadvise is None or dontneed is None:
+        raise OSError(errno.ENOSYS, "posix_fadvise is unavailable on this platform")
+    fadvise(fd, 0, 0, dontneed)
+
+
 def _reserve_file_blocks(fd: int, n_bytes: int, spill_dir: str) -> None:
     """Reserve every block of a spill file now, or raise ``OSError``.
 
@@ -351,18 +355,21 @@ def _reserve_file_blocks(fd: int, n_bytes: int, spill_dir: str) -> None:
     (``posix_fallocate`` unsupported) raises too: proceeding with an unreserved mapping would keep
     the SIGBUS window open, so the caller falls back to memory instead.
     """
+    # getattr rather than a direct reference: the symbol does not exist on non-Linux platforms,
+    # where the module must still import and merely refuse to spill
+    fallocate = getattr(os, "posix_fallocate", None)
+    if fallocate is None:
+        raise OSError(
+            errno.ENOSYS,
+            f"posix_fallocate is unavailable on this platform, so a "
+            f"{n_bytes / 2**30:.1f} GiB mapping under {spill_dir} cannot be made SIGBUS-safe",
+        )
     while True:
         try:
-            os.posix_fallocate(fd, 0, n_bytes)
+            fallocate(fd, 0, n_bytes)
             return
         except InterruptedError:
             continue  # EINTR: the syscall was interrupted, not refused
-        except AttributeError as no_fallocate:
-            raise OSError(
-                errno.ENOSYS,
-                f"posix_fallocate is unavailable on this platform, so a "
-                f"{n_bytes / 2**30:.1f} GiB mapping under {spill_dir} cannot be made SIGBUS-safe",
-            ) from no_fallocate
         except OSError as reserve_error:
             if reserve_error.errno in (errno.EOPNOTSUPP, errno.ENOSYS, errno.EINVAL):
                 # The filesystem cannot reserve. An unreserved mapping faults with SIGBUS if the
@@ -395,15 +402,10 @@ def allocate_disk_backed(
     an ``OSError`` at allocation time, where it can be reported and fallen back on; a filesystem
     that cannot reserve at all gets None rather than an unreserved mapping.
 
-    Measured cost of writing a 251-column fp32 matrix through the mapping instead of RAM: 46.8 s vs
-    15.1 s at 8M rows, so ~3.1x, i.e. roughly 6 minutes at the production shape by linear
-    extrapolation -- an estimate, not an upper bound, since the production pattern scatters ~938k
-    rows per chunk under cgroup dirty-page throttling.
-
-    What it buys: the destination's own bytes, ~56.42 GiB for a rank's node feature matrix, stop
-    being unreclaimable anonymous memory. The mapped pages are still charged to the cgroup, but as
-    page cache the kernel can reclaim them under pressure instead of OOM-killing. Freed chunk arenas
-    retained by the allocator are unaffected, so this does not remove the whole measured 1.63x peak.
+    Sequential writes through the mapping cost ~3.1x their in-memory equivalent (measured on a wide
+    fp32 matrix written row-by-row). What that buys: the destination's bytes stop being
+    unreclaimable anonymous memory -- still charged to the cgroup while resident, but reclaimable
+    page cache the kernel can evict under pressure instead of OOM-killing.
 
     Returns None whenever a file-backed buffer is not available or not worth it -- spilling disabled,
     below the size threshold, dtype with no numpy equivalent, no room to reserve, reservation
@@ -563,10 +565,9 @@ def _shared_memory_backing_dir() -> str:
     ``/dev/shm/torch_<pid>_<random>_0``, 16,000,064 bytes for a 16 MB tensor), and ``TMPDIR`` receives
     only a 4 KiB ``torch-shm-dir-*`` directory holding the libshm manager's socket. Under
     ``file_descriptor`` the segment is ``shm_open``ed and immediately unlinked, so nothing is visible
-    in the directory listing while it still consumes the mount's capacity.
-
-    An earlier version of this returned ``TMPDIR`` for ``file_system``, which would have sized the
-    check against the wrong filesystem in precisely the case the check exists for.
+    in the directory listing while it still consumes the mount's capacity. Returning ``TMPDIR``
+    for ``file_system`` would size the check against the wrong filesystem in precisely the case
+    the check exists for.
     """
     return "/dev/shm"
 
@@ -640,50 +641,25 @@ def allocate_preshared(
 ) -> torch.Tensor:
     """Allocate a large tensor in its FINAL home, so ``share_memory_()`` cannot duplicate it.
 
+    GLT's ``Graph.__init__`` shares the topology unconditionally, and for an anonymous tensor that
+    copies every byte into ``/dev/shm`` -- the tensor exists twice during the copy, fatal for a
+    tens-of-GiB CSR near the memory limit. Both homes here are immune to that copy: a spill file
+    (consumers that check :func:`is_disk_backed` leave it alone), or POSIX shared memory allocated
+    directly (``share_memory_()`` then finds it already shared and does nothing).
+
+    Disk-first for a destination written in order. A scatter destination prefers memory: an 8-byte
+    write to an uncached file page is a 4 KiB read-modify-write, repeated over the same pages, so
+    a file-backed scatter destination behaves like a hung run. With ``random_access=True`` a file
+    is only the checked, loudly-logged fallback for when memory will not hold the tensor.
+
+    Below the spill threshold returns a plain tensor. Uninitialised in all cases, like
+    ``torch.empty``.
+
     Args:
         shape: Shape of the tensor.
         dtype: Dtype of the tensor.
-        random_access: Set when the caller will write to SCATTERED offsets rather than stream
-            through in order. Then memory is preferred over a file and disk is a fallback, because
-            a file is catastrophically slower under that pattern -- see below. Defaults to False,
-            which keeps the disk-first behaviour that saves the most memory.
-
-    PLACEMENT
-        Disk-first is right for a destination written in order: one pass, sequential, and the bytes
-        become reclaimable page cache instead of unreclaimable anonymous memory.
-
-        It is badly wrong for a destination written by scatter. An 8-byte write to an uncached file
-        page costs a 4 KiB read-modify-write, and a chunked CSR build makes hundreds of passes over
-        the same millions of pages of a tens-of-GiB ``indices`` (measured: 251 passes over 8.2M
-        pages, 2.06 BILLION page touches, ~19 h at 60k IOPS). A production-scale run sat in exactly
-        that loop for over an hour at 4% CPU with memory flat, having logged nothing since the
-        allocation. The measured 3.1x cost of a file-backed destination came from a FEATURE matrix,
-        ~1000 contiguous bytes per row written once; carrying that ratio across to a scatter was an
-        extrapolation across a change in kind, not degree.
-
-        ``random_access=True`` therefore prefers shared memory, and falls back to a file only when
-        memory genuinely will not hold it -- logging the expected slowdown when it does, because a
-        silent fall back to disk here is a run that appears to hang.
-
-    WHY PRE-SHARED AT ALL
-    GLT's ``Graph.__init__`` calls ``Topology.share_memory_()`` unconditionally, and for an ordinary
-    anonymous tensor that copies every byte into ``/dev/shm``. The CSR therefore exists TWICE for the
-    duration of the copy. A production-scale run was killed one second after logging that its CSR was
-    built: indices 31.3 GiB + indptr 7.2 GiB duplicating to 77 GiB on top of an 84 GiB baseline,
-    against a limit under 160 GiB. No log line sits between the two, which is why it looked like the
-    CSR build itself.
-
-    Two backends, both immune to that copy:
-
-    * a file under ``GIGL_TENSOR_SPILL_DIR`` -- consumers that check :func:`is_disk_backed` before
-      sharing leave the tensor alone, and the bytes are reclaimable file pages rather than
-      unreclaimable anonymous memory (still cgroup-charged while resident);
-    * POSIX shared memory allocated directly -- ``share_memory_()`` then finds it already shared and
-      does nothing (verified: ``data_ptr`` unchanged across the call).
-
-    Below the spill threshold it returns a plain tensor, where a duplicate costs little.
-
-    Uninitialised in both cases, like ``torch.empty``.
+        random_access: Set when the caller will write to scattered offsets rather than stream
+            through in order; memory is then preferred and disk the checked fallback.
     """
     n_bytes = torch.empty(0, dtype=dtype).element_size()
     for extent in shape:
@@ -719,7 +695,7 @@ def allocate_preshared(
         # the first write past the limit takes SIGBUS, which no `except` can catch.
         #
         # Returning an anonymous tensor is equally unsafe, which is the part that is easy to get
-        # wrong: `_build_topology_without_edge_ids` would then pick a plain `Topology`, and
+        # wrong: the topology builder would then pick a plain in-memory topology, and
         # `Graph.__init__` calls GLT's UNGUARDED `share_memory_()` on it -- attempting the very same
         # oversized allocation on the very same full mount, a few seconds later and with no
         # attribution back to here. A warning-and-continue only moves the SIGBUS somewhere harder to
@@ -730,8 +706,8 @@ def allocate_preshared(
         raise RuntimeError(
             f"Cannot allocate {_human_bytes(n_bytes)} {tuple(shape)} {dtype} without risking SIGBUS: "
             f"{shortfall}. Continuing is not safe -- an anonymous tensor this size is relocated into "
-            f"the same full mount by graphlearn_torch's Graph.__init__, and that copy has OOM-killed "
-            f"real runs. Either set GIGL_TENSOR_SPILL_DIR to a filesystem with room "
+            f"the same full mount by graphlearn_torch's Graph.__init__, a few seconds later and "
+            f"with no attribution back to here. Either set GIGL_TENSOR_SPILL_DIR to a filesystem with room "
             f"(the intended configuration; the CSR is then file-backed and never copied), or raise "
             f"the container's shared-memory limit."
         )
@@ -782,23 +758,16 @@ def has_live_mapping(path: str) -> bool:
 def release_page_cache_by_path(path: str) -> bool:
     """Request eviction of a spill file's page cache when nothing maps it any more.
 
-    The counterpart to :func:`release_page_cache` for a tensor that has already been dropped. Once no
-    mapping remains there are no page-table entries to clear, so ``FADV_DONTNEED`` alone is
-    sufficient -- the reason the tensor version needs ``MADV_DONTNEED`` first does not apply.
+    The counterpart to :func:`release_page_cache` for a tensor already dropped: ``del`` unmaps it
+    but leaves the file's pages charged to the cgroup until the kernel reclaims them.
 
-    This is what a consumed input needs. ``del`` on an mmap-backed tensor unmaps it but leaves the
-    file's pages charged to the cgroup until the kernel reclaims them, so an input and an output of
-    the same size are both charged while the output is being written.
+    Refuses when a mapping is still live: ``FADV_DONTNEED`` silently skips pages present in any
+    page table, so it would return success having freed nothing. Use :func:`release_page_cache` on
+    the tensor in that case, which unmaps first.
 
-    Refuses when a mapping is still live, because ``FADV_DONTNEED`` SILENTLY SKIPS pages that are in
-    any page table -- it would return success having freed nothing. One stale reference (a tuple
-    built for a call, a name the caller forgot to drop) is enough to turn this into a no-op, and
-    without this check the caller logs a saving it did not get. Use :func:`release_page_cache` on the
-    tensor itself in that case, which unmaps first.
-
-    Returns True if the eviction was REQUESTED -- ``FADV_DONTNEED`` is advisory and reports no
-    count, so "requested" is all success can mean without measuring residency. False if a mapping
-    is still live, the file could not be opened, or the platform lacks ``posix_fadvise``.
+    Returns True if the eviction was REQUESTED (``FADV_DONTNEED`` is advisory and reports no
+    count); False if a mapping is still live, the file could not be opened, or the platform lacks
+    ``posix_fadvise``.
     """
     if has_live_mapping(path):
         logger.warning(
@@ -814,8 +783,8 @@ def release_page_cache_by_path(path: str) -> bool:
         return False
     try:
         os.fsync(fd)
-        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
-    except (AttributeError, OSError) as e:
+        _fadvise_dontneed(fd)
+    except OSError as e:
         logger.info(f"share_memory: could not drop page cache for {path}: {e}")
         return False
     finally:
@@ -826,37 +795,21 @@ def release_page_cache_by_path(path: str) -> bool:
 def release_page_cache(tensor: torch.Tensor) -> bool:
     """Write a disk-backed tensor's dirty pages out and ask the kernel to drop them from the cache.
 
-    Moving a tensor to a file changes the KIND of memory it occupies, not whether it is charged:
-    cgroup v2 counts page cache in ``memory.current``, so a 56.4 GiB feature matrix on the spill
-    filesystem still counts against the container's limit -- reclaimable rather than OOM-triggering,
-    but counted. A production-scale run died with exactly that 56.4 GiB charged alongside the CSR
-    build's anonymous allocations, within a few GiB of its limit.
-
-    Dropping the cache once the file is written releases the charge as the pages go (writeback can
-    briefly delay stragglers; the fsync below bounds that). The mapping stays
-    valid; pages fault back in on next access, so this costs a cold first read and nothing else.
-    Worth doing only for a tensor that is written now and not read until much later -- the
-    partitioned node features, which are written before the graph build and not touched again until
-    sampling starts.
+    A spilled tensor's pages are reclaimable but still charged to cgroup v2's ``memory.current``
+    while resident; dropping them releases the charge. The mapping stays valid and refaults on
+    next access, so this is worth it only for data written now and not read until much later.
 
     Three steps, in this order, and every one is load-bearing:
 
     1. ``msync`` through the backing memmap -- dirty pages cannot be dropped at all.
-    2. ``MADV_DONTNEED`` on the mapping -- removes this process's page-table entries.
+    2. ``MADV_DONTNEED`` on the mapping -- removes this process's page-table entries. Without it
+       step 3 silently skips every still-mapped page and reports success having freed nothing.
     3. ``fsync`` then ``POSIX_FADV_DONTNEED`` -- discards the now-unmapped clean page cache.
 
-    Step 2 is the one that is easy to omit and fatal to omit. Linux implements ``FADV_DONTNEED`` via
-    ``invalidate_mapping_pages()``, which SKIPS any page currently mapped into a page table, so
-    calling it alone on a live mapping leaves every page resident and charged while returning
-    success. ``MADV_DONTNEED`` is safe here only because the mapping is file-backed and has just been
-    flushed; on an anonymous mapping it would discard the data outright.
-
-    Returns True when every eviction step COMPLETED, which is not the same as proof that every page
-    went: ``FADV_DONTNEED`` is advisory and reports no count, and another process holding live PTEs on
-    the same file can keep pages resident. False means the sequence was incomplete -- not disk-backed,
-    no live mapping, or a failing step -- and note that a failure after step 2 leaves this process's
-    PTEs already dropped, so False does not mean nothing changed. To know what was actually evicted,
-    measure residency with ``mincore``; the tests do exactly that.
+    Returns True when every step COMPLETED -- ``FADV_DONTNEED`` is advisory, so completion is not
+    proof of eviction; measure residency with ``mincore`` to know (the tests do). False means the
+    sequence was incomplete, though a failure after step 2 has already dropped this process's
+    page-table entries.
     """
     handle = disk_backed_handle(tensor)
     if handle is None:
@@ -882,16 +835,9 @@ def release_page_cache(tensor: torch.Tensor) -> bool:
         logger.warning(f"share_memory: could not msync {handle.path}: {e}")
         return False
 
-    # STEP ORDER MATTERS, and getting it wrong makes this whole function a silent no-op.
-    #
-    # POSIX_FADV_DONTNEED alone does nothing here: Linux implements it via
-    # invalidate_mapping_pages(), which SKIPS any page currently mapped into a page table. With the
-    # tensor still mapped, every one of those pages stays resident and stays charged to the cgroup --
-    # while the call returns success. So the PTEs have to go first.
-    #
-    # MADV_DONTNEED on a shared FILE mapping only drops this process's page-table entries; the next
-    # access refaults from the file. (On an anonymous mapping it would discard the data -- this is
-    # only safe because the mapping is file-backed and has just been msync'd.)
+    # Step 2 of the docstring's order: the page-table entries must go before FADV_DONTNEED, and
+    # MADV_DONTNEED is only safe because the mapping is file-backed and has just been msync'd (on
+    # an anonymous mapping it would discard the data)
     mapping = getattr(backing, "_mmap", None)
     if mapping is None or not hasattr(mapping, "madvise"):
         logger.info(
@@ -917,9 +863,8 @@ def release_page_cache(tensor: torch.Tensor) -> bool:
         return False
     try:
         os.fsync(fd)
-        # length 0 means "to end of file".
-        os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
-    except (AttributeError, OSError) as e:
+        _fadvise_dontneed(fd)
+    except OSError as e:
         logger.info(
             f"share_memory: could not drop page cache for {handle.path} ({e}); its pages stay "
             f"charged to the cgroup until the kernel reclaims them"
@@ -956,16 +901,10 @@ def share_memory(
     provide a ForkingPickler registration method for the `RangePartitionBook`, and the cost of not moving this to shared memory is minimal,
     since the size of this tensor is very small, being equal in length to the number of machines.
 
-    This function does NOT spill to disk, deliberately. Its callers hand the result to another
-    process, and a spill whose path is not carried alongside it is undone the moment the tensor is
-    pickled -- torch copies a numpy-owned storage into ``/dev/shm``, so spilling here would cost a
-    full disk write AND the full RAM copy it was meant to avoid. Spilling belongs where a
-    descriptor travels with the tensor: :func:`share_memory_for_ipc` and
-    :func:`spill_tensor_to_disk`.
-
-    A tensor that is ALREADY disk-backed is left alone for the same reason. ``share_memory_()`` on
-    such a tensor copies every byte into ``/dev/shm`` -- measured at +16,128 kB for a 16 MiB
-    tensor -- which would quietly undo a spill made earlier and elsewhere.
+    This function never spills to disk, and a tensor that is ALREADY disk-backed is left alone:
+    ``share_memory_()`` on an mmap-backed tensor copies every byte into ``/dev/shm``, quietly
+    undoing a spill made elsewhere. Spilling belongs where a descriptor travels with the tensor --
+    :func:`share_memory_for_ipc` and :func:`spill_tensor_to_disk`.
 
     Args:
         entity (Optional[Union[torch.Tensor, PartitionBook, dict[_KeyType, torch.Tensor], dict[_KeyType, PartitionBook]]]):

--- a/gigl/utils/share_memory.py
+++ b/gigl/utils/share_memory.py
@@ -1,15 +1,22 @@
+import ctypes
 import errno
+import math
 import mmap
 import os
 import tempfile
-import weakref
 from collections import abc
-from dataclasses import dataclass
-from typing import Any, Optional, TypeVar, Union, cast
+from multiprocessing.reduction import ForkingPickler
+from typing import Optional, TypeVar, Union, cast
 
-import numpy as np
 import torch
+
+# Imported for its side effect as much as its symbols: importing torch.multiprocessing runs
+# init_reductions(), which registers torch's reducer for torch.Tensor. The spill-aware reducer near
+# the bottom of this module must register AFTER that so it replaces torch's entry; a later import
+# of torch.multiprocessing elsewhere is a cached no-op and cannot clobber it
+import torch.multiprocessing
 from graphlearn_torch.partition import PartitionBook, RangePartitionBook
+from torch.multiprocessing.reductions import reduce_tensor as _torch_reduce_tensor
 
 from gigl.common.logger import Logger
 from gigl.utils.host_memory import available_memory_bytes
@@ -41,13 +48,17 @@ _SHARED_MEMORY_RESERVE_BYTES = 2 * 2**30  # 2 GiB
 # this check against whatever headroom is left and falls back to disk if the answer is no
 _DEFAULT_RANDOM_ACCESS_RESERVE_BYTES = 16 * 2**30  # 16 GiB
 
-_NUMPY_DTYPES = {
-    torch.float32: "float32",
-    torch.float16: "float16",
-    torch.int64: "int64",
-    torch.int32: "int32",
-    torch.uint8: "uint8",
-}
+# Quantized tensors carry a quantizer beside their storage; rebuilding one from raw bytes produces
+# a tensor that trips internal torch assertions on first use (qscheme, copy_). Refused rather than
+# mapped wrong
+_UNSPILLABLE_DTYPES = frozenset(
+    dtype
+    for dtype in (
+        getattr(torch, name, None)
+        for name in ("qint8", "quint8", "qint32", "quint4x2", "quint2x4")
+    )
+    if dtype is not None
+)
 
 
 def prepare_spill_dir() -> None:
@@ -130,10 +141,6 @@ def _ensure_spill_dir_prepared(spill_dir: str) -> None:
 _cleared_spill_dirs: set[str] = set()
 _SPILL_PREFIX = "spill_"
 
-# (start address, byte length, weak reference to the backing array, descriptor) for every live spill
-# mapping in this process. See _register_mapping for why this cannot be read back off the tensor.
-_spilled_mappings: list[tuple[int, int, "weakref.ref[Any]", "SpilledTensorHandle"]] = []
-
 
 def _spill_dir() -> Optional[str]:
     d = os.environ.get(_SPILL_DIR_ENV)
@@ -157,151 +164,81 @@ def is_tensor_spilling_enabled() -> bool:
     return _spill_dir() is not None
 
 
-@dataclass(frozen=True)
-class SpilledTensorHandle:
-    """Where a spilled tensor lives, with no tensor attached, so it is cheap to pickle.
+def is_disk_backed(tensor: torch.Tensor) -> bool:
+    """Whether ``tensor`` (or a view of one) is an mmap over a real file rather than RAM.
 
-    This is what crosses a process boundary in place of the tensor. Sending the tensor instead
-    silently undoes the spill: torch's multiprocessing reduction does not consider a numpy-owned
-    storage shareable, so pickling copies every byte into RAM-backed ``/dev/shm`` (measured: Shmem
-    +383 MiB on a 383 MiB tensor). Call :func:`load_spilled_tensor` on the far side.
+    Read off the tensor itself: a storage created by ``from_file(shared=True)`` records the path
+    in ``untyped_storage().filename``, and a view shares its base's storage, so the label travels
+    with it. ``filename`` is None for everything else -- including tmpfs-shared storages
+    (``share_memory_()``, ``_new_shared``), which are RAM and must not be treated as spilled.
     """
-
-    path: str
-    dtype: torch.dtype
-    shape: tuple[int, ...]
-
-    def load(self) -> torch.Tensor:
-        """Re-map the tensor in the current process."""
-        return load_spilled_tensor(self.path, self.dtype, self.shape)
+    if not isinstance(tensor, torch.Tensor) or tensor.device.type != "cpu":
+        return False
+    if tensor.layout is not torch.strided:
+        return False
+    return tensor.untyped_storage().filename is not None
 
 
-@dataclass(frozen=True)
-class SpilledTensor:
-    """A tensor living in a file, plus everything needed to re-map it elsewhere.
+def _contiguous_strides(shape: tuple[int, ...]) -> tuple[int, ...]:
+    """Row-major strides for ``shape``, computed because ``set_`` with a size requires a stride."""
+    stride = [1] * len(shape)
+    for axis in range(len(shape) - 2, -1, -1):
+        stride[axis] = stride[axis + 1] * int(shape[axis + 1])
+    return tuple(stride)
 
-    ``.tensor`` is an mmap view; ``.handle`` is the part that is safe to send elsewhere.
+
+def _tensor_over_file(
+    path: str, dtype: torch.dtype, shape: tuple[int, ...]
+) -> torch.Tensor:
+    """A writable tensor mapped over the whole of ``path``, or raise ``OSError``.
+
+    ``shared=True`` is MAP_SHARED: always writable, writes reach the file, and the storage records
+    ``path`` in ``filename`` -- which is what marks the tensor disk-backed everywhere else in this
+    module and makes it pickle by path. A read-only mapping is never handed back: downstream code
+    is not audited for in-place mutation, and a write through PROT_READ storage is a SIGSEGV, not
+    an exception.
     """
-
-    tensor: torch.Tensor
-    path: str
-    dtype: torch.dtype
-    shape: tuple[int, ...]
-
-    @property
-    def handle(self) -> SpilledTensorHandle:
-        return SpilledTensorHandle(path=self.path, dtype=self.dtype, shape=self.shape)
+    n_bytes = math.prod(shape) * torch.empty(0, dtype=dtype).element_size()
+    # cast because the stub types from_file's return as the storage base class, which set_ rejects
+    storage = cast(
+        torch.UntypedStorage,
+        torch.UntypedStorage.from_file(path, shared=True, nbytes=n_bytes),
+    )
+    tensor = torch.empty(0, dtype=dtype)
+    tensor.set_(storage, 0, tuple(shape), _contiguous_strides(tuple(shape)))
+    return tensor
 
 
 def load_spilled_tensor(
     path: str, dtype: torch.dtype, shape: tuple[int, ...]
 ) -> torch.Tensor:
-    """Re-map a spilled tensor in another process, without copying its bytes anywhere.
+    """Re-map a spilled tensor in the current process, without copying its bytes anywhere.
 
-    The counterpart to :func:`spill_tensor_to_disk`. Pass ``SpilledTensor``'s path, dtype and
-    shape through whatever IPC channel is available and call this on the far side.
+    The counterpart to :func:`spill_tensor_to_disk` for a path that arrived through some channel
+    other than pickling a tensor (pickling already re-maps by itself).
 
     Raises:
-        ValueError: If ``dtype`` has no numpy equivalent, or the file is the wrong size for
-            ``shape`` -- which would otherwise be read as silently wrong data.
+        ValueError: If the file is the wrong size for ``shape`` -- which would otherwise be read
+            as silently wrong data.
+        OSError: If the file cannot be mapped writable.
     """
-    np_dtype = _NUMPY_DTYPES.get(dtype)
-    if np_dtype is None:
-        raise ValueError(f"Cannot map a spilled tensor of dtype {dtype}")
-    expected_bytes = int(np.prod(shape)) * torch.empty(0, dtype=dtype).element_size()
+    expected_bytes = math.prod(shape) * torch.empty(0, dtype=dtype).element_size()
     actual_bytes = os.path.getsize(path)
     if actual_bytes != expected_bytes:
         raise ValueError(
             f"Spill file {path} is {actual_bytes} bytes but {shape} of {dtype} needs "
             f"{expected_bytes}. Refusing to map it."
         )
-    return _map_spill_file(path, np_dtype, tuple(shape))
+    return _tensor_over_file(path, dtype, tuple(shape))
 
 
-def _register_mapping(
-    array: Any, tensor: torch.Tensor, handle: SpilledTensorHandle
-) -> None:
-    """Remember that ``tensor``'s bytes live in a file, so ``share_memory`` can refuse to copy them.
+def spill_tensor_to_disk(tensor: torch.Tensor) -> Optional[torch.Tensor]:
+    """Write ``tensor`` to disk and return a tensor mapped over the file, or ``None`` to keep it.
 
-    Needed because the fact is not recoverable from the tensor: ``tensor.numpy().base`` is the
-    tensor itself, and ``untyped_storage().filename`` is None for a storage adopted from numpy
-    (both measured). Without a registry, ``share_memory_()`` on a spilled tensor silently relocates
-    it into ``/dev/shm`` -- measured at +16,128 kB for a 16 MiB tensor -- undoing the spill at a
-    point far from where it was made.
-
-    The reference to ``array`` is weak, so an entry disappears when the mapping does. Views of a
-    spilled tensor point inside the recorded range and are recognised too.
-    """
-    nbytes = tensor.numel() * tensor.element_size()
-    _spilled_mappings[:] = [
-        entry for entry in _spilled_mappings if entry[2]() is not None
-    ]
-    _spilled_mappings.append((tensor.data_ptr(), nbytes, weakref.ref(array), handle))
-
-
-def is_disk_backed(tensor: torch.Tensor) -> bool:
-    """Whether ``tensor`` (or a view of one) is an mmap over a spill file rather than RAM."""
-    if not isinstance(tensor, torch.Tensor) or tensor.device.type != "cpu":
-        return False
-    pointer = tensor.data_ptr()
-    for start, nbytes, reference, _ in _spilled_mappings:
-        if reference() is not None and start <= pointer < start + nbytes:
-            return True
-    return False
-
-
-def disk_backed_handle(tensor: torch.Tensor) -> Optional[SpilledTensorHandle]:
-    """The spill descriptor for a tensor that IS an entire spill mapping, else None.
-
-    A partial view does not qualify: a descriptor names a whole file, so it cannot describe a
-    slice of one. Lets a caller re-send an already-spilled tensor by path instead of spilling a
-    second copy of it.
-
-    Requires the tensor to be CONTIGUOUS with no storage offset, not merely to have the right start
-    address and element count. A transpose of a square mmap tensor has the same pointer, shape and
-    numel as the original but reads the file in the wrong order, so matching on those alone would
-    hand the receiver transposed data described as untransposed -- silently wrong values rather than
-    an error.
-    """
-    if not isinstance(tensor, torch.Tensor) or tensor.device.type != "cpu":
-        return None
-    if not tensor.is_contiguous() or tensor.storage_offset() != 0:
-        return None
-    for start, nbytes, reference, handle in _spilled_mappings:
-        if (
-            reference() is not None
-            and start == tensor.data_ptr()
-            and nbytes == tensor.numel() * tensor.element_size()
-            and tuple(tensor.shape) == tuple(handle.shape)
-            and tensor.dtype == handle.dtype
-        ):
-            return handle
-    return None
-
-
-def _map_spill_file(path: str, np_dtype: str, shape: tuple[int, ...]) -> torch.Tensor:
-    """mmap a spill file as a torch tensor, always writable, or raise ``OSError``.
-
-    Never falls back to a read-only mapping. A read-only mapping is PROT_READ, and
-    ``torch.from_numpy`` does not enforce that -- an in-place write on the resulting tensor would
-    reach the mapping and take a SIGSEGV rather than raising. Downstream code is not audited for
-    in-place mutation of loaded tensors, so a file that cannot be opened writable raises here,
-    where the caller can fall back, instead of handing back storage that crashes on write.
-    """
-    mapped = np.memmap(path, dtype=np_dtype, mode="r+", shape=shape)
-    array = np.asarray(mapped)
-    tensor = torch.from_numpy(array)
-    _register_mapping(
-        array, tensor, SpilledTensorHandle(path=path, dtype=tensor.dtype, shape=shape)
-    )
-    return tensor
-
-
-def spill_tensor_to_disk(tensor: torch.Tensor) -> Optional[SpilledTensor]:
-    """Write ``tensor`` to disk and return a :class:`SpilledTensor`, or ``None`` to keep it.
-
-    ``None`` covers every reason not to spill -- spilling disabled, tensor below the threshold,
-    unsupported dtype, IO failure -- so callers can treat it as "keep what you had".
+    ``None`` covers every reason not to spill -- spilling disabled, tensor below the threshold, IO
+    failure -- so callers can treat it as "keep what you had". The returned tensor's storage knows
+    its file (:func:`is_disk_backed`), so :func:`share_memory` leaves it alone and pickling ships
+    the path rather than the bytes.
 
     Exposed for callers that hold a tensor directly rather than inside a Mapping, which
     :func:`share_memory` cannot substitute into. The partitioned node feature matrix is the case
@@ -313,25 +250,24 @@ def spill_tensor_to_disk(tensor: torch.Tensor) -> Optional[SpilledTensor]:
         return None
     if 0 in tensor.shape:
         return None
-    # Already living in a file -- most likely allocated by allocate_disk_backed rather than filled in
-    # memory and spilled. Copying it to a second file would double the disk use and the time for no
-    # benefit, so hand back a descriptor for the file it is already in.
-    existing = disk_backed_handle(tensor)
-    if existing is not None:
+    if tensor.is_quantized:
+        logger.warning(
+            f"share_memory: dtype {tensor.dtype} not spillable, using shared memory"
+        )
+        return None
+    # Already living in a file -- most likely allocated by allocate_disk_backed rather than filled
+    # in memory and spilled. Copying it to a second file would double the disk use and the time
+    # for no benefit
+    if is_disk_backed(tensor):
         logger.info(
             f"share_memory: {tuple(tensor.shape)} {tensor.dtype} is already on disk at "
-            f"{existing.path}; not writing a second copy"
+            f"{tensor.untyped_storage().filename}; not writing a second copy"
         )
-        return SpilledTensor(
-            tensor=tensor,
-            path=existing.path,
-            dtype=existing.dtype,
-            shape=existing.shape,
-        )
+        return tensor
     if tensor.numel() * tensor.element_size() < _spill_min_bytes():
         return None
     _ensure_spill_dir_prepared(spill_dir)
-    return _spill_to_mmap(tensor, spill_dir)
+    return _spill_to_file(tensor, spill_dir)
 
 
 def _fadvise_dontneed(fd: int) -> None:
@@ -396,34 +332,31 @@ def allocate_disk_backed(
     memory at all.
 
     Blocks are RESERVED up front with ``posix_fallocate`` rather than left sparse, and reservation
-    is mandatory. ``np.memmap(mode="w+")`` gives the file its full apparent size without allocating
-    it, so a filesystem that fills later fails at the moment a page is written -- and a write to a
-    mapping that cannot be backed raises **SIGBUS**, which is a signal, not an exception: it
-    bypasses every ``try`` here and kills the process with no traceback. Reserving turns that into
-    an ``OSError`` at allocation time, where it can be reported and fallen back on; a filesystem
-    that cannot reserve at all gets None rather than an unreserved mapping.
+    is mandatory. ``from_file`` gives the file its full apparent size without allocating it, so a
+    filesystem that fills later fails at the moment a page is written -- and a write to a mapping
+    that cannot be backed raises **SIGBUS**, which is a signal, not an exception: it bypasses
+    every ``try`` here and kills the process with no traceback. Reserving turns that into an
+    ``OSError`` at allocation time, where it can be reported and fallen back on; a filesystem that
+    cannot reserve at all gets None rather than an unreserved mapping.
 
     Sequential writes through the mapping cost ~3.1x their in-memory equivalent (measured on a wide
     fp32 matrix written row-by-row). What that buys: the destination's bytes stop being
     unreclaimable anonymous memory -- still charged to the cgroup while resident, but reclaimable
     page cache the kernel can evict under pressure instead of OOM-killing.
 
-    Returns None whenever a file-backed buffer is not available or not worth it -- spilling disabled,
-    below the size threshold, dtype with no numpy equivalent, no room to reserve, reservation
-    unsupported by the filesystem, IO failure -- so callers can simply fall back to ``torch.empty``.
+    Returns None whenever a file-backed buffer is not available or not worth it -- spilling
+    disabled, below the size threshold, quantized dtype, no room to reserve, reservation
+    unsupported by the filesystem, IO failure -- so callers can simply fall back to
+    ``torch.empty``.
     """
     spill_dir = _spill_dir()
     if spill_dir is None:
         return None
     if 0 in shape:
         return None
-    np_dtype = _NUMPY_DTYPES.get(dtype)
-    if np_dtype is None:
+    if dtype in _UNSPILLABLE_DTYPES:
         return None
-    element_size = torch.empty(0, dtype=dtype).element_size()
-    n_bytes = element_size
-    for extent in shape:
-        n_bytes *= extent
+    n_bytes = math.prod(shape) * torch.empty(0, dtype=dtype).element_size()
     if n_bytes < _spill_min_bytes():
         return None
     _ensure_spill_dir_prepared(spill_dir)
@@ -436,22 +369,9 @@ def allocate_disk_backed(
             _reserve_file_blocks(fd, n_bytes, spill_dir)
         finally:
             os.close(fd)
-        # "r+", NOT "w+": the file is already sized by the reservation, and numpy opens "w+" as
-        # `w+b`, which TRUNCATES the file and hands back every block just reserved -- leaving it
-        # sparse again and the SIGBUS risk exactly where it was
-        mapped = np.memmap(
-            path,
-            dtype=np_dtype,
-            mode="r+",
-            shape=tuple(shape),
-        )
-        array = np.asarray(mapped)
-        tensor = torch.from_numpy(array)
-        _register_mapping(
-            array,
-            tensor,
-            SpilledTensorHandle(path=path, dtype=dtype, shape=tuple(shape)),
-        )
+        # Mapped only AFTER the reservation. from_file leaves an existing file's allocated blocks
+        # intact (the tests hold this), so the mapping below is fully backed and SIGBUS-safe
+        tensor = _tensor_over_file(path, dtype, tuple(shape))
         logger.info(
             f"share_memory: allocated {n_bytes / 2**30:.1f} GiB buffer {tuple(shape)} {dtype} "
             f"on disk at {path} instead of in anonymous memory"
@@ -470,38 +390,26 @@ def allocate_disk_backed(
         return None
 
 
-def _spill_to_mmap(tensor: torch.Tensor, spill_dir: str) -> Optional[SpilledTensor]:
-    """Write ``tensor`` to a file under ``spill_dir`` and return an mmap view of it.
+def _spill_to_file(tensor: torch.Tensor, spill_dir: str) -> Optional[torch.Tensor]:
+    """Write ``tensor`` to a file under ``spill_dir`` and return a tensor mapped over it.
 
-    Returns None if the tensor cannot be spilled (unsupported dtype, reservation refused by the
-    filesystem, IO failure), in which case the caller should keep the tensor it already had.
+    Returns None if the tensor cannot be spilled (reservation refused by the filesystem, IO
+    failure), in which case the caller should keep the tensor it already had.
 
     Why this helps: ``/dev/shm`` is tmpfs, i.e. RAM. Node features for a ~1B-node graph approach
     a terabyte at fp32; even split across replicas that is the largest resident tensor, and
     ``share_memory_()`` costs 1x in tmpfs plus a transient 2x in RSS. Backing the bytes with
     a real file turns them into evictable page cache instead.
-
-    NOTE the mapping only stays file-backed within this process. Torch's multiprocessing reduction
-    copies a numpy-owned storage into shared memory when the tensor is pickled, so anything that
-    ships this tensor to another process undoes the spill. Ship ``SpilledTensor.path`` and call
-    :func:`load_spilled_tensor` on the far side instead.
     """
-    np_dtype = _NUMPY_DTYPES.get(tensor.dtype)
-    if np_dtype is None:
-        logger.warning(
-            f"share_memory: dtype {tensor.dtype} not spillable, using shared memory"
-        )
-        return None
-
     path: Optional[str] = None
     try:
         os.makedirs(spill_dir, exist_ok=True)
         n_bytes = tensor.numel() * tensor.element_size()
         # mkstemp, not a name derived from shape and byte count. A derived name collides for two
         # tensors with the same shape and element width -- including different dtypes of the same
-        # width -- and reopening that path with mode="w+" TRUNCATES the file still backing the
-        # first tensor's live read-only mapping, silently replacing its contents. Nothing would
-        # raise; the features would simply be wrong.
+        # width -- and reopening and resizing that path would silently replace the contents still
+        # backing the first tensor's live mapping. Nothing would raise; the features would simply
+        # be wrong
         fd, path = tempfile.mkstemp(dir=spill_dir, prefix=_SPILL_PREFIX, suffix=".bin")
         try:
             # Same SIGBUS-safety rule as allocate_disk_backed: every block is reserved before the
@@ -510,9 +418,7 @@ def _spill_to_mmap(tensor: torch.Tensor, spill_dir: str) -> Optional[SpilledTens
             _reserve_file_blocks(fd, n_bytes, spill_dir)
         finally:
             os.close(fd)
-        # "r+", not "w+": the reservation already sized the file, and "w+" would truncate the
-        # reserved blocks away
-        writable = np.memmap(path, dtype=np_dtype, mode="r+", shape=tuple(tensor.shape))
+        writable = _tensor_over_file(path, tensor.dtype, tuple(tensor.shape))
         # Copy in ~1 GiB slices so we never hold a second full-size buffer.
         row_bytes = (
             max(1, int(tensor[0].numel()) * tensor.element_size())
@@ -521,25 +427,25 @@ def _spill_to_mmap(tensor: torch.Tensor, spill_dir: str) -> Optional[SpilledTens
         )
         rows = max(1, int(2**30 // row_bytes))
         for start in range(0, tensor.shape[0], rows):
-            writable[start : start + rows] = tensor[start : start + rows].numpy()
-        writable.flush()
-        del writable
+            writable[start : start + rows].copy_(tensor[start : start + rows])
+        # msync equivalent: fsync writes back the pages the copy just dirtied, so the data is on
+        # disk and a later release_page_cache has clean pages to drop
+        flush_fd = os.open(path, os.O_RDWR)
+        try:
+            os.fsync(flush_fd)
+        finally:
+            os.close(flush_fd)
         logger.info(
             f"share_memory: spilled {n_bytes / 2**30:.1f} GiB to {path} instead of /dev/shm"
         )
-        return SpilledTensor(
-            tensor=_map_spill_file(path, np_dtype, tuple(tensor.shape)),
-            path=path,
-            dtype=tensor.dtype,
-            shape=tuple(tensor.shape),
-        )
+        return writable
     except Exception as e:  # noqa: BLE001
-        # Unlink the partial file. mkstemp has already created it, so a failure in the mmap, the
-        # copy, the flush or the remap would otherwise leave its bytes on disk with nothing
-        # referencing them. That matters most in the case that causes the failure: the spill
-        # filesystem is finite and node features are tens of GiB per replica, so a couple of failed
-        # attempts can exhaust the disk and push the tensors back into RAM -- turning a recoverable
-        # spill failure into the OOM this whole mechanism exists to avoid
+        # Unlink the partial file. mkstemp has already created it, so a failure in the mapping,
+        # the copy or the flush would otherwise leave its bytes on disk with nothing referencing
+        # them. That matters most in the case that causes the failure: the spill filesystem is
+        # finite and node features are tens of GiB per replica, so a couple of failed attempts can
+        # exhaust the disk and push the tensors back into RAM -- turning a recoverable spill
+        # failure into the OOM this whole mechanism exists to avoid
         if path is not None:
             try:
                 os.unlink(path)
@@ -661,9 +567,7 @@ def allocate_preshared(
         random_access: Set when the caller will write to scattered offsets rather than stream
             through in order; memory is then preferred and disk the checked fallback.
     """
-    n_bytes = torch.empty(0, dtype=dtype).element_size()
-    for extent in shape:
-        n_bytes *= extent
+    n_bytes = math.prod(shape) * torch.empty(0, dtype=dtype).element_size()
 
     prefer_memory = random_access and _memory_is_the_better_home(n_bytes) is None
     if not prefer_memory:
@@ -718,12 +622,7 @@ def allocate_preshared(
     try:
         storage = torch.UntypedStorage._new_shared(n_bytes)
         tensor = torch.empty(0, dtype=dtype)
-        # Contiguous strides, computed rather than left to be inferred: the typed overload of `set_`
-        # that takes a size also requires a stride.
-        stride: list[int] = [1] * len(shape)
-        for axis in range(len(shape) - 2, -1, -1):
-            stride[axis] = stride[axis + 1] * int(shape[axis + 1])
-        tensor.set_(storage, 0, tuple(shape), tuple(stride))
+        tensor.set_(storage, 0, tuple(shape), _contiguous_strides(tuple(shape)))
         logger.info(
             f"share_memory: allocated {_human_bytes(n_bytes)} {tuple(shape)} {dtype} directly in "
             f"shared memory, so share_memory_() will not copy it"
@@ -744,15 +643,18 @@ def allocate_preshared(
 
 
 def has_live_mapping(path: str) -> bool:
-    """Whether some tensor in this process still maps ``path``.
+    """Whether THIS process still maps ``path``, read from ``/proc/self/maps``.
 
-    Reads the spill registry, whose entries hold a weakref to the ``np.memmap``: a dead weakref means
-    the last tensor over that file was collected and the mapping is gone.
+    The kernel's own list of this process's mappings, so it sees every mapping over the file no
+    matter who created it. False when the list cannot be read (non-Linux), matching the rest of
+    this module: spilling is effectively Linux-only and refuses gracefully elsewhere.
     """
-    return any(
-        reference() is not None and handle.path == path
-        for _, _, reference, handle in _spilled_mappings
-    )
+    real = os.path.realpath(path)
+    try:
+        with open("/proc/self/maps") as maps:
+            return any(line.rstrip("\n").endswith(f" {real}") for line in maps)
+    except OSError:
+        return False
 
 
 def release_page_cache_by_path(path: str) -> bool:
@@ -792,92 +694,169 @@ def release_page_cache_by_path(path: str) -> bool:
     return True
 
 
+def _madvise_dontneed(address: int, n_bytes: int, path: str) -> bool:
+    """``MADV_DONTNEED`` on ``[address, address + n_bytes)``, dropping this process's page-table entries.
+
+    Safe only on a file-backed mapping whose dirty pages were just written back: the pages remain
+    in the file and refault on next access. On an anonymous mapping the same call would discard
+    the data, which is why this helper is private to :func:`release_page_cache`.
+    """
+    dontneed = getattr(mmap, "MADV_DONTNEED", None)
+    if dontneed is None:
+        logger.info(
+            f"share_memory: cannot unmap pages for {path} (no MADV_DONTNEED on this platform); "
+            f"its pages stay charged to the cgroup until the kernel reclaims them"
+        )
+        return False
+    libc = ctypes.CDLL(None, use_errno=True)
+    result = libc.madvise(
+        ctypes.c_void_p(address), ctypes.c_size_t(n_bytes), ctypes.c_int(dontneed)
+    )
+    if result != 0:
+        reason = os.strerror(ctypes.get_errno())
+        logger.info(
+            f"share_memory: MADV_DONTNEED failed for {path} ({reason}); page-cache eviction "
+            f"would be a no-op while the pages remain mapped, so nothing was dropped"
+        )
+        return False
+    return True
+
+
 def release_page_cache(tensor: torch.Tensor) -> bool:
     """Write a disk-backed tensor's dirty pages out and ask the kernel to drop them from the cache.
 
     A spilled tensor's pages are reclaimable but still charged to cgroup v2's ``memory.current``
     while resident; dropping them releases the charge. The mapping stays valid and refaults on
     next access, so this is worth it only for data written now and not read until much later.
+    Operates on the tensor's whole backing file, so views over the same file lose their cached
+    pages too.
 
     Three steps, in this order, and every one is load-bearing:
 
-    1. ``msync`` through the backing memmap -- dirty pages cannot be dropped at all.
+    1. ``fsync`` -- writes back the pages dirtied through the mapping; dirty pages cannot be
+       dropped at all.
     2. ``MADV_DONTNEED`` on the mapping -- removes this process's page-table entries. Without it
        step 3 silently skips every still-mapped page and reports success having freed nothing.
-    3. ``fsync`` then ``POSIX_FADV_DONTNEED`` -- discards the now-unmapped clean page cache.
+    3. ``POSIX_FADV_DONTNEED`` -- discards the now-unmapped clean page cache.
 
     Returns True when every step COMPLETED -- ``FADV_DONTNEED`` is advisory, so completion is not
     proof of eviction; measure residency with ``mincore`` to know (the tests do). False means the
     sequence was incomplete, though a failure after step 2 has already dropped this process's
     page-table entries.
     """
-    handle = disk_backed_handle(tensor)
-    if handle is None:
+    if not is_disk_backed(tensor):
         return False
-
-    # The numpy memmap that owns the mapping. `np.asarray(memmap)` keeps the memmap as its base, and
-    # torch keeps that array alive, so it is still reachable through the registry.
-    backing = None
-    for _, _, reference, registered in _spilled_mappings:
-        if registered is handle:
-            array = reference()
-            backing = getattr(array, "base", None) if array is not None else None
-            break
-    if backing is None or not hasattr(backing, "flush"):
-        logger.warning(
-            f"share_memory: no live mapping found for {handle.path}; cannot drop its cache"
-        )
-        return False
+    storage = tensor.untyped_storage()
+    path = storage.filename
+    assert path is not None  # is_disk_backed just checked
 
     try:
-        backing.flush()  # msync: dirty pages cannot be dropped, so this is not optional.
-    except (OSError, ValueError) as e:
-        logger.warning(f"share_memory: could not msync {handle.path}: {e}")
-        return False
-
-    # Step 2 of the docstring's order: the page-table entries must go before FADV_DONTNEED, and
-    # MADV_DONTNEED is only safe because the mapping is file-backed and has just been msync'd (on
-    # an anonymous mapping it would discard the data)
-    mapping = getattr(backing, "_mmap", None)
-    if mapping is None or not hasattr(mapping, "madvise"):
-        logger.info(
-            f"share_memory: cannot unmap pages for {handle.path} (no madvise available); its "
-            f"pages stay charged to the cgroup until the kernel reclaims them"
-        )
-        return False
-    try:
-        mapping.madvise(mmap.MADV_DONTNEED)
-    except (AttributeError, OSError, ValueError) as e:
-        logger.info(
-            f"share_memory: MADV_DONTNEED failed for {handle.path} ({e}); page-cache eviction "
-            f"would be a no-op while the pages remain mapped, so nothing was dropped"
-        )
-        return False
-
-    try:
-        fd = os.open(handle.path, os.O_RDWR)
+        fd = os.open(path, os.O_RDWR)
     except OSError as e:
-        logger.warning(
-            f"share_memory: could not reopen {handle.path} to drop cache: {e}"
-        )
+        logger.warning(f"share_memory: could not open {path} to drop cache: {e}")
         return False
     try:
-        os.fsync(fd)
-        _fadvise_dontneed(fd)
+        os.fsync(fd)  # step 1: dirty pages cannot be dropped, so this is not optional
+        # step 2 must precede step 3, and MADV_DONTNEED is only safe because the mapping is
+        # file-backed and its dirty pages were just written back (on an anonymous mapping it
+        # would discard the data)
+        if not _madvise_dontneed(storage.data_ptr(), storage.nbytes(), path):
+            return False
+        _fadvise_dontneed(fd)  # step 3
     except OSError as e:
         logger.info(
-            f"share_memory: could not drop page cache for {handle.path} ({e}); its pages stay "
+            f"share_memory: could not drop page cache for {path} ({e}); its pages stay "
             f"charged to the cgroup until the kernel reclaims them"
         )
         return False
     finally:
         os.close(fd)
-    n_bytes = tensor.numel() * tensor.element_size()
     logger.info(
-        f"share_memory: unmapped and requested eviction of {_human_bytes(n_bytes)} of page cache "
-        f"for {handle.path}; the mapping stays valid and refaults on next read"
+        f"share_memory: unmapped and requested eviction of {_human_bytes(storage.nbytes())} of "
+        f"page cache for {path}; the mapping stays valid and refaults on next read"
     )
     return True
+
+
+def _rebuild_spilled_tensor(
+    path: str,
+    dtype: torch.dtype,
+    shape: tuple[int, ...],
+    stride: tuple[int, ...],
+    storage_offset: int,
+    storage_nbytes: int,
+) -> torch.Tensor:
+    """The receiving half of :func:`_reduce_spill_aware`: re-map the file, no bytes copied.
+
+    Raises:
+        FileNotFoundError: If the spill file is gone -- ``from_file`` would otherwise CREATE it
+            and silently hand back zero-filled, unreserved storage.
+        ValueError: If the file is too small for the storage it is supposed to hold, for the same
+            reason.
+    """
+    actual_bytes = os.path.getsize(path)
+    if actual_bytes < storage_nbytes:
+        raise ValueError(
+            f"Spill file {path} is {actual_bytes} bytes but the pickled tensor needs "
+            f"{storage_nbytes}. Refusing to map it."
+        )
+    # cast because the stub types from_file's return as the storage base class, which set_ rejects
+    storage = cast(
+        torch.UntypedStorage,
+        torch.UntypedStorage.from_file(path, shared=True, nbytes=storage_nbytes),
+    )
+    tensor = torch.empty(0, dtype=dtype)
+    tensor.set_(storage, storage_offset, shape, stride)
+    return tensor
+
+
+def _reduce_spill_aware(tensor: torch.Tensor) -> tuple:
+    """Pickle a disk-backed tensor as its path; hand everything else to torch's own reducer.
+
+    Torch's reduction for CPU tensors moves the bytes into ``/dev/shm`` -- for a spilled tensor
+    that copies it back into RAM and undoes the spill. A storage with a ``filename`` was created
+    by ``from_file(shared=True)``, whose documented contract is already "all changes are written
+    to the file", so shipping the path preserves its sharing semantics: the receiver maps the same
+    file with the same offset, shape and strides. Everything else -- no filename, CUDA, sparse,
+    grad-carrying, quantized, named, conj/neg views whose flag a raw re-map would drop -- is
+    reduced by torch exactly as if this module were not loaded.
+
+    Gated on spilling being enabled, so the feature stays opt-in: a process that never set
+    ``GIGL_TENSOR_SPILL_DIR`` pickles its own ``from_file`` tensors exactly as torch does today
+    (spawn children inherit the environment, so the gate agrees on both sides of a boundary).
+    """
+    if (
+        is_tensor_spilling_enabled()
+        and tensor.layout is torch.strided
+        and tensor.device.type == "cpu"
+        and not tensor.requires_grad
+        and not tensor.is_quantized
+        and not tensor.has_names()
+        and not tensor.is_conj()
+        and not tensor.is_neg()
+    ):
+        storage = tensor.untyped_storage()
+        if storage.filename is not None:
+            return (
+                _rebuild_spilled_tensor,
+                (
+                    storage.filename,
+                    tensor.dtype,
+                    tuple(tensor.shape),
+                    tuple(tensor.stride()),
+                    tensor.storage_offset(),
+                    storage.nbytes(),
+                ),
+            )
+    return _torch_reduce_tensor(tensor)
+
+
+# Replaces torch's entry for torch.Tensor in the ForkingPickler dispatch table (keyed by exact
+# type, so subclasses like torch.nn.Parameter keep their own reducers). Module import is the only
+# hook that reliably precedes any pickling in both the sending and receiving process: the sender
+# has imported this module to create or receive a spilled tensor, and the receiver imports it when
+# unpickling resolves _rebuild_spilled_tensor
+ForkingPickler.register(torch.Tensor, _reduce_spill_aware)
 
 
 def share_memory(
@@ -903,8 +882,8 @@ def share_memory(
 
     This function never spills to disk, and a tensor that is ALREADY disk-backed is left alone:
     ``share_memory_()`` on an mmap-backed tensor copies every byte into ``/dev/shm``, quietly
-    undoing a spill made elsewhere. Spilling belongs where a descriptor travels with the tensor --
-    :func:`share_memory_for_ipc` and :func:`spill_tensor_to_disk`.
+    undoing a spill made elsewhere. Spilling belongs to :func:`share_memory_for_ipc` and
+    :func:`spill_tensor_to_disk`.
 
     Args:
         entity (Optional[Union[torch.Tensor, PartitionBook, dict[_KeyType, torch.Tensor], dict[_KeyType, PartitionBook]]]):
@@ -934,64 +913,24 @@ def share_memory(
 
 def share_memory_for_ipc(
     entity: dict[_KeyType, torch.Tensor],
-) -> dict[_KeyType, Union[torch.Tensor, SpilledTensorHandle]]:
+) -> dict[_KeyType, torch.Tensor]:
     """Prepare a mapping of tensors to cross a process boundary, spilling instead of copying.
 
     Same intent as :func:`share_memory`, but for values that will be **pickled to another
-    process**: a spilled tensor is replaced by a :class:`SpilledTensorHandle` rather than by its
-    mmap view. Sending the view would copy every byte back into ``/dev/shm``, which is RAM, and
-    silently undo the spill -- the reason this function exists separately.
-
-    Tensors that are not spilled (spilling disabled, below the size threshold, unsupported dtype)
-    go to POSIX shared memory exactly as before, which pickles by handle already.
+    process**: each value large enough is spilled first, and a spilled tensor pickles as its file
+    path (see :func:`_reduce_spill_aware`), so its bytes never transit ``/dev/shm``. Tensors that
+    are not spilled (spilling disabled, below the size threshold) go to POSIX shared memory
+    exactly as before, which pickles by handle already.
 
     Returns a NEW dict; the input is left alone, since the caller usually still holds the tensors
     and dropping them is its decision.
     """
-    prepared: dict[_KeyType, Union[torch.Tensor, SpilledTensorHandle]] = {}
+    prepared: dict[_KeyType, torch.Tensor] = {}
     for key, value in entity.items():
-        already_spilled = disk_backed_handle(value)
-        if already_spilled is not None:
-            # Spilled earlier by something else; send that file's descriptor rather than writing a
-            # second copy of the same bytes.
-            prepared[key] = already_spilled
-            continue
         spilled = spill_tensor_to_disk(value)
         if spilled is not None:
-            prepared[key] = spilled.handle
-            # Nothing here keeps the mmap view alive on purpose: the far side re-maps from the
-            # path, and holding a second mapping in this process buys nothing.
+            prepared[key] = spilled
             continue
         share_memory(value)
         prepared[key] = value
     return prepared
-
-
-def resolve_spilled_handles(
-    value: Union[
-        torch.Tensor,
-        SpilledTensorHandle,
-        dict[_KeyType, Union[torch.Tensor, SpilledTensorHandle]],
-        None,
-    ],
-) -> Any:
-    """Turn any :class:`SpilledTensorHandle` back into a tensor, mapped in this process.
-
-    The receiving half of :func:`share_memory_for_ipc`. Accepts a bare value or a mapping of
-    values -- matching how the loader ships either a single tensor (homogeneous) or a dict keyed
-    by node/edge type (heterogeneous) -- and passes anything that is already a tensor straight
-    through.
-    """
-    if value is None:
-        return None
-    if isinstance(value, SpilledTensorHandle):
-        tensor = value.load()
-        logger.info(
-            f"share_memory: mapped spilled tensor {tuple(value.shape)} {value.dtype} from "
-            f"{value.path} ({tensor.numel() * tensor.element_size() / 2**30:.1f} GiB, no copy)"
-        )
-        return tensor
-    if isinstance(value, abc.Mapping):
-        by_type = cast(dict[Any, Union[torch.Tensor, SpilledTensorHandle]], value)
-        return {key: resolve_spilled_handles(item) for key, item in by_type.items()}
-    return value

--- a/tests/unit/utils/share_memory_test.py
+++ b/tests/unit/utils/share_memory_test.py
@@ -3,6 +3,7 @@ import gc
 import os
 import pickle
 import tempfile
+import unittest
 from collections import abc
 from pathlib import Path
 from typing import Optional, Union
@@ -68,7 +69,8 @@ class ShareMemoryTest(TestCase):
             Union[torch.Tensor, RangePartitionBook, dict[NodeType, torch.Tensor]]
         ],
     ):
-        share_memory(entity=entity)
+        # The -> None contract is public API: returning the entity would be a signature change
+        self.assertIsNone(share_memory(entity=entity))
         if isinstance(entity, torch.Tensor):
             self.assertTrue(entity.is_shared())
         elif isinstance(entity, RangePartitionBook):
@@ -199,10 +201,16 @@ def _fallocate_reflected_in_st_blocks(directory: str) -> bool:
     """
     fd, path = tempfile.mkstemp(dir=directory)
     probe_bytes = 1 << 20
+    # getattr because the symbol does not exist off Linux, where this file must still type-check
+    fallocate = getattr(os, "posix_fallocate", None)
+    if fallocate is None:
+        os.close(fd)
+        os.unlink(path)
+        return False
     try:
-        os.posix_fallocate(fd, 0, probe_bytes)
+        fallocate(fd, 0, probe_bytes)
         return os.stat(path).st_blocks * 512 >= probe_bytes
-    except (AttributeError, OSError):
+    except OSError:
         return False
     finally:
         os.close(fd)
@@ -217,8 +225,7 @@ def _shmem_kib() -> int:
 
     Read from meminfo rather than by listing ``/dev/shm``: torch's ``file_descriptor`` sharing
     strategy unlinks its segment immediately, so the directory looks empty while the pages are very
-    much resident. An earlier probe that scanned the directory reported a false negative for
-    exactly this reason.
+    much resident -- a directory scan reports a false negative here.
     """
     with open("/proc/meminfo") as meminfo:
         for line in meminfo:
@@ -227,6 +234,10 @@ def _shmem_kib() -> int:
     raise AssertionError("no Shmem line in /proc/meminfo")
 
 
+@unittest.skipUnless(
+    hasattr(os, "posix_fallocate"),
+    "tensor spilling requires posix_fallocate, absent on this platform",
+)
 class ShareMemoryForIpcTest(TestCase):
     def setUp(self) -> None:
         self._spill_dir = tempfile.TemporaryDirectory()
@@ -404,6 +415,26 @@ class ShareMemoryForIpcTest(TestCase):
             "the file is sparse -- the fallocate reservation was discarded by the mapping",
         )
 
+    def test_the_spill_copy_path_never_truncates_its_reservation(self):
+        """``_spill_to_mmap`` must map ``r+`` too, for the same reason as ``allocate_disk_backed``.
+
+        numpy opens ``mode="w+"`` as ``w+b``, which truncates the file and discards the blocks
+        ``posix_fallocate`` just reserved, silently restoring the disk-full SIGBUS path this suite
+        exists to close.
+        """
+        real_memmap = np.memmap
+        with mock.patch("numpy.memmap", side_effect=real_memmap) as memmap_spy:
+            spilled = spill_tensor_to_disk(torch.randn(20_000, 8))
+
+        assert spilled is not None
+        modes = [call.kwargs.get("mode") for call in memmap_spy.call_args_list]
+        self.assertTrue(len(modes) >= 1)
+        # Every mapping must be writable AND non-truncating: "w+" discards the reservation, and a
+        # read-only "r" hands back storage that segfaults on in-place write
+        self.assertEqual(
+            set(modes), {"r+"}, "the spill path used a mapping mode other than r+"
+        )
+
     def test_a_filesystem_that_cannot_reserve_gets_memory_not_a_file(self):
         """Reservation is mandatory: a refused ``posix_fallocate`` means no file-backed tensor.
 
@@ -478,8 +509,8 @@ class ShareMemoryForIpcTest(TestCase):
     def test_release_page_cache_reports_failure_when_it_cannot_unmap(self):
         """A no-op must report False, not True.
 
-        The first version of this returned True after calling only ``FADV_DONTNEED``, which drops
-        nothing while the pages are mapped -- so the log said 56.4 GiB had been freed when none had.
+        Returning True after calling only ``FADV_DONTNEED`` would drop nothing while the pages are
+        mapped, and the caller would log a saving it did not get.
         """
         buffer = allocate_disk_backed((40_000, 8), torch.float32)
         assert buffer is not None
@@ -502,9 +533,9 @@ class ShareMemoryForIpcTest(TestCase):
     def test_release_page_cache_actually_reduces_residency(self):
         """Measured, not assumed: ``mincore`` before and after.
 
-        The previous version of this test only proved the data survived, which it would have done
-        even with the broken implementation -- and touching every page to check repopulated the cache
-        before anything could observe it. Residency has to be read BEFORE the refault.
+        Proving the data survived is not enough -- it survives even when eviction silently fails --
+        and touching every page to check repopulates the cache before anything can observe it, so
+        residency has to be read BEFORE the refault.
         """
         rows, columns = (
             200_000,
@@ -541,9 +572,9 @@ class ShareMemoryForIpcTest(TestCase):
     def test_release_page_cache_drops_resident_pages_and_keeps_the_data(self):
         """Dropping the cache must remove the cgroup charge without losing the bytes.
 
-        This is the fix for a misconception that has OOM-killed a real run: moving a tensor to a
-        file makes its pages reclaimable but leaves them CHARGED to ``memory.current``, so a
-        tens-of-GiB feature matrix still counted against the limit during the CSR build. Resident pages are read
+        Moving a tensor to a file makes its pages reclaimable but leaves them CHARGED to
+        ``memory.current``, so a tens-of-GiB feature matrix still counts against the limit while
+        later phases allocate. Resident pages are read
         from ``/proc/self/smaps_rollup``-style accounting via mincore semantics; here the simpler
         observable is that the values survive a refault.
         """
@@ -689,8 +720,8 @@ class ShareMemoryForIpcTest(TestCase):
             self.assertIsNone(allocate_disk_backed((5000, 8), torch.float32))
 
     def test_an_already_disk_backed_buffer_is_not_spilled_again(self):
-        """`_spill_partitioned_node_features` runs after assembly; if the assembly already wrote the
-        matrix to disk, copying it to a second file doubles both the disk use and the time."""
+        """Spilling a tensor that already lives in a spill file must reuse that file: copying it to
+        a second one doubles both the disk use and the time for no benefit."""
         buffer = allocate_disk_backed((5000, 8), torch.float32)
         assert buffer is not None
 

--- a/tests/unit/utils/share_memory_test.py
+++ b/tests/unit/utils/share_memory_test.py
@@ -1,15 +1,16 @@
 import errno
 import gc
+import io
 import os
 import pickle
 import tempfile
 import unittest
 from collections import abc
+from multiprocessing.reduction import ForkingPickler
 from pathlib import Path
 from typing import Optional, Union
 from unittest import mock
 
-import numpy as np
 import torch
 import torch.multiprocessing as mp
 from graphlearn_torch.partition import RangePartitionBook
@@ -19,21 +20,37 @@ from torch.testing import assert_close
 from gigl.src.common.types.graph_data import NodeType
 from gigl.utils import share_memory as share_memory_module
 from gigl.utils.share_memory import (
-    SpilledTensorHandle,
     allocate_disk_backed,
     allocate_preshared,
-    disk_backed_handle,
     has_live_mapping,
     is_disk_backed,
+    load_spilled_tensor,
     prepare_spill_dir,
     release_page_cache,
     release_page_cache_by_path,
-    resolve_spilled_handles,
     share_memory,
     share_memory_for_ipc,
     spill_tensor_to_disk,
 )
 from tests.test_assets.test_case import TestCase
+
+
+def _spill_file_path(tensor: torch.Tensor) -> str:
+    """The file behind a disk-backed tensor, read off its storage."""
+    path = tensor.untyped_storage().filename
+    assert path is not None, "the tensor is not disk-backed"
+    return path
+
+
+def _forking_pickle(value: object) -> bytes:
+    """Serialize the way multiprocessing does, so the spill-aware reducer applies.
+
+    ``pickle.dumps`` uses the plain pickler, which does not consult ForkingPickler's dispatch
+    table -- tensors then serialize by value and every size assertion would be meaningless.
+    """
+    buffer = io.BytesIO()
+    ForkingPickler(buffer).dump(value)
+    return buffer.getvalue()
 
 
 class ShareMemoryTest(TestCase):
@@ -97,22 +114,29 @@ class ShareMemoryTest(TestCase):
         self.assertFalse(empty_2d_tensor.is_shared())
 
 
-def _load_in_child(
-    prepared: dict[NodeType, Union[torch.Tensor, SpilledTensorHandle]],
+def _receive_in_child(
+    in_queue: "mp.Queue",
     result_queue: "mp.Queue",
 ) -> None:
-    """Resolve handles in a spawned child and report what arrived, plus the Shmem delta.
+    """Receive a prepared mapping in a spawned child and report what arrived, plus the Shmem delta.
 
     Runs in a separate process on purpose: the failure this guards against only exists across a
-    process boundary, where pickling an mmap-backed tensor copies it into ``/dev/shm``.
+    process boundary, where torch's own reduction would copy the bytes into ``/dev/shm``. The
+    mapping travels through the QUEUE rather than as a spawn argument so the deserialization
+    happens inside the measurement window below.
     """
     before = _shmem_kib()
-    resolved = resolve_spilled_handles(prepared)
+    received = in_queue.get(timeout=120)
     after = _shmem_kib()
     result_queue.put(
         {
-            key: (tuple(tensor.shape), str(tensor.dtype), tensor.sum().item())
-            for key, tensor in resolved.items()
+            key: (
+                tuple(tensor.shape),
+                str(tensor.dtype),
+                tensor.sum().item(),
+                is_disk_backed(tensor),
+            )
+            for key, tensor in received.items()
         }
     )
     result_queue.put(after - before)
@@ -121,7 +145,7 @@ def _load_in_child(
 
 
 def _spill_in_child(result_queue: "mp.Queue") -> None:
-    """Spill a tensor in a spawned child and hand back only its descriptor, then exit.
+    """Spill a tensor in a spawned child, send it back (it pickles by path), then exit.
 
     Mirrors what a tensor-loading child does, including exiting before the parent uses the file.
     """
@@ -134,32 +158,16 @@ def _spill_in_child(result_queue: "mp.Queue") -> None:
 
 
 def _share_memory_in_child(
-    handle: SpilledTensorHandle, result_queue: "mp.Queue"
+    in_queue: "mp.Queue",
+    result_queue: "mp.Queue",
 ) -> None:
-    """Map a spilled tensor, pass it to share_memory, and report whether it got copied to RAM."""
-    tensor = handle.load()
+    """Receive a spilled tensor, pass it to share_memory, and report whether it got copied to RAM."""
+    tensor = in_queue.get(timeout=120)
     before = _shmem_kib()
     share_memory(tensor)
-    result_queue.put((_shmem_kib() - before, tensor.is_shared()))
+    result_queue.put((_shmem_kib() - before, is_disk_backed(tensor)))
     result_queue.close()
     result_queue.join_thread()
-
-
-class _RecordingMmap:
-    """Stand-in for the memmap's underlying ``mmap.mmap``, which is a C type and cannot be patched."""
-
-    def __init__(self, calls: list[str]) -> None:
-        self._calls = calls
-
-    def madvise(self, *_args: object) -> None:
-        self._calls.append("madvise")
-
-
-class _FailingMmap:
-    """A mapping whose ``madvise`` is unsupported, as on a platform or filesystem that lacks it."""
-
-    def madvise(self, *_args: object) -> None:
-        raise OSError("madvise unsupported")
 
 
 def _resident_page_fraction(tensor: torch.Tensor) -> Optional[float]:
@@ -262,7 +270,7 @@ class ShareMemoryForIpcTest(TestCase):
         # protect here.
         os.environ.pop("GIGL_TENSOR_SPILL_DIR_PREPARED", None)
 
-    def test_spilled_tensors_are_sent_as_handles_not_tensors(self):
+    def test_spilled_tensors_pickle_by_path_not_by_value(self):
         entity = {
             NodeType("user"): torch.arange(100_000, dtype=torch.float32),
             # Under the threshold, so it should stay a tensor in shared memory.
@@ -270,29 +278,155 @@ class ShareMemoryForIpcTest(TestCase):
         }
         prepared = share_memory_for_ipc(entity)
 
-        self.assertIsInstance(prepared[NodeType("user")], SpilledTensorHandle)
+        big = prepared[NodeType("user")]
+        self.assertTrue(is_disk_backed(big))
         small = prepared[NodeType("item")]
-        assert isinstance(small, torch.Tensor)
+        self.assertFalse(is_disk_backed(small))
         self.assertTrue(small.is_shared())
 
         # The whole point: what crosses the boundary must be small, whatever the tensor's size.
-        self.assertLess(len(pickle.dumps(prepared)), 4096)
+        # Serialized the way multiprocessing serializes, where the spill-aware reducer applies.
+        self.assertLess(len(_forking_pickle({NodeType("user"): big})), 4096)
 
-    def test_handles_resolve_to_the_same_values_in_another_process(self):
+    def test_a_pickled_spilled_tensor_remaps_the_same_file(self):
+        prepared = share_memory_for_ipc(
+            {NodeType("user"): torch.arange(100_000, dtype=torch.float32)}
+        )
+        original = prepared[NodeType("user")]
+
+        received = pickle.loads(_forking_pickle(original))
+
+        assert_close(received, original)
+        self.assertEqual(_spill_file_path(received), _spill_file_path(original))
+        # A shared mapping of the same file, not a copy: a write on one side is visible on the
+        # other, which is from_file's documented contract and what path-shipping must preserve.
+        received[42] = -1.0
+        self.assertEqual(original[42].item(), -1.0)
+        original[42] = 42.0
+
+    def test_a_pickled_view_keeps_its_offset_and_strides(self):
+        """Shipping a view by path alone would hand the receiver the wrong bytes.
+
+        A square tensor's transpose has the same storage, pointer, shape and numel as the
+        original -- only the strides differ. A slice differs only in offset and shape. Both must
+        round-trip by value, not just by file.
+        """
+        prepared = share_memory_for_ipc(
+            {
+                NodeType("user"): torch.arange(256 * 256, dtype=torch.float32).reshape(
+                    256, 256
+                )
+            }
+        )
+        mapped = prepared[NodeType("user")]
+
+        transposed = pickle.loads(_forking_pickle(mapped.t()))
+        assert_close(transposed, mapped.t())
+
+        sliced = pickle.loads(_forking_pickle(mapped[3:17, 5:9]))
+        assert_close(sliced, mapped[3:17, 5:9])
+
+        # Neither round-trip may write a second spill file: the view travels as (path, offset,
+        # shape, strides) over the one existing file.
+        self.assertEqual(
+            len(list(Path(self._spill_dir.name).glob("spill_*.bin"))),
+            1,
+        )
+
+    def test_a_stale_pickle_fails_loudly_instead_of_fabricating_zeros(self):
+        """``from_file`` CREATES a missing file, so a stale recipe must be refused, not mapped.
+
+        If the spill file is unlinked while a pickled tensor is in flight, mapping the path would
+        silently hand the receiver a fresh zero-filled file -- corrupt data with the SIGBUS
+        reservation gone too. Missing and truncated files must both raise, and the failed rebuild
+        must not leave a recreated file behind.
+        """
+        prepared = share_memory_for_ipc(
+            {NodeType("user"): torch.arange(100_000, dtype=torch.float32)}
+        )
+        original = prepared[NodeType("user")]
+        path = _spill_file_path(original)
+        blob = _forking_pickle(original)
+
+        with open(path, "r+b") as spill_file:
+            spill_file.truncate(1024)
+        with self.assertRaises(ValueError):
+            pickle.loads(blob)
+
+        os.unlink(path)
+        with self.assertRaises(FileNotFoundError):
+            pickle.loads(blob)
+        self.assertFalse(
+            os.path.exists(path), "the failed rebuild recreated the missing spill file"
+        )
+
+    def test_quantized_tensors_are_refused(self):
+        """A quantized tensor's quantizer lives beside its storage, so raw bytes cannot rebuild it.
+
+        Mapping one anyway produces a tensor that trips internal torch assertions on first use;
+        both entry points must decline so the caller keeps a working in-memory tensor.
+        """
+        self.assertIsNone(allocate_disk_backed((20_000, 8), torch.qint8))
+        quantized = torch.quantize_per_tensor(torch.ones(100_000), 0.1, 0, torch.qint8)
+        self.assertIsNone(spill_tensor_to_disk(quantized))
+
+    def test_the_reducer_is_inert_when_spilling_is_disabled(self):
+        """Opt-in means opt-in: without ``GIGL_TENSOR_SPILL_DIR``, torch's own reduction runs.
+
+        A user's unrelated ``from_file`` tensor must pickle exactly as it does without this module
+        loaded -- torch copies it into shared memory, so the received tensor has no ``filename``.
+        With spilling enabled the same tensor ships by path and keeps it.
+        """
+        side_file = os.path.join(self._spill_dir.name, "not_a_spill.bin")
+        tensor = torch.from_file(side_file, shared=True, size=1000, dtype=torch.float32)
+        tensor.fill_(7.0)
+        strategy = mp.get_sharing_strategy()
+        # file_system, because torch's fd-passing reduction cannot round-trip inside one process
+        mp.set_sharing_strategy("file_system")
+        self.addCleanup(mp.set_sharing_strategy, strategy)
+
+        # Enabled first: path-shipping does not mutate the sender. Torch's reduction does -- it
+        # relocates the sender's storage into /dev/shm in place, stripping the filename -- so the
+        # disabled round-trip must come last
+        received_enabled = pickle.loads(_forking_pickle(tensor))
+        with mock.patch.dict(os.environ, {"GIGL_TENSOR_SPILL_DIR": ""}):
+            received_disabled = pickle.loads(_forking_pickle(tensor))
+
+        self.assertEqual(received_enabled.untyped_storage().filename, side_file)
+        assert_close(received_enabled, torch.full((1000,), 7.0))
+        assert_close(received_disabled, torch.full((1000,), 7.0))
+        self.assertIsNone(received_disabled.untyped_storage().filename)
+
+    def test_a_named_tensor_is_delegated_to_torch_which_refuses_it(self):
+        """Shipping a named tensor by path would drop its names silently; torch raises instead.
+
+        Delegation preserves that explicit refusal rather than swallowing it.
+        """
+        prepared = share_memory_for_ipc(
+            {NodeType("user"): torch.arange(100_000, dtype=torch.float32)}
+        )
+        named = prepared[NodeType("user")].reshape(1000, 100).refine_names("row", "col")
+
+        with self.assertRaisesRegex(RuntimeError, "[Nn]amed"):
+            _forking_pickle(named)
+
+    def test_tensors_resolve_to_the_same_values_in_another_process(self):
         entity = {
             NodeType("user"): torch.arange(100_000, dtype=torch.float32),
             NodeType("item"): torch.arange(10, dtype=torch.float32),
         }
         expected = {
-            key: (tuple(t.shape), str(t.dtype), t.sum().item())
+            key: (tuple(t.shape), str(t.dtype), t.sum().item(), key == NodeType("user"))
             for key, t in entity.items()
         }
         prepared = share_memory_for_ipc(entity)
 
         ctx = mp.get_context("spawn")
+        in_queue = ctx.Queue()
         result_queue = ctx.Queue()
-        child = ctx.Process(target=_load_in_child, args=(prepared, result_queue))
+        child = ctx.Process(target=_receive_in_child, args=(in_queue, result_queue))
         child.start()
+        in_queue.put(prepared)
         got = result_queue.get(timeout=120)
         shmem_delta_kib = result_queue.get(timeout=120)
         child.join(timeout=120)
@@ -303,32 +437,31 @@ class ShareMemoryForIpcTest(TestCase):
         # bound is loose because the whole machine's Shmem is being sampled, not just ours.
         self.assertLess(shmem_delta_kib, 200)
 
-    def test_resolve_passes_through_tensors_and_none(self):
-        tensor = torch.arange(10)
-        self.assertIs(resolve_spilled_handles(tensor), tensor)
-        self.assertIsNone(resolve_spilled_handles(None))
-
     def test_share_memory_leaves_a_disk_backed_tensor_alone(self):
-        """``share_memory_()`` on an mmap view copies it into /dev/shm, undoing the spill.
+        """``share_memory_()`` relocating an mmap view into /dev/shm would undo the spill.
 
-        Measured at +16,128 kB for a 16 MiB tensor, so a caller that reaches one of these tensors
-        after it has been spilled would silently put it back in RAM.
+        Checked in a separate process, where the tensor arrives by path: after ``share_memory`` it
+        must still be disk-backed and RAM-backed shared memory must not have grown.
         """
         prepared = share_memory_for_ipc(
             {NodeType("user"): torch.arange(1_000_000, dtype=torch.float32)}
         )
-        handle = prepared[NodeType("user")]
-        assert isinstance(handle, SpilledTensorHandle)
 
         ctx = mp.get_context("spawn")
+        in_queue = ctx.Queue()
         result_queue = ctx.Queue()
-        child = ctx.Process(target=_share_memory_in_child, args=(handle, result_queue))
+        child = ctx.Process(
+            target=_share_memory_in_child, args=(in_queue, result_queue)
+        )
         child.start()
-        shmem_delta_kib, is_shared = result_queue.get(timeout=120)
+        in_queue.put(prepared[NodeType("user")])
+        shmem_delta_kib, still_disk_backed = result_queue.get(timeout=120)
         child.join(timeout=120)
 
         self.assertEqual(child.exitcode, 0)
-        self.assertFalse(is_shared, "share_memory relocated a disk-backed tensor")
+        self.assertTrue(
+            still_disk_backed, "share_memory relocated a disk-backed tensor"
+        )
         self.assertLess(shmem_delta_kib, 512)
 
     def test_share_memory_still_shares_an_ordinary_tensor(self):
@@ -362,31 +495,59 @@ class ShareMemoryForIpcTest(TestCase):
             1,
         )
 
-    def test_a_reserved_file_is_mapped_without_truncating_it(self):
-        """A reserved file must be mapped ``r+``, never ``w+``.
-
-        Not hypothetical: numpy opens ``mode="w+"`` as ``w+b``, which truncates the file and hands
-        every block ``posix_fallocate`` reserved straight back, leaving it sparse and the SIGBUS risk
-        exactly where it started.
-
-        Asserted on the MODE rather than on the resulting block count, so the check is deterministic:
-        block accounting varies by filesystem, while the mode used for a reserved file must never
-        vary.
-        """
-        real_memmap = np.memmap
-        with mock.patch("numpy.memmap", side_effect=real_memmap) as memmap_spy:
-            buffer = allocate_disk_backed((20_000, 8), torch.float32)
+    def test_dtypes_without_numpy_equivalents_are_spillable(self):
+        """The mapping is torch-native, so torch-only dtypes like bfloat16 spill too."""
+        buffer = allocate_disk_backed((20_000, 8), torch.bfloat16)
 
         assert buffer is not None
-        self.assertEqual(memmap_spy.call_count, 1)
-        self.assertEqual(
-            memmap_spy.call_args.kwargs.get("mode"),
-            "r+",
-            "a reserved file was mapped with a mode that truncates it",
-        )
+        self.assertTrue(is_disk_backed(buffer))
+        buffer.fill_(2.0)
+        assert_close(buffer[123], torch.full((8,), 2.0, dtype=torch.bfloat16))
+
+    @parameterized.expand(
+        [
+            param(
+                "allocate path",
+                act=lambda: allocate_disk_backed((20_000, 8), torch.float32),
+            ),
+            param(
+                "spill copy path",
+                act=lambda: spill_tensor_to_disk(torch.randn(20_000, 8)),
+            ),
+        ]
+    )
+    def test_every_block_is_reserved_before_the_file_is_mapped(self, _, act):
+        """The ORDER is the SIGBUS guard, so it is pinned deterministically.
+
+        A mapping made before the reservation is sparse for as long as the gap lasts, and a write
+        into a sparse page on a full filesystem dies as SIGBUS -- a signal no ``except`` can catch.
+        Asserted on the call order rather than on block counts, which vary by filesystem.
+        """
+        calls: list[str] = []
+        real_fallocate = os.posix_fallocate
+        real_from_file = torch.UntypedStorage.from_file
+
+        def fallocate_spy(fd: int, offset: int, n_bytes: int) -> None:
+            calls.append("reserve")
+            real_fallocate(fd, offset, n_bytes)
+
+        def from_file_spy(path: str, shared: bool = False, nbytes: int = 0):
+            calls.append("map")
+            return real_from_file(path, shared=shared, nbytes=nbytes)
+
+        with (
+            mock.patch("os.posix_fallocate", side_effect=fallocate_spy),
+            mock.patch.object(
+                torch.UntypedStorage, "from_file", side_effect=from_file_spy
+            ),
+        ):
+            produced = act()
+
+        assert produced is not None
+        self.assertEqual(calls, ["reserve", "map"])
 
     def test_the_reserved_blocks_are_still_allocated_after_mapping(self):
-        """End-to-end version of the above, where the filesystem can actually demonstrate it.
+        """``from_file`` must not truncate the reservation away when it maps the file.
 
         Skipped rather than failed where ``posix_fallocate`` is unsupported or where ``st_blocks``
         does not reflect reservations -- compressed, copy-on-write, network and emulated filesystems
@@ -403,9 +564,7 @@ class ShareMemoryForIpcTest(TestCase):
         buffer = allocate_disk_backed((rows, columns), torch.float32)
 
         assert buffer is not None
-        handle = disk_backed_handle(buffer)
-        assert handle is not None
-        stat = os.stat(handle.path)
+        stat = os.stat(_spill_file_path(buffer))
         self.assertEqual(stat.st_size, expected_bytes)
         # st_blocks counts 512-byte units actually allocated; a sparse file reports far fewer than
         # its apparent size.
@@ -413,26 +572,6 @@ class ShareMemoryForIpcTest(TestCase):
             stat.st_blocks * 512,
             expected_bytes,
             "the file is sparse -- the fallocate reservation was discarded by the mapping",
-        )
-
-    def test_the_spill_copy_path_never_truncates_its_reservation(self):
-        """``_spill_to_mmap`` must map ``r+`` too, for the same reason as ``allocate_disk_backed``.
-
-        numpy opens ``mode="w+"`` as ``w+b``, which truncates the file and discards the blocks
-        ``posix_fallocate`` just reserved, silently restoring the disk-full SIGBUS path this suite
-        exists to close.
-        """
-        real_memmap = np.memmap
-        with mock.patch("numpy.memmap", side_effect=real_memmap) as memmap_spy:
-            spilled = spill_tensor_to_disk(torch.randn(20_000, 8))
-
-        assert spilled is not None
-        modes = [call.kwargs.get("mode") for call in memmap_spy.call_args_list]
-        self.assertTrue(len(modes) >= 1)
-        # Every mapping must be writable AND non-truncating: "w+" discards the reservation, and a
-        # read-only "r" hands back storage that segfaults on in-place write
-        self.assertEqual(
-            set(modes), {"r+"}, "the spill path used a mapping mode other than r+"
         )
 
     def test_a_filesystem_that_cannot_reserve_gets_memory_not_a_file(self):
@@ -466,36 +605,24 @@ class ShareMemoryForIpcTest(TestCase):
         """The ORDER is the whole mechanism, so it is pinned deterministically.
 
         ``FADV_DONTNEED`` on a live mapping is a no-op that reports success -- Linux skips pages held
-        in a page table. So ``MADV_DONTNEED`` must come first, and after an ``msync`` because dirty
-        pages cannot be dropped at all. A residency test alone would not catch a reordering that
-        happens to work on one kernel.
+        in a page table. So ``MADV_DONTNEED`` must come first, and after the write-back because
+        dirty pages cannot be dropped at all. A residency test alone would not catch a reordering
+        that happens to work on one kernel.
         """
         buffer = allocate_disk_backed((40_000, 8), torch.float32)
         assert buffer is not None
         calls: list[str] = []
-        handle = disk_backed_handle(buffer)
-        assert handle is not None
-        backing = buffer.numpy().base
-        # torch.from_numpy(np.asarray(memmap)) -- reach the memmap the same way the code does.
-        for _, _, reference, registered in share_memory_module._spilled_mappings:
-            if registered is handle:
-                array = reference()
-                assert array is not None, (
-                    "the mapping was collected before the test ran"
-                )
-                backing = array.base
-                break
 
-        # `mmap.mmap` is a C type whose `madvise` cannot be patched, so the whole object is
-        # swapped for a recorder. `_mmap` is a plain attribute of numpy's memmap, so this is
-        # exactly the object the implementation reaches for.
+        def record_madvise(address: int, n_bytes: int, path: str) -> bool:
+            calls.append("madvise")
+            return True
+
         with (
             mock.patch.object(
-                backing, "flush", side_effect=lambda: calls.append("msync")
-            ),
-            mock.patch.object(backing, "_mmap", _RecordingMmap(calls)),
-            mock.patch.object(
                 os, "fsync", side_effect=lambda fd: calls.append("fsync")
+            ),
+            mock.patch.object(
+                share_memory_module, "_madvise_dontneed", side_effect=record_madvise
             ),
             mock.patch.object(
                 os, "posix_fadvise", side_effect=lambda *a: calls.append("fadvise")
@@ -504,7 +631,7 @@ class ShareMemoryForIpcTest(TestCase):
             released = release_page_cache(buffer)
 
         self.assertTrue(released)
-        self.assertEqual(calls, ["msync", "madvise", "fsync", "fadvise"])
+        self.assertEqual(calls, ["fsync", "madvise", "fadvise"])
 
     def test_release_page_cache_reports_failure_when_it_cannot_unmap(self):
         """A no-op must report False, not True.
@@ -514,20 +641,10 @@ class ShareMemoryForIpcTest(TestCase):
         """
         buffer = allocate_disk_backed((40_000, 8), torch.float32)
         assert buffer is not None
-        handle = disk_backed_handle(buffer)
-        assert handle is not None
-        backing = None
-        for _, _, reference, registered in share_memory_module._spilled_mappings:
-            if registered is handle:
-                array = reference()
-                assert array is not None, (
-                    "the mapping was collected before the test ran"
-                )
-                backing = array.base
-                break
-        assert backing is not None
 
-        with mock.patch.object(backing, "_mmap", _FailingMmap()):
+        with mock.patch.object(
+            share_memory_module, "_madvise_dontneed", return_value=False
+        ):
             self.assertFalse(release_page_cache(buffer))
 
     def test_release_page_cache_actually_reduces_residency(self):
@@ -574,9 +691,7 @@ class ShareMemoryForIpcTest(TestCase):
 
         Moving a tensor to a file makes its pages reclaimable but leaves them CHARGED to
         ``memory.current``, so a tens-of-GiB feature matrix still counts against the limit while
-        later phases allocate. Resident pages are read
-        from ``/proc/self/smaps_rollup``-style accounting via mincore semantics; here the simpler
-        observable is that the values survive a refault.
+        later phases allocate. Here the simpler observable is that the values survive a refault.
         """
         rows, columns = 40_000, 8
         buffer = allocate_disk_backed((rows, columns), torch.float32)
@@ -596,9 +711,10 @@ class ShareMemoryForIpcTest(TestCase):
         assert_close(buffer, expected)
         # And the flush must have reached the file, not just the cache: read it through a fresh
         # mapping that shares nothing with the original.
-        handle = disk_backed_handle(buffer)
-        assert handle is not None
-        assert_close(handle.load(), expected)
+        remapped = load_spilled_tensor(
+            _spill_file_path(buffer), buffer.dtype, tuple(buffer.shape)
+        )
+        assert_close(remapped, expected)
 
     def test_release_page_cache_declines_for_an_ordinary_tensor(self):
         self.assertFalse(release_page_cache(torch.arange(1000, dtype=torch.float32)))
@@ -613,22 +729,21 @@ class ShareMemoryForIpcTest(TestCase):
         """
         buffer = allocate_disk_backed((40_000, 8), torch.float32)
         assert buffer is not None
-        handle = disk_backed_handle(buffer)
-        assert handle is not None
+        path = _spill_file_path(buffer)
         buffer.fill_(1.0)
 
-        self.assertTrue(has_live_mapping(handle.path))
+        self.assertTrue(has_live_mapping(path))
         self.assertFalse(
-            release_page_cache_by_path(handle.path),
+            release_page_cache_by_path(path),
             "a still-mapped file cannot have its cache dropped by fadvise alone",
         )
 
         del buffer
         gc.collect()
 
-        self.assertFalse(has_live_mapping(handle.path))
+        self.assertFalse(has_live_mapping(path))
         self.assertTrue(
-            release_page_cache_by_path(handle.path),
+            release_page_cache_by_path(path),
             "with the mapping gone, fadvise is sufficient",
         )
 
@@ -727,12 +842,26 @@ class ShareMemoryForIpcTest(TestCase):
 
         spilled = spill_tensor_to_disk(buffer)
 
-        assert spilled is not None
-        self.assertIs(spilled.tensor, buffer)
+        self.assertIs(spilled, buffer)
         self.assertEqual(
             len(list(Path(self._spill_dir.name).glob("spill_*.bin"))),
             1,
             "a second copy of the same bytes was written",
+        )
+
+    def test_an_already_spilled_tensor_is_not_spilled_twice(self):
+        first = share_memory_for_ipc(
+            {NodeType("user"): torch.arange(100_000, dtype=torch.float32)}
+        )
+        tensor = first[NodeType("user")]
+
+        second = share_memory_for_ipc({NodeType("user"): tensor})
+
+        self.assertIs(second[NodeType("user")], tensor)
+        self.assertEqual(
+            len(list(Path(self._spill_dir.name).glob("spill_*.bin"))),
+            1,
+            "the same bytes were written to a second spill file",
         )
 
     def test_a_failed_spill_leaves_no_partial_file(self):
@@ -743,7 +872,7 @@ class ShareMemoryForIpcTest(TestCase):
         into RAM -- converting a recoverable spill failure into the OOM the spill exists to prevent.
         """
         with mock.patch.object(
-            np.memmap, "flush", side_effect=OSError("no space left on device")
+            os, "fsync", side_effect=OSError("no space left on device")
         ):
             spilled = spill_tensor_to_disk(torch.arange(100_000, dtype=torch.float32))
 
@@ -752,44 +881,6 @@ class ShareMemoryForIpcTest(TestCase):
             list(Path(self._spill_dir.name).glob("spill_*.bin")),
             [],
             "a partial spill file was left behind",
-        )
-
-    def test_a_transposed_view_does_not_reuse_the_file_descriptor(self):
-        """Same pointer, same shape, same numel -- different strides.
-
-        A square tensor's transpose matches on everything ``disk_backed_handle`` used to compare, so
-        reusing the descriptor would hand the receiver untransposed values with no error anywhere.
-        """
-        prepared = share_memory_for_ipc(
-            {
-                NodeType("user"): torch.arange(256 * 256, dtype=torch.float32).reshape(
-                    256, 256
-                )
-            }
-        )
-        handle = prepared[NodeType("user")]
-        assert isinstance(handle, SpilledTensorHandle)
-        mapped = handle.load()
-
-        self.assertEqual(disk_backed_handle(mapped), handle)
-        self.assertIsNone(disk_backed_handle(mapped.t()))
-        # A partial view names only part of the file, so it cannot be described by the file either.
-        self.assertIsNone(disk_backed_handle(mapped[:8]))
-
-    def test_an_already_spilled_tensor_is_not_spilled_twice(self):
-        first = share_memory_for_ipc(
-            {NodeType("user"): torch.arange(100_000, dtype=torch.float32)}
-        )
-        handle = first[NodeType("user")]
-        assert isinstance(handle, SpilledTensorHandle)
-
-        second = share_memory_for_ipc({NodeType("user"): handle.load()})
-
-        self.assertEqual(second[NodeType("user")], handle)
-        self.assertEqual(
-            len(list(Path(self._spill_dir.name).glob("spill_*.bin"))),
-            1,
-            "the same bytes were written to a second spill file",
         )
 
     def test_prepare_removes_files_from_previous_runs(self):
@@ -819,29 +910,31 @@ class ShareMemoryForIpcTest(TestCase):
         first_queue = ctx.Queue()
         first = ctx.Process(target=_spill_in_child, args=(first_queue,))
         first.start()
-        first_handle = first_queue.get(timeout=120)
+        first_tensor = first_queue.get(timeout=120)
         first.join(timeout=120)
         self.assertEqual(first.exitcode, 0)
+        first_path = _spill_file_path(first_tensor)
         self.assertTrue(
-            Path(first_handle.path).exists(),
+            Path(first_path).exists(),
             "the first child's spill vanished on its own",
         )
 
         second_queue = ctx.Queue()
         second = ctx.Process(target=_spill_in_child, args=(second_queue,))
         second.start()
-        second_handle = second_queue.get(timeout=120)
+        second_tensor = second_queue.get(timeout=120)
         second.join(timeout=120)
         self.assertEqual(second.exitcode, 0)
 
-        self.assertNotEqual(first_handle.path, second_handle.path)
+        self.assertNotEqual(first_path, _spill_file_path(second_tensor))
         self.assertTrue(
-            Path(first_handle.path).exists(),
+            Path(first_path).exists(),
             "the second child deleted the first child's live spill file",
         )
-        # And the parent -- which only maps after both children are gone -- still gets the data.
-        assert_close(first_handle.load(), torch.arange(100_000, dtype=torch.float32))
-        assert_close(second_handle.load(), torch.arange(100_000, dtype=torch.float32))
+        # And the parent -- which received both tensors after their writers exited -- still gets
+        # the data.
+        assert_close(first_tensor, torch.arange(100_000, dtype=torch.float32))
+        assert_close(second_tensor, torch.arange(100_000, dtype=torch.float32))
 
 
 if __name__ == "__main__":

--- a/tests/unit/utils/share_memory_test.py
+++ b/tests/unit/utils/share_memory_test.py
@@ -1,12 +1,37 @@
+import errno
+import gc
+import os
+import pickle
+import tempfile
 from collections import abc
+from pathlib import Path
 from typing import Optional, Union
+from unittest import mock
 
+import numpy as np
 import torch
+import torch.multiprocessing as mp
 from graphlearn_torch.partition import RangePartitionBook
 from parameterized import param, parameterized
+from torch.testing import assert_close
 
 from gigl.src.common.types.graph_data import NodeType
-from gigl.utils.share_memory import share_memory
+from gigl.utils import share_memory as share_memory_module
+from gigl.utils.share_memory import (
+    SpilledTensorHandle,
+    allocate_disk_backed,
+    allocate_preshared,
+    disk_backed_handle,
+    has_live_mapping,
+    is_disk_backed,
+    prepare_spill_dir,
+    release_page_cache,
+    release_page_cache_by_path,
+    resolve_spilled_handles,
+    share_memory,
+    share_memory_for_ipc,
+    spill_tensor_to_disk,
+)
 from tests.test_assets.test_case import TestCase
 
 
@@ -68,3 +93,727 @@ class ShareMemoryTest(TestCase):
         empty_2d_tensor = torch.empty((5, 0))
         share_memory(empty_2d_tensor)
         self.assertFalse(empty_2d_tensor.is_shared())
+
+
+def _load_in_child(
+    prepared: dict[NodeType, Union[torch.Tensor, SpilledTensorHandle]],
+    result_queue: "mp.Queue",
+) -> None:
+    """Resolve handles in a spawned child and report what arrived, plus the Shmem delta.
+
+    Runs in a separate process on purpose: the failure this guards against only exists across a
+    process boundary, where pickling an mmap-backed tensor copies it into ``/dev/shm``.
+    """
+    before = _shmem_kib()
+    resolved = resolve_spilled_handles(prepared)
+    after = _shmem_kib()
+    result_queue.put(
+        {
+            key: (tuple(tensor.shape), str(tensor.dtype), tensor.sum().item())
+            for key, tensor in resolved.items()
+        }
+    )
+    result_queue.put(after - before)
+    result_queue.close()
+    result_queue.join_thread()
+
+
+def _spill_in_child(result_queue: "mp.Queue") -> None:
+    """Spill a tensor in a spawned child and hand back only its descriptor, then exit.
+
+    Mirrors what a tensor-loading child does, including exiting before the parent uses the file.
+    """
+    prepared = share_memory_for_ipc(
+        {NodeType("user"): torch.arange(100_000, dtype=torch.float32)}
+    )
+    result_queue.put(prepared[NodeType("user")])
+    result_queue.close()
+    result_queue.join_thread()
+
+
+def _share_memory_in_child(
+    handle: SpilledTensorHandle, result_queue: "mp.Queue"
+) -> None:
+    """Map a spilled tensor, pass it to share_memory, and report whether it got copied to RAM."""
+    tensor = handle.load()
+    before = _shmem_kib()
+    share_memory(tensor)
+    result_queue.put((_shmem_kib() - before, tensor.is_shared()))
+    result_queue.close()
+    result_queue.join_thread()
+
+
+class _RecordingMmap:
+    """Stand-in for the memmap's underlying ``mmap.mmap``, which is a C type and cannot be patched."""
+
+    def __init__(self, calls: list[str]) -> None:
+        self._calls = calls
+
+    def madvise(self, *_args: object) -> None:
+        self._calls.append("madvise")
+
+
+class _FailingMmap:
+    """A mapping whose ``madvise`` is unsupported, as on a platform or filesystem that lacks it."""
+
+    def madvise(self, *_args: object) -> None:
+        raise OSError("madvise unsupported")
+
+
+def _resident_page_fraction(tensor: torch.Tensor) -> Optional[float]:
+    """Fraction of a tensor's pages currently resident, via ``mincore``, or None if unavailable.
+
+    The only way to tell a real eviction from a call that returned success and did nothing. Reading
+    the tensor to check would itself refault every page, so residency must be sampled through the
+    kernel rather than by touching memory.
+    """
+    import ctypes
+    import ctypes.util
+
+    page_size = os.sysconf("SC_PAGE_SIZE")
+    length = tensor.numel() * tensor.element_size()
+    pages = (length + page_size - 1) // page_size
+    try:
+        libc = ctypes.CDLL(ctypes.util.find_library("c") or "libc.so.6", use_errno=True)
+        mincore = libc.mincore
+    except (OSError, AttributeError):
+        return None
+    mincore.restype = ctypes.c_int
+    mincore.argtypes = [ctypes.c_void_p, ctypes.c_size_t, ctypes.c_char_p]
+    vector = ctypes.create_string_buffer(pages)
+    # mincore requires a page-aligned address; a whole mapping's data_ptr always is.
+    address = tensor.data_ptr()
+    if address % page_size:
+        return None
+    if mincore(ctypes.c_void_p(address), ctypes.c_size_t(length), vector) != 0:
+        return None
+    return sum(byte & 1 for byte in vector.raw) / pages
+
+
+def _fallocate_reflected_in_st_blocks(directory: str) -> bool:
+    """Whether this filesystem both supports ``posix_fallocate`` and shows it in ``st_blocks``.
+
+    Two separate capabilities, and both are needed before a block-count assertion means anything.
+    Probed on the directory under test rather than assumed, because tests run on whatever the
+    developer or CI happens to mount.
+    """
+    fd, path = tempfile.mkstemp(dir=directory)
+    probe_bytes = 1 << 20
+    try:
+        os.posix_fallocate(fd, 0, probe_bytes)
+        return os.stat(path).st_blocks * 512 >= probe_bytes
+    except (AttributeError, OSError):
+        return False
+    finally:
+        os.close(fd)
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _shmem_kib() -> int:
+    """POSIX shared memory in use, from /proc/meminfo.
+
+    Read from meminfo rather than by listing ``/dev/shm``: torch's ``file_descriptor`` sharing
+    strategy unlinks its segment immediately, so the directory looks empty while the pages are very
+    much resident. An earlier probe that scanned the directory reported a false negative for
+    exactly this reason.
+    """
+    with open("/proc/meminfo") as meminfo:
+        for line in meminfo:
+            if line.startswith("Shmem:"):
+                return int(line.split()[1])
+    raise AssertionError("no Shmem line in /proc/meminfo")
+
+
+class ShareMemoryForIpcTest(TestCase):
+    def setUp(self) -> None:
+        self._spill_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self._spill_dir.cleanup)
+        self._env = mock.patch.dict(
+            os.environ,
+            {
+                "GIGL_TENSOR_SPILL_DIR": self._spill_dir.name,
+                # Well below the tensors here, so they spill; the production default is 2 GiB.
+                "GIGL_TENSOR_SPILL_MIN_BYTES": str(64 * 1024),
+            },
+        )
+        self._env.start()
+        self.addCleanup(self._env.stop)
+        # The prepared-marker is process-wide and deliberately survives across calls in production
+        # (spawn children inherit it, which is what stops a later sibling from deleting an earlier
+        # sibling's live spill files). That makes it test-visible state: any earlier test that goes
+        # through share_memory_for_ipc sets it, and prepare_spill_dir then returns early, so
+        # test_prepare_removes_files_from_previous_runs would find its stale file still there.
+        # mock.patch.dict overrides keys but does not remove ones it was not given, so clear it
+        # explicitly. Each test gets a fresh temp spill dir, so there is never anything live to
+        # protect here.
+        os.environ.pop("GIGL_TENSOR_SPILL_DIR_PREPARED", None)
+
+    def test_spilled_tensors_are_sent_as_handles_not_tensors(self):
+        entity = {
+            NodeType("user"): torch.arange(100_000, dtype=torch.float32),
+            # Under the threshold, so it should stay a tensor in shared memory.
+            NodeType("item"): torch.arange(10, dtype=torch.float32),
+        }
+        prepared = share_memory_for_ipc(entity)
+
+        self.assertIsInstance(prepared[NodeType("user")], SpilledTensorHandle)
+        small = prepared[NodeType("item")]
+        assert isinstance(small, torch.Tensor)
+        self.assertTrue(small.is_shared())
+
+        # The whole point: what crosses the boundary must be small, whatever the tensor's size.
+        self.assertLess(len(pickle.dumps(prepared)), 4096)
+
+    def test_handles_resolve_to_the_same_values_in_another_process(self):
+        entity = {
+            NodeType("user"): torch.arange(100_000, dtype=torch.float32),
+            NodeType("item"): torch.arange(10, dtype=torch.float32),
+        }
+        expected = {
+            key: (tuple(t.shape), str(t.dtype), t.sum().item())
+            for key, t in entity.items()
+        }
+        prepared = share_memory_for_ipc(entity)
+
+        ctx = mp.get_context("spawn")
+        result_queue = ctx.Queue()
+        child = ctx.Process(target=_load_in_child, args=(prepared, result_queue))
+        child.start()
+        got = result_queue.get(timeout=120)
+        shmem_delta_kib = result_queue.get(timeout=120)
+        child.join(timeout=120)
+
+        self.assertEqual(child.exitcode, 0)
+        self.assertEqual(got, expected)
+        # 400 KB of features must not appear in RAM-backed shared memory on the far side. The
+        # bound is loose because the whole machine's Shmem is being sampled, not just ours.
+        self.assertLess(shmem_delta_kib, 200)
+
+    def test_resolve_passes_through_tensors_and_none(self):
+        tensor = torch.arange(10)
+        self.assertIs(resolve_spilled_handles(tensor), tensor)
+        self.assertIsNone(resolve_spilled_handles(None))
+
+    def test_share_memory_leaves_a_disk_backed_tensor_alone(self):
+        """``share_memory_()`` on an mmap view copies it into /dev/shm, undoing the spill.
+
+        Measured at +16,128 kB for a 16 MiB tensor, so a caller that reaches one of these tensors
+        after it has been spilled would silently put it back in RAM.
+        """
+        prepared = share_memory_for_ipc(
+            {NodeType("user"): torch.arange(1_000_000, dtype=torch.float32)}
+        )
+        handle = prepared[NodeType("user")]
+        assert isinstance(handle, SpilledTensorHandle)
+
+        ctx = mp.get_context("spawn")
+        result_queue = ctx.Queue()
+        child = ctx.Process(target=_share_memory_in_child, args=(handle, result_queue))
+        child.start()
+        shmem_delta_kib, is_shared = result_queue.get(timeout=120)
+        child.join(timeout=120)
+
+        self.assertEqual(child.exitcode, 0)
+        self.assertFalse(is_shared, "share_memory relocated a disk-backed tensor")
+        self.assertLess(shmem_delta_kib, 512)
+
+    def test_share_memory_still_shares_an_ordinary_tensor(self):
+        tensor = torch.arange(1000, dtype=torch.float32)
+
+        share_memory(tensor)
+
+        self.assertTrue(tensor.is_shared())
+
+    def test_allocate_disk_backed_returns_a_writable_file_backed_buffer(self):
+        """The destination IS the file, so the bytes never occupy anonymous memory at all.
+
+        Spilling has to fill memory first and then copy it out; a buffer that is assembled
+        incrementally can skip that entirely.
+        """
+        buffer = allocate_disk_backed((5000, 8), torch.float32)
+
+        assert buffer is not None
+        self.assertEqual(buffer.shape, (5000, 8))
+        self.assertEqual(buffer.dtype, torch.float32)
+        self.assertTrue(is_disk_backed(buffer))
+        # Writable, and scattered advanced-index assignment lands correctly -- that is exactly how
+        # the range partitioner fills it.
+        rows = torch.tensor([4999, 0, 2500])
+        buffer[rows] = torch.arange(3, dtype=torch.float32).unsqueeze(1).repeat(1, 8)
+        assert_close(buffer[4999], torch.zeros(8))
+        assert_close(buffer[0], torch.ones(8))
+        assert_close(buffer[2500], torch.full((8,), 2.0))
+        self.assertEqual(
+            len(list(Path(self._spill_dir.name).glob("spill_*.bin"))),
+            1,
+        )
+
+    def test_a_reserved_file_is_mapped_without_truncating_it(self):
+        """A reserved file must be mapped ``r+``, never ``w+``.
+
+        Not hypothetical: numpy opens ``mode="w+"`` as ``w+b``, which truncates the file and hands
+        every block ``posix_fallocate`` reserved straight back, leaving it sparse and the SIGBUS risk
+        exactly where it started.
+
+        Asserted on the MODE rather than on the resulting block count, so the check is deterministic:
+        block accounting varies by filesystem, while the mode used for a reserved file must never
+        vary.
+        """
+        real_memmap = np.memmap
+        with mock.patch("numpy.memmap", side_effect=real_memmap) as memmap_spy:
+            buffer = allocate_disk_backed((20_000, 8), torch.float32)
+
+        assert buffer is not None
+        self.assertEqual(memmap_spy.call_count, 1)
+        self.assertEqual(
+            memmap_spy.call_args.kwargs.get("mode"),
+            "r+",
+            "a reserved file was mapped with a mode that truncates it",
+        )
+
+    def test_the_reserved_blocks_are_still_allocated_after_mapping(self):
+        """End-to-end version of the above, where the filesystem can actually demonstrate it.
+
+        Skipped rather than failed where ``posix_fallocate`` is unsupported or where ``st_blocks``
+        does not reflect reservations -- compressed, copy-on-write, network and emulated filesystems
+        all account for blocks differently, so ``st_blocks`` is not a portable oracle even though
+        the reservation itself is mandatory.
+        """
+        if not _fallocate_reflected_in_st_blocks(self._spill_dir.name):
+            self.skipTest(
+                "this filesystem does not report reserved extents through st_blocks"
+            )
+        rows, columns = 20_000, 8
+        expected_bytes = rows * columns * 4
+
+        buffer = allocate_disk_backed((rows, columns), torch.float32)
+
+        assert buffer is not None
+        handle = disk_backed_handle(buffer)
+        assert handle is not None
+        stat = os.stat(handle.path)
+        self.assertEqual(stat.st_size, expected_bytes)
+        # st_blocks counts 512-byte units actually allocated; a sparse file reports far fewer than
+        # its apparent size.
+        self.assertGreaterEqual(
+            stat.st_blocks * 512,
+            expected_bytes,
+            "the file is sparse -- the fallocate reservation was discarded by the mapping",
+        )
+
+    def test_a_filesystem_that_cannot_reserve_gets_memory_not_a_file(self):
+        """Reservation is mandatory: a refused ``posix_fallocate`` means no file-backed tensor.
+
+        An unreserved mapping takes SIGBUS -- a signal no ``except`` can catch -- if the filesystem
+        fills, so both refusal flavours must yield None (the caller falls back to memory) and must
+        leave no partial file behind. Covers the allocate path and the spill-copy path, which share
+        the reservation.
+        """
+        for refusal in (errno.ENOSPC, errno.EOPNOTSUPP):
+            with self.subTest(errno=errno.errorcode[refusal]):
+                with mock.patch(
+                    "os.posix_fallocate",
+                    side_effect=OSError(refusal, os.strerror(refusal)),
+                ):
+                    buffer = allocate_disk_backed((20_000, 8), torch.float32)
+                    spilled = spill_tensor_to_disk(torch.randn(20_000, 8))
+                self.assertIsNone(buffer)
+                self.assertIsNone(spilled)
+                leftovers = [
+                    entry.name
+                    for entry in os.scandir(self._spill_dir.name)
+                    if entry.name.startswith("spill_")
+                ]
+                self.assertEqual(
+                    leftovers, [], "a refused reservation left a file behind"
+                )
+
+    def test_release_page_cache_unmaps_before_discarding(self):
+        """The ORDER is the whole mechanism, so it is pinned deterministically.
+
+        ``FADV_DONTNEED`` on a live mapping is a no-op that reports success -- Linux skips pages held
+        in a page table. So ``MADV_DONTNEED`` must come first, and after an ``msync`` because dirty
+        pages cannot be dropped at all. A residency test alone would not catch a reordering that
+        happens to work on one kernel.
+        """
+        buffer = allocate_disk_backed((40_000, 8), torch.float32)
+        assert buffer is not None
+        calls: list[str] = []
+        handle = disk_backed_handle(buffer)
+        assert handle is not None
+        backing = buffer.numpy().base
+        # torch.from_numpy(np.asarray(memmap)) -- reach the memmap the same way the code does.
+        for _, _, reference, registered in share_memory_module._spilled_mappings:
+            if registered is handle:
+                array = reference()
+                assert array is not None, (
+                    "the mapping was collected before the test ran"
+                )
+                backing = array.base
+                break
+
+        # `mmap.mmap` is a C type whose `madvise` cannot be patched, so the whole object is
+        # swapped for a recorder. `_mmap` is a plain attribute of numpy's memmap, so this is
+        # exactly the object the implementation reaches for.
+        with (
+            mock.patch.object(
+                backing, "flush", side_effect=lambda: calls.append("msync")
+            ),
+            mock.patch.object(backing, "_mmap", _RecordingMmap(calls)),
+            mock.patch.object(
+                os, "fsync", side_effect=lambda fd: calls.append("fsync")
+            ),
+            mock.patch.object(
+                os, "posix_fadvise", side_effect=lambda *a: calls.append("fadvise")
+            ),
+        ):
+            released = release_page_cache(buffer)
+
+        self.assertTrue(released)
+        self.assertEqual(calls, ["msync", "madvise", "fsync", "fadvise"])
+
+    def test_release_page_cache_reports_failure_when_it_cannot_unmap(self):
+        """A no-op must report False, not True.
+
+        The first version of this returned True after calling only ``FADV_DONTNEED``, which drops
+        nothing while the pages are mapped -- so the log said 56.4 GiB had been freed when none had.
+        """
+        buffer = allocate_disk_backed((40_000, 8), torch.float32)
+        assert buffer is not None
+        handle = disk_backed_handle(buffer)
+        assert handle is not None
+        backing = None
+        for _, _, reference, registered in share_memory_module._spilled_mappings:
+            if registered is handle:
+                array = reference()
+                assert array is not None, (
+                    "the mapping was collected before the test ran"
+                )
+                backing = array.base
+                break
+        assert backing is not None
+
+        with mock.patch.object(backing, "_mmap", _FailingMmap()):
+            self.assertFalse(release_page_cache(buffer))
+
+    def test_release_page_cache_actually_reduces_residency(self):
+        """Measured, not assumed: ``mincore`` before and after.
+
+        The previous version of this test only proved the data survived, which it would have done
+        even with the broken implementation -- and touching every page to check repopulated the cache
+        before anything could observe it. Residency has to be read BEFORE the refault.
+        """
+        rows, columns = (
+            200_000,
+            32,
+        )  # 25.6 MB, enough that partial eviction is unambiguous
+        buffer = allocate_disk_backed((rows, columns), torch.float32)
+        assert buffer is not None
+        expected = (
+            torch.arange(rows, dtype=torch.float32).unsqueeze(1).repeat(1, columns)
+        )
+        buffer.copy_(expected)
+        resident_before = _resident_page_fraction(buffer)
+        if resident_before is None:
+            self.skipTest("mincore unavailable on this platform")
+        self.assertGreater(
+            resident_before,
+            0.5,
+            "the buffer should be resident right after being written",
+        )
+
+        released = release_page_cache(buffer)
+        resident_after = _resident_page_fraction(buffer)
+
+        self.assertTrue(released)
+        assert resident_after is not None
+        self.assertLess(
+            resident_after,
+            0.1,
+            f"pages stayed resident ({resident_after:.0%}) -- eviction did not happen",
+        )
+        # And only now touch it, which must refault the real data back.
+        assert_close(buffer, expected)
+
+    def test_release_page_cache_drops_resident_pages_and_keeps_the_data(self):
+        """Dropping the cache must remove the cgroup charge without losing the bytes.
+
+        This is the fix for a misconception that has OOM-killed a real run: moving a tensor to a
+        file makes its pages reclaimable but leaves them CHARGED to ``memory.current``, so a
+        tens-of-GiB feature matrix still counted against the limit during the CSR build. Resident pages are read
+        from ``/proc/self/smaps_rollup``-style accounting via mincore semantics; here the simpler
+        observable is that the values survive a refault.
+        """
+        rows, columns = 40_000, 8
+        buffer = allocate_disk_backed((rows, columns), torch.float32)
+        assert buffer is not None
+        expected = (
+            torch.arange(rows, dtype=torch.float32).unsqueeze(1).repeat(1, columns)
+        )
+        buffer.copy_(expected)
+
+        dropped = release_page_cache(buffer)
+
+        self.assertTrue(
+            dropped, "the buffer was disk-backed, so the cache should have been dropped"
+        )
+        # The mapping is still valid and the data must refault intact -- dropping cache must never
+        # be a data-loss operation.
+        assert_close(buffer, expected)
+        # And the flush must have reached the file, not just the cache: read it through a fresh
+        # mapping that shares nothing with the original.
+        handle = disk_backed_handle(buffer)
+        assert handle is not None
+        assert_close(handle.load(), expected)
+
+    def test_release_page_cache_declines_for_an_ordinary_tensor(self):
+        self.assertFalse(release_page_cache(torch.arange(1000, dtype=torch.float32)))
+
+    def test_release_by_path_refuses_while_a_tensor_still_maps_the_file(self):
+        """A live mapping must be reported as a failure, not silently freeing nothing.
+
+        ``FADV_DONTNEED`` skips pages that are in any page table, so calling it on a still-mapped
+        file returns success having freed nothing -- the same trap that made ``release_page_cache``
+        a no-op before ``MADV_DONTNEED`` was added. Here the caller cannot unmap on our behalf, so
+        the only honest answer is False.
+        """
+        buffer = allocate_disk_backed((40_000, 8), torch.float32)
+        assert buffer is not None
+        handle = disk_backed_handle(buffer)
+        assert handle is not None
+        buffer.fill_(1.0)
+
+        self.assertTrue(has_live_mapping(handle.path))
+        self.assertFalse(
+            release_page_cache_by_path(handle.path),
+            "a still-mapped file cannot have its cache dropped by fadvise alone",
+        )
+
+        del buffer
+        gc.collect()
+
+        self.assertFalse(has_live_mapping(handle.path))
+        self.assertTrue(
+            release_page_cache_by_path(handle.path),
+            "with the mapping gone, fadvise is sufficient",
+        )
+
+    def test_preshared_raises_when_the_buffer_cannot_fit_the_mount(self):
+        """A shared allocation larger than the mount must RAISE -- there is no safe fallback.
+
+        Attempting it: sizing a tmpfs object does not reserve its pages, so `_new_shared` against a
+        64 MiB /dev/shm -- Docker's default -- returns a storage and the first write past the limit
+        takes SIGBUS, which no `except` can catch. Falling back to an anonymous tensor: GLT's
+        unguarded `Topology.share_memory_()` then attempts the SAME oversized allocation on the SAME
+        full mount a few seconds later, so the SIGBUS is merely deferred to somewhere less
+        attributable. The n_bytes here (76 MiB) exceeds the mocked mount outright, not just the
+        reserve.
+        """
+        tiny_mount = os.statvfs_result(
+            (4096, 4096, 16384, 16384, 16384, 0, 0, 0, 0, 255)
+        )  # 64 MiB total, 64 MiB free
+
+        with (
+            mock.patch.dict(os.environ, {"GIGL_TENSOR_SPILL_DIR": ""}),
+            mock.patch.object(os, "statvfs", return_value=tiny_mount),
+            self.assertRaisesRegex(RuntimeError, "SIGBUS"),
+        ):
+            allocate_preshared((10_000_000,), torch.int64)  # 76 MiB > 64 MiB mount
+
+    def test_preshared_raises_when_only_the_reserve_is_breached(self):
+        """The reserve is part of the contract: room for the tensor but not the reserve still raises,
+        because torch's queues and the sampling channels allocate on the same mount."""
+        tiny_mount = os.statvfs_result(
+            (4096, 4096, 16384, 16384, 16384, 0, 0, 0, 0, 255)
+        )
+
+        with (
+            mock.patch.dict(os.environ, {"GIGL_TENSOR_SPILL_DIR": ""}),
+            mock.patch.object(os, "statvfs", return_value=tiny_mount),
+            self.assertRaisesRegex(RuntimeError, "reserve"),
+        ):
+            allocate_preshared(
+                (200_000,), torch.int64
+            )  # 1.5 MiB, fits; reserve does not
+
+    def test_preshared_survives_an_unreadable_mount(self):
+        """statvfs failing must not block an allocation that would have worked."""
+        with (
+            mock.patch.dict(
+                os.environ,
+                {
+                    "GIGL_TENSOR_SPILL_DIR": "",
+                    "GIGL_TENSOR_SPILL_MIN_BYTES": str(4 * 1024),
+                },
+            ),
+            mock.patch.object(os, "statvfs", side_effect=OSError("no such mount")),
+        ):
+            tensor = allocate_preshared((200_000,), torch.int64)
+
+        self.assertTrue(tensor.is_shared())
+
+    def test_preshared_uses_shared_memory_when_the_mount_has_room(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {
+                    "GIGL_TENSOR_SPILL_DIR": "",
+                    "GIGL_TENSOR_SPILL_MIN_BYTES": str(4 * 1024),
+                },
+            ),
+            # "has room" must be part of the FIXTURE, not an accident of the host: even 1.6 MB
+            # needs n_bytes + the 2 GiB reserve free, so on a container with Docker's default
+            # 64 MiB /dev/shm this test would exercise the failure branch instead
+            mock.patch.object(
+                share_memory_module, "_shared_memory_shortfall", return_value=None
+            ),
+        ):
+            tensor = allocate_preshared((200_000,), torch.int64)
+
+        self.assertTrue(tensor.is_shared())
+
+    def test_release_by_path_reports_failure_for_a_missing_file(self):
+        self.assertFalse(
+            release_page_cache_by_path(os.path.join(self._spill_dir.name, "absent.bin"))
+        )
+
+    def test_allocate_disk_backed_declines_when_too_small_or_disabled(self):
+        # Below GIGL_TENSOR_SPILL_MIN_BYTES (64 KiB here): not worth a file.
+        self.assertIsNone(allocate_disk_backed((4, 4), torch.float32))
+        # Zero-sized: nothing to back.
+        self.assertIsNone(allocate_disk_backed((0, 8), torch.float32))
+        with mock.patch.dict(os.environ, {"GIGL_TENSOR_SPILL_DIR": ""}):
+            self.assertIsNone(allocate_disk_backed((5000, 8), torch.float32))
+
+    def test_an_already_disk_backed_buffer_is_not_spilled_again(self):
+        """`_spill_partitioned_node_features` runs after assembly; if the assembly already wrote the
+        matrix to disk, copying it to a second file doubles both the disk use and the time."""
+        buffer = allocate_disk_backed((5000, 8), torch.float32)
+        assert buffer is not None
+
+        spilled = spill_tensor_to_disk(buffer)
+
+        assert spilled is not None
+        self.assertIs(spilled.tensor, buffer)
+        self.assertEqual(
+            len(list(Path(self._spill_dir.name).glob("spill_*.bin"))),
+            1,
+            "a second copy of the same bytes was written",
+        )
+
+    def test_a_failed_spill_leaves_no_partial_file(self):
+        """A failure after ``mkstemp`` must not leave orphaned bytes on the spill filesystem.
+
+        The spill filesystem is finite and node features are tens of GiB per replica, so a couple of
+        abandoned partial writes exhaust the disk, spilling stops working, and the tensors go back
+        into RAM -- converting a recoverable spill failure into the OOM the spill exists to prevent.
+        """
+        with mock.patch.object(
+            np.memmap, "flush", side_effect=OSError("no space left on device")
+        ):
+            spilled = spill_tensor_to_disk(torch.arange(100_000, dtype=torch.float32))
+
+        self.assertIsNone(spilled, "a failed spill must report failure")
+        self.assertEqual(
+            list(Path(self._spill_dir.name).glob("spill_*.bin")),
+            [],
+            "a partial spill file was left behind",
+        )
+
+    def test_a_transposed_view_does_not_reuse_the_file_descriptor(self):
+        """Same pointer, same shape, same numel -- different strides.
+
+        A square tensor's transpose matches on everything ``disk_backed_handle`` used to compare, so
+        reusing the descriptor would hand the receiver untransposed values with no error anywhere.
+        """
+        prepared = share_memory_for_ipc(
+            {
+                NodeType("user"): torch.arange(256 * 256, dtype=torch.float32).reshape(
+                    256, 256
+                )
+            }
+        )
+        handle = prepared[NodeType("user")]
+        assert isinstance(handle, SpilledTensorHandle)
+        mapped = handle.load()
+
+        self.assertEqual(disk_backed_handle(mapped), handle)
+        self.assertIsNone(disk_backed_handle(mapped.t()))
+        # A partial view names only part of the file, so it cannot be described by the file either.
+        self.assertIsNone(disk_backed_handle(mapped[:8]))
+
+    def test_an_already_spilled_tensor_is_not_spilled_twice(self):
+        first = share_memory_for_ipc(
+            {NodeType("user"): torch.arange(100_000, dtype=torch.float32)}
+        )
+        handle = first[NodeType("user")]
+        assert isinstance(handle, SpilledTensorHandle)
+
+        second = share_memory_for_ipc({NodeType("user"): handle.load()})
+
+        self.assertEqual(second[NodeType("user")], handle)
+        self.assertEqual(
+            len(list(Path(self._spill_dir.name).glob("spill_*.bin"))),
+            1,
+            "the same bytes were written to a second spill file",
+        )
+
+    def test_prepare_removes_files_from_previous_runs(self):
+        stale = Path(self._spill_dir.name) / "spill_from_a_previous_run.bin"
+        stale.write_bytes(b"\0" * 1024)
+        unrelated = Path(self._spill_dir.name) / "someone_elses_file.bin"
+        unrelated.write_bytes(b"\0" * 16)
+
+        prepare_spill_dir()
+
+        self.assertFalse(stale.exists())
+        # Only files this module could have written are fair game.
+        self.assertTrue(unrelated.exists())
+
+    def test_a_later_sibling_does_not_delete_an_earlier_sibling_spill(self):
+        """The exact ordering that sequential loading produces, in real processes.
+
+        The edge child spills and EXITS; then the node child starts, and only then does it spill.
+        An age-based cleanup in the second child deletes the first child's file -- which the parent
+        has not mapped yet, because it maps only after every child has joined. This test exists
+        because an in-process version of it cannot reproduce that ordering and passed while the bug
+        was live.
+        """
+        prepare_spill_dir()
+        ctx = mp.get_context("spawn")
+
+        first_queue = ctx.Queue()
+        first = ctx.Process(target=_spill_in_child, args=(first_queue,))
+        first.start()
+        first_handle = first_queue.get(timeout=120)
+        first.join(timeout=120)
+        self.assertEqual(first.exitcode, 0)
+        self.assertTrue(
+            Path(first_handle.path).exists(),
+            "the first child's spill vanished on its own",
+        )
+
+        second_queue = ctx.Queue()
+        second = ctx.Process(target=_spill_in_child, args=(second_queue,))
+        second.start()
+        second_handle = second_queue.get(timeout=120)
+        second.join(timeout=120)
+        self.assertEqual(second.exitcode, 0)
+
+        self.assertNotEqual(first_handle.path, second_handle.path)
+        self.assertTrue(
+            Path(first_handle.path).exists(),
+            "the second child deleted the first child's live spill file",
+        )
+        # And the parent -- which only maps after both children are gone -- still gets the data.
+        assert_close(first_handle.load(), torch.arange(100_000, dtype=torch.float32))
+        assert_close(second_handle.load(), torch.arange(100_000, dtype=torch.float32))
+
+
+if __name__ == "__main__":
+    from absl.testing import absltest
+
+    absltest.main()


### PR DESCRIPTION
Adds an opt-in tensor-spill layer to `gigl/utils/share_memory.py`, plus its tests. Off by default: with `GIGL_TENSOR_SPILL_DIR` unset, nothing changes.

## Why

In colocated mode each rank's features and topology live in POSIX shared memory. `/dev/shm` is tmpfs, i.e. RAM, and without swap those pages cannot be evicted; worse, `share_memory_()` on an anonymous tensor **copies** it into `/dev/shm`, so the largest tensors transiently exist twice -- GLT's `Graph.__init__` shares the CSR unconditionally, and at billion-node scale that transient 2x is what OOM-kills the graph build. Spilling large tensors to a local disk turns their bytes into reclaimable page cache, letting large graphs run colocated without a separate storage tier.

## What it adds

- `prepare_spill_dir()` -- run-start cleanup of the spill directory. Cleanup never runs at exit, because the process that spills exits before the consumers unmap; a spill directory belongs to one workload and is reused across its sequential runs.
- `spill_tensor_to_disk` / `allocate_disk_backed` / `allocate_preshared` -- placement. `None` always means "fall back to memory". Sequential-write destinations go to disk (~3.1x measured write cost, bytes never anonymous); scattered destinations prefer memory, because an uncached 8-byte file write is a 4 KiB read-modify-write and a CSR build revisits the same pages hundreds of times. Block reservation via `posix_fallocate` is mandatory, so a filesystem that fills or cannot reserve fails as `OSError` at allocation, never as SIGBUS on a later page write.
- `SpilledTensorHandle` + `share_memory_for_ipc` / `resolve_spilled_handles` -- crossing process boundaries by descriptor. Pickling an mmap-backed tensor copies every byte back into `/dev/shm`, silently undoing the spill, so handles travel instead.
- `release_page_cache` / `release_page_cache_by_path` -- release the cgroup charge of written-once data (msync, then `MADV_DONTNEED`, then `FADV_DONTNEED`; skipping the middle step makes the call a silent no-op).
- Introspection: `is_tensor_spilling_enabled`, `is_disk_backed`, `disk_backed_handle`, `has_live_mapping`.

Placement decisions read `available_memory_bytes()` from #756.

## Behaviour change

None when spilling is unset. `share_memory()` keeps its `-> None` signature; its one change is leaving an already disk-backed tensor alone rather than copying it into `/dev/shm`, reachable only with spilling on.

## Testing

32 tests pass; `ty` and `ruff` clean. The tests exercise the real filesystem: spill/re-map round trips, threshold and dtype refusals, handle pickling across processes, forced `posix_fallocate` refusal (both "no space" and "not supported") asserting memory fallback with no leftover file, preshared allocation asserted on `data_ptr` stability across `share_memory_()`, and page-cache release asserted on measured page residency (`mincore`) rather than return values.

## Open questions

- Module home: this extends `share_memory.py` because `share_memory()` itself must recognise disk-backed tensors; a separate module importing the registry check is workable if a ~1k-line utility file is unwanted.
- Env vars vs config plumbing: env vars are required at the `mp.spawn` boundary, but a config field mapped to them may be the friendlier surface.
- Defaults: the 2 GiB spill threshold and 16 GiB scattered-write reserve are the values validated at ~1B-node scale.
- Should the final direct-to-shared-memory allocation also require cgroup headroom, failing fast instead of risking a later OOM?
