### PR TITLE
Make sampling-loader bring-up and steady-state RPC timeouts configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Make sampling-loader bring-up and steady-state RPC timeouts configurable via `GIGL_SAMPLING_RPC_TIMEOUT_SECONDS`,
+  `GIGL_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS`, and `GIGL_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS`; a sampling worker
+  dying before its init barrier now fails the job with the dead workers' ranks and exit codes instead of hanging by
+  @dsaini2 in https://github.com/Snapchat/GiGL/pull/PENDING
+
 ### Removed
 
 - Remove the deprecated `RESOURCE_CONFIG_PATH` environment variable; use `GIGL_RESOURCE_CONFIG_URI` instead by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Make the sampling-loader bring-up RPC timeout configurable via `GIGL_SAMPLING_RPC_INIT_TIMEOUT_SECONDS` (workers reset
-  to the 600 s steady-state timeout once initialized, and the wait for workers to initialize is bounded at 3x the bring-up
-  timeout); a sampling worker dying before its init barrier now fails the job with the dead workers' ranks and exit codes
-  instead of hanging by @dsaini2 in https://github.com/Snapchat/GiGL/pull/PENDING
+  to the 600 s steady-state timeout once initialized, and the wait for workers to initialize is bounded at 3x the
+  bring-up timeout); a sampling worker dying before its init barrier now fails the job with the dead workers' ranks and
+  exit codes instead of hanging by @dsaini2 in https://github.com/Snapchat/GiGL/pull/760
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Make sampling-loader bring-up and steady-state RPC timeouts configurable via `GIGL_SAMPLING_RPC_TIMEOUT_SECONDS`,
-  `GIGL_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS`, and `GIGL_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS`; a sampling worker
-  dying before its init barrier now fails the job with the dead workers' ranks and exit codes instead of hanging by
-  @dsaini2 in https://github.com/Snapchat/GiGL/pull/PENDING
+- Make the sampling-loader bring-up RPC timeout configurable via `GIGL_SAMPLING_RPC_INIT_TIMEOUT_SECONDS` (workers reset
+  to the 600 s steady-state timeout once initialized, and the wait for workers to initialize is bounded at 3x the bring-up
+  timeout); a sampling worker dying before its init barrier now fails the job with the dead workers' ranks and exit codes
+  instead of hanging by @dsaini2 in https://github.com/Snapchat/GiGL/pull/PENDING
 
 ### Removed
 

--- a/gigl/distributed/base_dist_loader.py
+++ b/gigl/distributed/base_dist_loader.py
@@ -36,7 +36,10 @@ from typing_extensions import Self
 
 import gigl.distributed.utils
 from gigl.common.logger import Logger
-from gigl.distributed.constants import DEFAULT_MASTER_INFERENCE_PORT
+from gigl.distributed.constants import (
+    DEFAULT_MASTER_INFERENCE_PORT,
+    sampling_rpc_timeout_seconds,
+)
 from gigl.distributed.dist_context import DistributedContext
 from gigl.distributed.dist_dataset import DistDataset
 from gigl.distributed.dist_ppr_sampler import (
@@ -670,7 +673,7 @@ class BaseDistLoader(DistLoader):
             # Load testing shows that when num_rpc_threads exceed 16, the performance
             # will degrade.
             num_rpc_threads=min(dataset_num_partitions, 16),
-            rpc_timeout=600,
+            rpc_timeout=sampling_rpc_timeout_seconds(),
             channel_size=channel_size,
             pin_memory=pin_memory,
         )

--- a/gigl/distributed/base_dist_loader.py
+++ b/gigl/distributed/base_dist_loader.py
@@ -38,7 +38,7 @@ import gigl.distributed.utils
 from gigl.common.logger import Logger
 from gigl.distributed.constants import (
     DEFAULT_MASTER_INFERENCE_PORT,
-    sampling_rpc_timeout_seconds,
+    sampling_rpc_init_timeout_seconds,
 )
 from gigl.distributed.dist_context import DistributedContext
 from gigl.distributed.dist_dataset import DistDataset
@@ -673,7 +673,7 @@ class BaseDistLoader(DistLoader):
             # Load testing shows that when num_rpc_threads exceed 16, the performance
             # will degrade.
             num_rpc_threads=min(dataset_num_partitions, 16),
-            rpc_timeout=sampling_rpc_timeout_seconds(),
+            rpc_timeout=sampling_rpc_init_timeout_seconds(),
             channel_size=channel_size,
             pin_memory=pin_memory,
         )

--- a/gigl/distributed/constants.py
+++ b/gigl/distributed/constants.py
@@ -1,3 +1,10 @@
+import os
+from typing import Final
+
+from gigl.common.logger import Logger
+
+logger = Logger()
+
 # TODO (mkolodner-sc): Set these ports dynamically while ensuring no overlap
 # Ports for various purposes, we need to make sure they do not overlap.
 # Note that [master_port_for_inference, master_port_for_inference + num_inference_processes).
@@ -5,3 +12,83 @@
 DEFAULT_MASTER_INFERENCE_PORT = 10_000
 DEFAULT_MASTER_SAMPLING_PORT = 20_000
 DEFAULT_MASTER_DATA_BUILDING_PORT = 30_000
+
+# --------------------------------------------------------------------------------------------
+# Loader bring-up skew tolerance.
+#
+# Constructing a distributed loader is a cluster-wide rendezvous: every sampling worker on every
+# rank must complete GLT's ``init_rpc``, which gathers all ``num_workers x world_size`` of them,
+# and only then does each rank's parent pass its local init barrier. NOTHING synchronises ranks
+# between the end of dataset building and the FIRST loader construction (the barriers in the
+# applied trainers come *after* each loader), so any skew accumulated during partitioning or CSR
+# assembly is spent here.
+#
+# Two independent mechanisms bound that wait, and they must be set together:
+#   * the RPC gather tolerance (below) -- exceeded, a worker dies
+#   * ``DistSamplingProducer``'s init barrier -- unbounded, its parent would wedge forever
+# A dead worker whose parent wedges is the worst case: the healthy peers block in collectives
+# until the training process group's own timeout fires, which is now hours rather than minutes.
+# --------------------------------------------------------------------------------------------
+SAMPLING_RPC_TIMEOUT_ENV: Final[str] = "GIGL_SAMPLING_RPC_TIMEOUT_SECONDS"
+# 600 s is GLT's own default and is preserved so this change alters no existing behaviour.
+DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS: Final[int] = 600
+
+# GLT's ``rpc_timeout`` is not init-only: it becomes the RPC agent's default request timeout for
+# EVERY sampling and feature-collection RPC. Raising it to tolerate bring-up skew would therefore
+# also mean a genuinely stuck steady-state request takes that long to surface -- trading a fast,
+# diagnosable stall for a slow one. So the worker resets the agent's timeout to the value below
+# immediately after it passes the init barrier, which is exactly the boundary between the two
+# regimes. Default 600 s: identical to what steady-state sampling gets today.
+SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV: Final[str] = (
+    "GIGL_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS"
+)
+DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS: Final[int] = 600
+
+SAMPLING_WORKER_INIT_TIMEOUT_ENV: Final[str] = (
+    "GIGL_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS"
+)
+# Above the RPC tolerance: a worker that loses the gather is already dead, so the barrier should
+# outlive the gather and report that death rather than time out first and blame the wrong thing.
+DEFAULT_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS: Final[int] = 1800
+
+
+def _positive_int_from_env(name: str, default: int) -> int:
+    """Read a positive integer from the environment, warning and defaulting on anything else."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        parsed = int(raw)
+    except ValueError:
+        logger.warning(f"{name}={raw!r} is not an integer; using {default}")
+        return default
+    if parsed <= 0:
+        logger.warning(f"{name}={parsed} is not positive; using {default}")
+        return default
+    return parsed
+
+
+def sampling_rpc_timeout_seconds() -> int:
+    """Tolerance for GLT's cross-rank sampling-worker RPC gather, in seconds.
+
+    Raise this when ranks can legitimately reach loader construction more than the default apart
+    -- e.g. a run whose CSR assembly has a slow single-rank fallback path.
+    """
+    return _positive_int_from_env(
+        SAMPLING_RPC_TIMEOUT_ENV, DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS
+    )
+
+
+def sampling_steady_state_rpc_timeout_seconds() -> int:
+    """Request timeout applied to sampling RPCs once a worker is past its init barrier."""
+    return _positive_int_from_env(
+        SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV,
+        DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
+    )
+
+
+def sampling_worker_init_timeout_seconds() -> int:
+    """Bound on how long a rank waits for its own sampling workers to reach the init barrier."""
+    return _positive_int_from_env(
+        SAMPLING_WORKER_INIT_TIMEOUT_ENV, DEFAULT_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS
+    )

--- a/gigl/distributed/constants.py
+++ b/gigl/distributed/constants.py
@@ -23,33 +23,30 @@ DEFAULT_MASTER_DATA_BUILDING_PORT = 30_000
 # applied trainers come *after* each loader), so any skew accumulated during partitioning or CSR
 # assembly is spent here.
 #
-# Two independent mechanisms bound that wait, and they must be set together:
-#   * the RPC gather tolerance (below) -- exceeded, a worker dies
-#   * ``DistSamplingProducer``'s init barrier -- unbounded, its parent would wedge forever
-# A dead worker whose parent wedges is the worst case: the healthy peers block in collectives
-# until the training process group's own timeout fires, which is now hours rather than minutes.
+# Two mechanisms bound that wait; both derive from the single env var below so they cannot be
+# mis-set relative to each other:
+#   * the RPC gather tolerance -- exceeded, a worker dies
+#   * ``DistSamplingProducer``'s init barrier, bounded at a multiple of the gather tolerance --
+#     previously unbounded, so a dead worker left its parent wedged forever while healthy peers
+#     blocked in collectives until the training process group's own timeout fired.
 # --------------------------------------------------------------------------------------------
-SAMPLING_RPC_TIMEOUT_ENV: Final[str] = "GIGL_SAMPLING_RPC_TIMEOUT_SECONDS"
-# 600 s is GLT's own default and is preserved so this change alters no existing behaviour.
-DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS: Final[int] = 600
+SAMPLING_RPC_INIT_TIMEOUT_ENV: Final[str] = "GIGL_SAMPLING_RPC_INIT_TIMEOUT_SECONDS"
+# GLT's own default
+DEFAULT_SAMPLING_RPC_INIT_TIMEOUT_SECONDS: Final[int] = 600
 
 # GLT's ``rpc_timeout`` is not init-only: it becomes the RPC agent's default request timeout for
 # EVERY sampling and feature-collection RPC. Raising it to tolerate bring-up skew would therefore
 # also mean a genuinely stuck steady-state request takes that long to surface -- trading a fast,
-# diagnosable stall for a slow one. So the worker resets the agent's timeout to the value below
-# immediately after it passes the init barrier, which is exactly the boundary between the two
-# regimes. Default 600 s: identical to what steady-state sampling gets today.
-SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV: Final[str] = (
-    "GIGL_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS"
-)
-DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS: Final[int] = 600
+# diagnosable stall for a slow one. So the worker resets the agent's timeout back to this value
+# (GLT's default) immediately after it passes the init barrier, which is exactly the boundary
+# between the two regimes. Deliberately not configurable: steady-state sampling keeps today's
+# behaviour no matter how far bring-up tolerance is raised.
+SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS: Final[int] = 600
 
-SAMPLING_WORKER_INIT_TIMEOUT_ENV: Final[str] = (
-    "GIGL_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS"
-)
-# Above the RPC tolerance: a worker that loses the gather is already dead, so the barrier should
-# outlive the gather and report that death rather than time out first and blame the wrong thing.
-DEFAULT_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS: Final[int] = 1800
+# The init barrier must outlive the RPC gather: a worker that loses the gather is already dead,
+# and the barrier should report that death rather than time out first and blame the wrong thing.
+# 3x leaves margin for post-gather worker setup, and 3 x 600 reproduces the previous 1800 s bound.
+SAMPLING_WORKER_INIT_TIMEOUT_MULTIPLIER: Final[int] = 3
 
 
 def _positive_int_from_env(name: str, default: int) -> int:
@@ -68,27 +65,21 @@ def _positive_int_from_env(name: str, default: int) -> int:
     return parsed
 
 
-def sampling_rpc_timeout_seconds() -> int:
+def sampling_rpc_init_timeout_seconds() -> int:
     """Tolerance for GLT's cross-rank sampling-worker RPC gather, in seconds.
 
     Raise this when ranks can legitimately reach loader construction more than the default apart
     -- e.g. a run whose CSR assembly has a slow single-rank fallback path.
     """
     return _positive_int_from_env(
-        SAMPLING_RPC_TIMEOUT_ENV, DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS
-    )
-
-
-def sampling_steady_state_rpc_timeout_seconds() -> int:
-    """Request timeout applied to sampling RPCs once a worker is past its init barrier."""
-    return _positive_int_from_env(
-        SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV,
-        DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
+        SAMPLING_RPC_INIT_TIMEOUT_ENV, DEFAULT_SAMPLING_RPC_INIT_TIMEOUT_SECONDS
     )
 
 
 def sampling_worker_init_timeout_seconds() -> int:
-    """Bound on how long a rank waits for its own sampling workers to reach the init barrier."""
-    return _positive_int_from_env(
-        SAMPLING_WORKER_INIT_TIMEOUT_ENV, DEFAULT_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS
-    )
+    """Bound on how long a rank waits for its own sampling workers to reach the init barrier.
+
+    Derived from the gather tolerance rather than configured separately, so raising
+    ``GIGL_SAMPLING_RPC_INIT_TIMEOUT_SECONDS`` moves both bounds coherently.
+    """
+    return SAMPLING_WORKER_INIT_TIMEOUT_MULTIPLIER * sampling_rpc_init_timeout_seconds()

--- a/gigl/distributed/dist_sampling_producer.py
+++ b/gigl/distributed/dist_sampling_producer.py
@@ -39,8 +39,8 @@ from torch.utils.data.dataset import Dataset
 
 from gigl.common.logger import Logger
 from gigl.distributed.constants import (
-    SAMPLING_WORKER_INIT_TIMEOUT_ENV,
-    sampling_steady_state_rpc_timeout_seconds,
+    SAMPLING_RPC_INIT_TIMEOUT_ENV,
+    SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
     sampling_worker_init_timeout_seconds,
 )
 from gigl.distributed.sampler_options import SamplerOptions
@@ -58,14 +58,15 @@ def _narrow_rpc_timeout_after_init(rank: int, bringup_rpc_timeout: float) -> Non
     before a stuck request surfaces. The init barrier is precisely the boundary between the two
     regimes, so the worker narrows the timeout immediately after passing it.
 
-    A no-op when the steady-state value already equals the bring-up value.
+    A no-op when the bring-up value already equals the steady-state value.
     """
-    steady_state_timeout = sampling_steady_state_rpc_timeout_seconds()
-    if steady_state_timeout != bringup_rpc_timeout:
-        torch.distributed.rpc._set_rpc_timeout(float(steady_state_timeout))
+    if SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS != bringup_rpc_timeout:
+        torch.distributed.rpc._set_rpc_timeout(
+            float(SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS)
+        )
         logger.info(
             f"sampling worker {rank} past init barrier; RPC request timeout narrowed from "
-            f"{bringup_rpc_timeout}s (bring-up) to {steady_state_timeout}s"
+            f"{bringup_rpc_timeout}s (bring-up) to {SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS}s"
         )
 
 
@@ -298,6 +299,6 @@ class DistSamplingProducer(DistMpSamplingProducer):
             raise RuntimeError(
                 f"sampling workers did not reach the init barrier within {timeout_seconds}s; "
                 f"{diagnosis}. A worker that loses GLT's init_rpc gather dies before this "
-                f"barrier. Raise {SAMPLING_WORKER_INIT_TIMEOUT_ENV} if init is legitimately "
-                f"slower than this on a cold cache."
+                f"barrier. Raise {SAMPLING_RPC_INIT_TIMEOUT_ENV} (this bound is a multiple of "
+                f"it) if init is legitimately slower than this on a cold cache."
             ) from None

--- a/gigl/distributed/dist_sampling_producer.py
+++ b/gigl/distributed/dist_sampling_producer.py
@@ -6,10 +6,11 @@
 
 import datetime
 import queue
-from threading import Barrier
+from threading import Barrier, BrokenBarrierError
 from typing import Optional, Union, cast
 
 import torch
+import torch.distributed.rpc
 import torch.multiprocessing as mp
 from graphlearn_torch.channel import ChannelBase
 from graphlearn_torch.distributed import (
@@ -37,10 +38,35 @@ from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.dataset import Dataset
 
 from gigl.common.logger import Logger
+from gigl.distributed.constants import (
+    SAMPLING_WORKER_INIT_TIMEOUT_ENV,
+    sampling_steady_state_rpc_timeout_seconds,
+    sampling_worker_init_timeout_seconds,
+)
 from gigl.distributed.sampler_options import SamplerOptions
 from gigl.distributed.utils.dist_sampler import create_dist_sampler
 
 logger = Logger()
+
+
+def _narrow_rpc_timeout_after_init(rank: int, bringup_rpc_timeout: float) -> None:
+    """Reset the RPC agent's request timeout once a sampling worker is past its init barrier.
+
+    ``init_rpc`` sets the agent's default request timeout to the bring-up tolerance, which is
+    deliberately generous so cross-rank skew does not kill the gather -- but leaving it there
+    would mean every steady-state sampling and feature-collection RPC also waits that long
+    before a stuck request surfaces. The init barrier is precisely the boundary between the two
+    regimes, so the worker narrows the timeout immediately after passing it.
+
+    A no-op when the steady-state value already equals the bring-up value.
+    """
+    steady_state_timeout = sampling_steady_state_rpc_timeout_seconds()
+    if steady_state_timeout != bringup_rpc_timeout:
+        torch.distributed.rpc._set_rpc_timeout(float(steady_state_timeout))
+        logger.info(
+            f"sampling worker {rank} past init barrier; RPC request timeout narrowed from "
+            f"{bringup_rpc_timeout}s (bring-up) to {steady_state_timeout}s"
+        )
 
 
 def _sampling_worker_loop(
@@ -121,6 +147,8 @@ def _sampling_worker_loop(
 
         mp_barrier.wait()
 
+        _narrow_rpc_timeout_after_init(rank, worker_options.rpc_timeout)
+
         keep_running = True
         while keep_running:
             try:
@@ -165,10 +193,12 @@ def _sampling_worker_loop(
     except KeyboardInterrupt:
         # Main process will raise KeyboardInterrupt anyways.
         pass
-
-    if dist_sampler is not None:
-        dist_sampler.shutdown_loop()
-    shutdown_rpc(graceful=False)
+    finally:
+        # In a finally so a worker released through a broken init barrier still tears down
+        # its sampler loop and RPC agent instead of leaking them
+        if dist_sampler is not None:
+            dist_sampler.shutdown_loop()
+        shutdown_rpc(graceful=False)
 
 
 class DistSamplingProducer(DistMpSamplingProducer):
@@ -224,4 +254,50 @@ class DistSamplingProducer(DistMpSamplingProducer):
             worker.daemon = True
             worker.start()
             self._workers.append(worker)
-        barrier.wait()
+        self._wait_for_workers_at_barrier(barrier)
+
+    def _wait_for_workers_at_barrier(self, barrier: Barrier) -> None:
+        """Wait for every sampling worker to reach the init barrier, but not forever.
+
+        An unbounded ``barrier.wait()`` here is the difference between a job that fails and a job
+        that hangs. Each worker must complete GLT's ``init_rpc``, which itself gathers all
+        ``num_workers x world_size`` workers within the bring-up tolerance; a worker that loses
+        that gather dies, never reaches this barrier, and leaves this process blocked forever
+        while its peers sit in collectives until the training process group's own timeout fires.
+        Bounding this wait is what turns that wedge into a fast, attributable failure.
+
+        The barrier is waited on ONCE with the full timeout rather than polled: a timed-out
+        ``wait`` puts a multiprocessing barrier into the broken state permanently, for the children
+        too, so polling it would destroy the very rendezvous it is checking.
+
+        Raises:
+            RuntimeError: if the barrier is not reached within the timeout, naming the workers
+                that died so the failure is diagnosable from one replica's log.
+        """
+        timeout_seconds = sampling_worker_init_timeout_seconds()
+        try:
+            barrier.wait(timeout=timeout_seconds)
+        except BrokenBarrierError:
+            # Diagnose BEFORE shutdown(): it terminates the surviving workers, which would
+            # make every worker look dead and erase the exit codes that matter
+            dead = [
+                rank
+                for rank, worker in enumerate(self._workers)
+                if not worker.is_alive()
+            ]
+            exit_codes = {rank: self._workers[rank].exitcode for rank in dead}
+            diagnosis = (
+                f"dead workers (rank -> exitcode): {exit_codes}"
+                if exit_codes
+                else "no worker has exited, so at least one is still initialising"
+            )
+            # Tear down the queues and processes this producer already created; GLT's
+            # shutdown() joins with a timeout and terminates stragglers, so it cannot
+            # replace the hang this bound exists to remove
+            self.shutdown()
+            raise RuntimeError(
+                f"sampling workers did not reach the init barrier within {timeout_seconds}s; "
+                f"{diagnosis}. A worker that loses GLT's init_rpc gather dies before this "
+                f"barrier. Raise {SAMPLING_WORKER_INIT_TIMEOUT_ENV} if init is legitimately "
+                f"slower than this on a cold cache."
+            ) from None

--- a/tests/unit/distributed/sampling_timeouts_test.py
+++ b/tests/unit/distributed/sampling_timeouts_test.py
@@ -5,14 +5,11 @@ from unittest import mock
 from absl.testing import absltest
 
 from gigl.distributed.constants import (
-    DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS,
-    DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
-    DEFAULT_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS,
-    SAMPLING_RPC_TIMEOUT_ENV,
-    SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV,
-    SAMPLING_WORKER_INIT_TIMEOUT_ENV,
-    sampling_rpc_timeout_seconds,
-    sampling_steady_state_rpc_timeout_seconds,
+    DEFAULT_SAMPLING_RPC_INIT_TIMEOUT_SECONDS,
+    SAMPLING_RPC_INIT_TIMEOUT_ENV,
+    SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
+    SAMPLING_WORKER_INIT_TIMEOUT_MULTIPLIER,
+    sampling_rpc_init_timeout_seconds,
     sampling_worker_init_timeout_seconds,
 )
 from gigl.distributed.dist_sampling_producer import (
@@ -20,12 +17,6 @@ from gigl.distributed.dist_sampling_producer import (
     _narrow_rpc_timeout_after_init,
 )
 from tests.test_assets.test_case import TestCase
-
-_ALL_ENVS = (
-    SAMPLING_RPC_TIMEOUT_ENV,
-    SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV,
-    SAMPLING_WORKER_INIT_TIMEOUT_ENV,
-)
 
 
 class _ExitedWorker:
@@ -44,97 +35,69 @@ class _ExitedWorker:
         pass
 
 
-class SamplingTimeoutConstantsTest(TestCase):
+class _EnvRestoringTestCase(TestCase):
     def setUp(self) -> None:
         super().setUp()
-        self._saved = {name: os.environ.pop(name, None) for name in _ALL_ENVS}
+        self._saved = os.environ.pop(SAMPLING_RPC_INIT_TIMEOUT_ENV, None)
 
     def tearDown(self) -> None:
-        for name, value in self._saved.items():
-            os.environ.pop(name, None)
-            if value is not None:
-                os.environ[name] = value
+        os.environ.pop(SAMPLING_RPC_INIT_TIMEOUT_ENV, None)
+        if self._saved is not None:
+            os.environ[SAMPLING_RPC_INIT_TIMEOUT_ENV] = self._saved
         super().tearDown()
 
+
+class SamplingTimeoutConstantsTest(_EnvRestoringTestCase):
     def test_defaults_apply_when_the_environment_is_unset(self) -> None:
         self.assertEqual(
-            sampling_rpc_timeout_seconds(), DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS
-        )
-        self.assertEqual(
-            sampling_steady_state_rpc_timeout_seconds(),
-            DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
+            sampling_rpc_init_timeout_seconds(),
+            DEFAULT_SAMPLING_RPC_INIT_TIMEOUT_SECONDS,
         )
         self.assertEqual(
             sampling_worker_init_timeout_seconds(),
-            DEFAULT_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS,
+            SAMPLING_WORKER_INIT_TIMEOUT_MULTIPLIER
+            * DEFAULT_SAMPLING_RPC_INIT_TIMEOUT_SECONDS,
         )
 
-    def test_environment_overrides_are_read(self) -> None:
-        os.environ[SAMPLING_RPC_TIMEOUT_ENV] = "1200"
-        os.environ[SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV] = "90"
-        os.environ[SAMPLING_WORKER_INIT_TIMEOUT_ENV] = "2400"
+    def test_the_barrier_bound_scales_with_the_environment_override(self) -> None:
+        os.environ[SAMPLING_RPC_INIT_TIMEOUT_ENV] = "1200"
 
-        self.assertEqual(sampling_rpc_timeout_seconds(), 1200)
-        self.assertEqual(sampling_steady_state_rpc_timeout_seconds(), 90)
-        self.assertEqual(sampling_worker_init_timeout_seconds(), 2400)
+        self.assertEqual(sampling_rpc_init_timeout_seconds(), 1200)
+        self.assertEqual(
+            sampling_worker_init_timeout_seconds(),
+            SAMPLING_WORKER_INIT_TIMEOUT_MULTIPLIER * 1200,
+        )
 
     def test_invalid_values_fall_back_to_the_default(self) -> None:
         for bad in ("not-a-number", "0", "-5", ""):
-            os.environ[SAMPLING_RPC_TIMEOUT_ENV] = bad
+            os.environ[SAMPLING_RPC_INIT_TIMEOUT_ENV] = bad
             self.assertEqual(
-                sampling_rpc_timeout_seconds(),
-                DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS,
+                sampling_rpc_init_timeout_seconds(),
+                DEFAULT_SAMPLING_RPC_INIT_TIMEOUT_SECONDS,
                 msg=f"for value {bad!r}",
             )
 
 
 class SteadyStateNarrowingTest(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self._saved = os.environ.pop(SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV, None)
-
-    def tearDown(self) -> None:
-        os.environ.pop(SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV, None)
-        if self._saved is not None:
-            os.environ[SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV] = self._saved
-        super().tearDown()
-
     def test_a_mismatched_bringup_timeout_is_narrowed_to_steady_state(self) -> None:
         with mock.patch("torch.distributed.rpc._set_rpc_timeout") as set_rpc_timeout:
             _narrow_rpc_timeout_after_init(rank=0, bringup_rpc_timeout=3600)
 
         set_rpc_timeout.assert_called_once_with(
-            float(DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS)
+            float(SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS)
         )
 
     def test_equal_timeouts_leave_the_agent_untouched(self) -> None:
         with mock.patch("torch.distributed.rpc._set_rpc_timeout") as set_rpc_timeout:
             _narrow_rpc_timeout_after_init(
                 rank=0,
-                bringup_rpc_timeout=DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
+                bringup_rpc_timeout=SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
             )
 
         set_rpc_timeout.assert_not_called()
 
-    def test_an_overridden_steady_state_value_is_applied(self) -> None:
-        os.environ[SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV] = "90"
-        with mock.patch("torch.distributed.rpc._set_rpc_timeout") as set_rpc_timeout:
-            _narrow_rpc_timeout_after_init(rank=0, bringup_rpc_timeout=600)
 
-        set_rpc_timeout.assert_called_once_with(90.0)
-
-
-class WorkerInitBarrierTest(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self._saved_timeout = os.environ.pop(SAMPLING_WORKER_INIT_TIMEOUT_ENV, None)
-
-    def tearDown(self) -> None:
-        os.environ.pop(SAMPLING_WORKER_INIT_TIMEOUT_ENV, None)
-        if self._saved_timeout is not None:
-            os.environ[SAMPLING_WORKER_INIT_TIMEOUT_ENV] = self._saved_timeout
-        super().tearDown()
-
+class WorkerInitBarrierTest(_EnvRestoringTestCase):
     def _producer_with_workers(self, workers: list) -> DistSamplingProducer:
         producer = DistSamplingProducer.__new__(DistSamplingProducer)
         producer._workers = workers
@@ -144,7 +107,7 @@ class WorkerInitBarrierTest(TestCase):
         return producer
 
     def test_a_worker_that_never_arrives_raises_instead_of_hanging(self) -> None:
-        os.environ[SAMPLING_WORKER_INIT_TIMEOUT_ENV] = "1"
+        os.environ[SAMPLING_RPC_INIT_TIMEOUT_ENV] = "1"
         producer = self._producer_with_workers([_ExitedWorker(exitcode=1)])
         # 2 parties and only this process waiting = the dead worker's slot never fills
         barrier = std_mp.get_context("spawn").Barrier(2)
@@ -153,7 +116,7 @@ class WorkerInitBarrierTest(TestCase):
             producer._wait_for_workers_at_barrier(barrier)
 
     def test_a_full_barrier_passes_without_raising(self) -> None:
-        os.environ[SAMPLING_WORKER_INIT_TIMEOUT_ENV] = "5"
+        os.environ[SAMPLING_RPC_INIT_TIMEOUT_ENV] = "5"
         producer = self._producer_with_workers([])
         barrier = std_mp.get_context("spawn").Barrier(1)
 

--- a/tests/unit/distributed/sampling_timeouts_test.py
+++ b/tests/unit/distributed/sampling_timeouts_test.py
@@ -1,0 +1,164 @@
+import multiprocessing as std_mp
+import os
+from unittest import mock
+
+from absl.testing import absltest
+
+from gigl.distributed.constants import (
+    DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS,
+    DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
+    DEFAULT_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS,
+    SAMPLING_RPC_TIMEOUT_ENV,
+    SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV,
+    SAMPLING_WORKER_INIT_TIMEOUT_ENV,
+    sampling_rpc_timeout_seconds,
+    sampling_steady_state_rpc_timeout_seconds,
+    sampling_worker_init_timeout_seconds,
+)
+from gigl.distributed.dist_sampling_producer import (
+    DistSamplingProducer,
+    _narrow_rpc_timeout_after_init,
+)
+from tests.test_assets.test_case import TestCase
+
+_ALL_ENVS = (
+    SAMPLING_RPC_TIMEOUT_ENV,
+    SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV,
+    SAMPLING_WORKER_INIT_TIMEOUT_ENV,
+)
+
+
+class _ExitedWorker:
+    """Stands in for a sampling worker process that died before the barrier."""
+
+    def __init__(self, exitcode: int) -> None:
+        self.exitcode = exitcode
+
+    def is_alive(self) -> bool:
+        return False
+
+    def join(self, timeout: float | None = None) -> None:
+        pass
+
+    def terminate(self) -> None:
+        pass
+
+
+class SamplingTimeoutConstantsTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._saved = {name: os.environ.pop(name, None) for name in _ALL_ENVS}
+
+    def tearDown(self) -> None:
+        for name, value in self._saved.items():
+            os.environ.pop(name, None)
+            if value is not None:
+                os.environ[name] = value
+        super().tearDown()
+
+    def test_defaults_apply_when_the_environment_is_unset(self) -> None:
+        self.assertEqual(
+            sampling_rpc_timeout_seconds(), DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS
+        )
+        self.assertEqual(
+            sampling_steady_state_rpc_timeout_seconds(),
+            DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
+        )
+        self.assertEqual(
+            sampling_worker_init_timeout_seconds(),
+            DEFAULT_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS,
+        )
+
+    def test_environment_overrides_are_read(self) -> None:
+        os.environ[SAMPLING_RPC_TIMEOUT_ENV] = "1200"
+        os.environ[SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV] = "90"
+        os.environ[SAMPLING_WORKER_INIT_TIMEOUT_ENV] = "2400"
+
+        self.assertEqual(sampling_rpc_timeout_seconds(), 1200)
+        self.assertEqual(sampling_steady_state_rpc_timeout_seconds(), 90)
+        self.assertEqual(sampling_worker_init_timeout_seconds(), 2400)
+
+    def test_invalid_values_fall_back_to_the_default(self) -> None:
+        for bad in ("not-a-number", "0", "-5", ""):
+            os.environ[SAMPLING_RPC_TIMEOUT_ENV] = bad
+            self.assertEqual(
+                sampling_rpc_timeout_seconds(),
+                DEFAULT_SAMPLING_RPC_TIMEOUT_SECONDS,
+                msg=f"for value {bad!r}",
+            )
+
+
+class SteadyStateNarrowingTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._saved = os.environ.pop(SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV, None)
+
+    def tearDown(self) -> None:
+        os.environ.pop(SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV, None)
+        if self._saved is not None:
+            os.environ[SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV] = self._saved
+        super().tearDown()
+
+    def test_a_mismatched_bringup_timeout_is_narrowed_to_steady_state(self) -> None:
+        with mock.patch("torch.distributed.rpc._set_rpc_timeout") as set_rpc_timeout:
+            _narrow_rpc_timeout_after_init(rank=0, bringup_rpc_timeout=3600)
+
+        set_rpc_timeout.assert_called_once_with(
+            float(DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS)
+        )
+
+    def test_equal_timeouts_leave_the_agent_untouched(self) -> None:
+        with mock.patch("torch.distributed.rpc._set_rpc_timeout") as set_rpc_timeout:
+            _narrow_rpc_timeout_after_init(
+                rank=0,
+                bringup_rpc_timeout=DEFAULT_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS,
+            )
+
+        set_rpc_timeout.assert_not_called()
+
+    def test_an_overridden_steady_state_value_is_applied(self) -> None:
+        os.environ[SAMPLING_STEADY_STATE_RPC_TIMEOUT_ENV] = "90"
+        with mock.patch("torch.distributed.rpc._set_rpc_timeout") as set_rpc_timeout:
+            _narrow_rpc_timeout_after_init(rank=0, bringup_rpc_timeout=600)
+
+        set_rpc_timeout.assert_called_once_with(90.0)
+
+
+class WorkerInitBarrierTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self._saved_timeout = os.environ.pop(SAMPLING_WORKER_INIT_TIMEOUT_ENV, None)
+
+    def tearDown(self) -> None:
+        os.environ.pop(SAMPLING_WORKER_INIT_TIMEOUT_ENV, None)
+        if self._saved_timeout is not None:
+            os.environ[SAMPLING_WORKER_INIT_TIMEOUT_ENV] = self._saved_timeout
+        super().tearDown()
+
+    def _producer_with_workers(self, workers: list) -> DistSamplingProducer:
+        producer = DistSamplingProducer.__new__(DistSamplingProducer)
+        producer._workers = workers
+        # The timeout path calls GLT's shutdown(), which reads these
+        producer._shutdown = False
+        producer._task_queues = []
+        return producer
+
+    def test_a_worker_that_never_arrives_raises_instead_of_hanging(self) -> None:
+        os.environ[SAMPLING_WORKER_INIT_TIMEOUT_ENV] = "1"
+        producer = self._producer_with_workers([_ExitedWorker(exitcode=1)])
+        # 2 parties and only this process waiting = the dead worker's slot never fills
+        barrier = std_mp.get_context("spawn").Barrier(2)
+
+        with self.assertRaisesRegex(RuntimeError, r"rank -> exitcode.*\{0: 1\}"):
+            producer._wait_for_workers_at_barrier(barrier)
+
+    def test_a_full_barrier_passes_without_raising(self) -> None:
+        os.environ[SAMPLING_WORKER_INIT_TIMEOUT_ENV] = "5"
+        producer = self._producer_with_workers([])
+        barrier = std_mp.get_context("spawn").Barrier(1)
+
+        producer._wait_for_workers_at_barrier(barrier)
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
**Scope of work done**

Constructing a distributed loader is a cluster-wide rendezvous: every sampling worker on every rank must complete GLT's `init_rpc`, which gathers all `num_workers x world_size` workers, and only then does each rank's parent pass its local init barrier. Nothing synchronizes ranks between the end of dataset building and the first loader construction, so any skew accumulated during partitioning or graph assembly is spent inside that gather -- against a hard-coded 600s tolerance, with the parent's barrier wait unbounded behind it.

This PR makes those tolerances configurable and bounds the wait, via three env knobs in `gigl/distributed/constants.py`:

- `GIGL_SAMPLING_RPC_TIMEOUT_SECONDS` (default 600, GLT's own default): the bring-up gather tolerance, consumed at the `rpc_timeout` site in `base_dist_loader.py`. Large colocated topologies whose ranks legitimately arrive more than 600s apart get a knob instead of a dead job.
- `GIGL_SAMPLING_STEADY_STATE_RPC_TIMEOUT_SECONDS` (default 600): GLT's `rpc_timeout` is not init-only -- it becomes the agent's default request timeout for every steady-state sampling and feature-collection RPC, so raising it for bring-up would also make a genuinely stuck steady-state request take that long to surface. Each worker therefore narrows the agent's timeout to this value immediately after passing its init barrier, exactly the boundary between the two regimes. With both values equal the reset is skipped. (`torch.distributed.rpc._set_rpc_timeout` is the same internal torch uses to implement `rpc_sync`'s `timeout` argument; there is no public per-agent setter after `init_rpc`, and per-call timeouts are unavailable because the steady-state calls are made inside GLT.)
- `GIGL_SAMPLING_WORKER_INIT_TIMEOUT_SECONDS` (default 1800): the parent's `barrier.wait()` becomes bounded. **This is the one behavior change without any configuration:** a worker that loses the gather dies before the barrier, and today its parent blocks forever while healthy peers sit in collectives until the training process group timeout. Such a job now fails in 30 minutes with a `RuntimeError` naming the dead workers and their exit codes. The default deliberately sits above the gather tolerance so the barrier reports the death rather than timing out first and blaming the wrong thing. The barrier is waited once with the full timeout, never polled -- a timed-out wait breaks a multiprocessing barrier permanently. On timeout the producer diagnoses first, then tears itself down via GLT's bounded `shutdown()`, then raises; worker-side sampler/RPC teardown moved into a `finally` so a broken barrier cannot leak either.

Invalid env values (non-integer, non-positive) warn and fall back to the default.

***Where is the documentation for this feature?***: docstrings and rationale comments in `gigl/distributed/constants.py` and `dist_sampling_producer.py`, plus the CHANGELOG entry

***Did you add automated tests or write a test plan?***

Yes: new `tests/unit/distributed/sampling_timeouts_test.py` (8 tests: env parsing with defaults/overrides/invalid fallback; the narrowing helper at the torch RPC boundary -- mismatch narrows, equality is a no-op, override applies; the barrier bound against a real multiprocessing barrier, including the raise naming a dead worker's exit code). The full `distributed_neighborloader_test.py` suite (36 tests, real spawned loaders exercising both barriers and the narrowing path) passes on this change.

***Updated Changelog.md?*** YES

***Ready for code review?:*** YES