### PR TITLE
Prepare for Python 3.12 and 3.13: drop distutils, make GLT install fa…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,14 @@ format_cpp:
 
 format: format_py format_cpp format_scala format_md
 
+# ty resolves the stdlib against a single Python version per invocation, so each end of
+# the supported range needs its own pass.
 type_check:
+# Floor: 3.11, from [tool.ty.environment] in pyproject.toml. Catches stdlib APIs that do
+# not exist that far back.
 	uv run ty check ${PYTHON_DIRS}
+# Ceiling: catches stdlib modules and signatures 3.13 removed or changed.
+	uv run ty check --python-version 3.13 ${PYTHON_DIRS}
 
 build_cpp_extensions:
 	$(MAKE) -C gigl-core build_cpp_extensions

--- a/examples/link_prediction/graph_store/storage_main.py
+++ b/examples/link_prediction/graph_store/storage_main.py
@@ -74,7 +74,6 @@ the compute processes signal shutdown via `gigl.distributed.graph_store.compute.
 import argparse
 import ast
 import os
-from distutils.util import strtobool
 from typing import Literal, Optional, Union
 
 import torch
@@ -82,6 +81,7 @@ import torch
 from gigl.common import Uri, UriFactory
 from gigl.common.logger import Logger
 from gigl.common.utils.os_utils import import_obj
+from gigl.common.utils.parse import str_to_bool
 from gigl.distributed.graph_store import (
     GraphStoreInfo,
     build_storage_dataset,
@@ -254,7 +254,7 @@ if __name__ == "__main__":
         splitter=splitter,
         ssl_positive_label_percentage=ssl_positive_label_percentage,
         should_load_tf_records_in_parallel=bool(
-            strtobool(args.should_load_tf_records_in_parallel)
+            str_to_bool(args.should_load_tf_records_in_parallel)
         ),
         num_rpc_threads=args.num_rpc_threads,
         rpc_timeout=args.rpc_timeout,

--- a/examples/tutorial/KDD_2025/heterogeneous_inference.py
+++ b/examples/tutorial/KDD_2025/heterogeneous_inference.py
@@ -26,7 +26,6 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # Suppress TensorFlow logs isort: skip
 import argparse
 import datetime
 from collections.abc import Mapping
-from distutils.util import strtobool
 from pathlib import Path
 
 import fastavro
@@ -38,6 +37,7 @@ from examples.tutorial.KDD_2025.utils import LOCAL_SAVED_MODEL_URI, init_model
 from gigl.common import Uri, UriFactory
 from gigl.common.data.export import EmbeddingExporter
 from gigl.common.logger import Logger
+from gigl.common.utils.parse import str_to_bool
 from gigl.distributed import (
     DistDataset,
     DistNeighborLoader,
@@ -154,7 +154,7 @@ if __name__ == "__main__":
         task_config_uri,
         _tfrecord_uri_pattern=".*tfrecord",
     )
-    if strtobool(args.use_local_saved_model):
+    if str_to_bool(args.use_local_saved_model):
         model_uri = LOCAL_SAVED_MODEL_URI
     else:
         model_uri = gbml_config_pb_wrapper.shared_config.trained_model_metadata.trained_model_uri

--- a/examples/tutorial/KDD_2025/heterogeneous_training.py
+++ b/examples/tutorial/KDD_2025/heterogeneous_training.py
@@ -37,7 +37,6 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # Suppress TensorFlow logs isort: skip
 
 import argparse
 from collections.abc import Iterable, Mapping
-from distutils.util import strtobool
 from typing import Literal
 
 import torch
@@ -48,6 +47,7 @@ from torch_geometric.data import HeteroData
 from examples.tutorial.KDD_2025.utils import LOCAL_SAVED_MODEL_URI, init_model
 from gigl.common import UriFactory
 from gigl.common.logger import Logger
+from gigl.common.utils.parse import str_to_bool
 from gigl.distributed import (
     DistABLPLoader,
     DistDataset,
@@ -269,7 +269,7 @@ if __name__ == "__main__":
         logger.info(f"Test node type {node_type} has {node_ids.size(0)} nodes.")  # ty: ignore[unresolved-attribute] TODO(ty-torch-keyed-access): fix ty false positives for torch-backed keyed container access.
     training_process_port = get_free_port()
     logger.info(f"Will train for {max_training_batches} batches.")
-    if strtobool(args.use_local_saved_model):
+    if str_to_bool(args.use_local_saved_model):
         model_uri = LOCAL_SAVED_MODEL_URI
     else:
         model_uri = gbml_config_pb_wrapper.shared_config.trained_model_metadata.trained_model_uri

--- a/gigl/common/utils/parse.py
+++ b/gigl/common/utils/parse.py
@@ -1,0 +1,41 @@
+from typing import Final
+
+_TRUE_VALUES: Final[frozenset[str]] = frozenset({"y", "yes", "t", "true", "on", "1"})
+_FALSE_VALUES: Final[frozenset[str]] = frozenset({"n", "no", "f", "false", "off", "0"})
+
+
+def str_to_bool(value: str) -> bool:
+    """
+    Converts a string representation of truth to a bool.
+
+    Accepts and rejects the same spellings as `distutils.util.strtobool`, which is no
+    longer part of the standard library, though the `ValueError` message keeps the
+    caller's casing instead of lowercasing it:
+
+      - True: "y", "yes", "t", "true", "on", "1"
+      - False: "n", "no", "f", "false", "off", "0"
+
+    Matching is case-insensitive. Whitespace is not stripped, so " true" raises rather
+    than returning True.
+
+    Example:
+        >>> str_to_bool("TRUE")
+        True
+        >>> str_to_bool("off")
+        False
+
+    Args:
+        value (str): The string to interpret as a boolean.
+
+    Returns:
+        bool: The truth value `value` spells.
+
+    Raises:
+        ValueError: If `value` is not one of the accepted spellings.
+    """
+    normalized_value = value.lower()
+    if normalized_value in _TRUE_VALUES:
+        return True
+    if normalized_value in _FALSE_VALUES:
+        return False
+    raise ValueError(f"invalid truth value {value!r}")

--- a/gigl/distributed/dataset_factory.py
+++ b/gigl/distributed/dataset_factory.py
@@ -5,7 +5,6 @@ process which initializes rpc + worker group, loads and builds a partitioned dat
 
 import time
 from collections.abc import Mapping
-from distutils.util import strtobool
 from typing import Literal, MutableMapping, Optional, Tuple, Type, Union
 
 import torch
@@ -29,6 +28,7 @@ from gigl.common.data.load_torch_tensors import (
 )
 from gigl.common.logger import Logger
 from gigl.common.utils.decorator import tf_on_cpu
+from gigl.common.utils.parse import str_to_bool
 from gigl.distributed.constants import DEFAULT_MASTER_DATA_BUILDING_PORT
 from gigl.distributed.dist_context import DistributedContext
 from gigl.distributed.dist_dataset import DistDataset
@@ -629,11 +629,11 @@ def build_dataset_from_task_config_uri(
     )
 
     should_use_range_partitioning = bool(
-        strtobool(args.get("should_use_range_partitioning", "True"))
+        str_to_bool(args.get("should_use_range_partitioning", "True"))
     )
 
     should_load_tensors_in_parallel = bool(
-        strtobool(args.get("should_load_tensors_in_parallel", "True"))
+        str_to_bool(args.get("should_load_tensors_in_parallel", "True"))
     )
 
     logger.info(

--- a/gigl/scripts/post_install.py
+++ b/gigl/scripts/post_install.py
@@ -34,8 +34,17 @@ def run_command_and_stream_stdout(cmd: str) -> Optional[int]:
     return return_code
 
 
-def main():
-    """Main entry point for the post-install script."""
+def main() -> int:
+    """Main entry point for the post-install script.
+
+    Returns:
+        int: 0, when install_glt.sh succeeds.
+
+    Raises:
+        SystemExit: With a non-zero code when install_glt.sh is missing, fails, or
+            reports no exit status. Callers must propagate it: swallowing it lets a
+            build succeed while shipping an environment with no working GLT.
+    """
     print("Running GIGL post-install script...")
 
     # Get the directory where this script is located
@@ -52,9 +61,16 @@ def main():
 
     try:
         print(f"Executing {cmd}...")
-        result = run_command_and_stream_stdout(cmd)
-        print("Post-install script finished running, with return code: ", result)
-        return result
+        return_code = run_command_and_stream_stdout(cmd)
+        print("Post-install script finished running, with return code: ", return_code)
+        # `Popen.poll()` returns None while the child has no recorded status, so an
+        # unknown outcome is not evidence of success.
+        if return_code is None:
+            print("Error: could not determine the exit status of install_glt.sh")
+            sys.exit(1)
+        if return_code != 0:
+            sys.exit(return_code)
+        return return_code
 
     except subprocess.CalledProcessError as e:
         print(f"Error running install_glt.sh: {e}")
@@ -65,4 +81,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/gigl/src/common/modeling_task_specs/node_anchor_based_link_prediction_modeling_task_spec.py
+++ b/gigl/src/common/modeling_task_specs/node_anchor_based_link_prediction_modeling_task_spec.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 from contextlib import ExitStack
-from distutils.util import strtobool
 from time import time
 from typing import Any, Optional, Type
 
@@ -12,6 +11,7 @@ from torch.optim.lr_scheduler import LRScheduler
 
 from gigl.common.logger import Logger
 from gigl.common.utils import os_utils
+from gigl.common.utils.parse import str_to_bool
 from gigl.common.utils.torch_training import (
     get_rank,
     get_world_size,
@@ -201,7 +201,7 @@ class NodeAnchorBasedLinkPredictionModelingTaskSpec(
         # Retrieval-specific Task Parameters
         softmax_temp = float(kwargs.get("softmax_temp", 0.07))
         should_remove_accidental_hits = bool(
-            strtobool(kwargs.get("should_remove_accidental_hits", "True"))
+            str_to_bool(kwargs.get("should_remove_accidental_hits", "True"))
         )
         task = base_task(
             temperature=softmax_temp,

--- a/gigl/src/common/modeling_task_specs/utils/profiler_wrapper.py
+++ b/gigl/src/common/modeling_task_specs/utils/profiler_wrapper.py
@@ -1,5 +1,4 @@
 import tempfile
-from distutils.util import strtobool
 
 from torch.profiler import (
     ProfilerActivity,
@@ -10,6 +9,7 @@ from torch.profiler import (
 
 from gigl.common import LocalUri
 from gigl.common.logger import Logger
+from gigl.common.utils.parse import str_to_bool
 
 logger = Logger()
 
@@ -33,9 +33,9 @@ class TorchProfiler:
             active=self.active,
             repeat=self.repeat,
         )
-        self.profile_memory = bool(strtobool(kwargs.get("profile_memory", "True")))
-        self.record_shapes = bool(strtobool(kwargs.get("record_shapes", "False")))
-        self.with_stack = bool(strtobool(kwargs.get("with_stack", "False")))
+        self.profile_memory = bool(str_to_bool(kwargs.get("profile_memory", "True")))
+        self.record_shapes = bool(str_to_bool(kwargs.get("record_shapes", "False")))
+        self.with_stack = bool(str_to_bool(kwargs.get("with_stack", "False")))
         logger.info(f"Profiler will be instantiated with {self.__dict__}")
 
     def profiler_context(self) -> profile:

--- a/gigl/src/common/types/pb_wrappers/gbml_config.py
+++ b/gigl/src/common/types/pb_wrappers/gbml_config.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from distutils.util import strtobool
 from typing import Optional
 
 from gigl.common import Uri, UriFactory
 from gigl.common.logger import Logger
+from gigl.common.utils.parse import str_to_bool
 from gigl.common.utils.proto_utils import ProtoUtils
 from gigl.src.common.types.graph_data import EdgeType, NodeType
 from gigl.src.common.types.pb_wrappers.dataset_metadata import DatasetMetadataPbWrapper
@@ -529,7 +529,7 @@ class GbmlConfigPbWrapper:
         """
 
         return bool(
-            strtobool(
+            str_to_bool(
                 dict(self.gbml_config_pb.feature_flags).get(
                     "should_run_glt_backend", "False"
                 )
@@ -550,7 +550,7 @@ class GbmlConfigPbWrapper:
             bool: Whether to populate predictions path in the InferenceOutput for each entity type
         """
         return bool(
-            strtobool(
+            str_to_bool(
                 dict(self.gbml_config_pb.feature_flags).get(
                     "should_populate_predictions_path", "False"
                 )
@@ -570,7 +570,7 @@ class GbmlConfigPbWrapper:
             bool: Whether to populate embeddings path in the InferenceOutput for each entity type
         """
         return bool(
-            strtobool(
+            str_to_bool(
                 dict(self.gbml_config_pb.feature_flags).get(
                     "should_populate_embeddings_path", "True"
                 )

--- a/gigl/src/subgraph_sampler/subgraph_sampler.py
+++ b/gigl/src/subgraph_sampler/subgraph_sampler.py
@@ -1,7 +1,6 @@
 import argparse
 import datetime
 import os
-from distutils.util import strtobool
 from typing import Optional, Sequence
 
 import gigl.env.dep_constants as dep_constants
@@ -16,6 +15,7 @@ from gigl.common.logger import Logger
 from gigl.common.metrics.decorators import flushes_metrics, profileit
 from gigl.common.utils import os_utils
 from gigl.common.utils.gcs import GcsUtils
+from gigl.common.utils.parse import str_to_bool
 from gigl.env.pipelines_config import get_resource_config
 from gigl.src.common.constants.components import GiGLComponents
 from gigl.src.common.constants.metrics import TIMER_SUBGRAPH_SAMPLER_S
@@ -101,7 +101,7 @@ class SubgraphSampler:
         # Dataproc image 2.0 starting 2026-08-25. Setting the `use_spark35_runner`
         # experimental flag to "False" remains a temporary escape hatch until then.
         use_spark35: bool = bool(
-            strtobool(
+            str_to_bool(
                 gbml_config_pb_wrapper.dataset_config.subgraph_sampler_config.experimental_flags.get(
                     "use_spark35_runner", "True"
                 )

--- a/gigl/src/training/v1/lib/training_process.py
+++ b/gigl/src/training/v1/lib/training_process.py
@@ -5,7 +5,6 @@ import multiprocessing as mp
 import sys
 import tempfile
 import traceback
-from distutils.util import strtobool
 from typing import Any, Optional
 
 import tensorflow as tf
@@ -19,6 +18,7 @@ from gigl.common.logger import Logger
 from gigl.common.metrics.decorators import flushes_metrics, profileit
 from gigl.common.utils import os_utils, torch_training
 from gigl.common.utils.local_fs import does_path_exist
+from gigl.common.utils.parse import str_to_bool
 from gigl.common.utils.torch_training import (
     get_distributed_backend,
     get_rank,
@@ -300,7 +300,9 @@ class GnnTrainingProcess:
         # If all parameters are always expected to receive backprop in training, it is not recommended to enable this flag, as it can adversely affect
         # performance as a result of the extra traversal of the autograd graph every iteration.
         should_enable_find_unused_parameters = bool(
-            strtobool(trainer_args.get("should_enable_find_unused_parameters", "False"))
+            str_to_bool(
+                trainer_args.get("should_enable_find_unused_parameters", "False")
+            )
         )
 
         trainer_instance.model = setup_model_device(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -288,7 +288,13 @@ exclude = ["*_pb2.py", "*_pb2.pyi"]
 #   Enforces a consistent import order (stdlib → third-party → first-party).
 #   Replaces: isort
 #   Docs: https://docs.astral.sh/ruff/rules/#isort-i
-select = ["F401", "I"]
+#
+# UP005 - Deprecated unittest aliases (pyupgrade)
+#   Flags 15 of the 16 aliases removed in Python 3.12, such as `assertEquals`; it does
+#   not cover `assertDictContainsSubset`. Autofixable.
+#   Replaces: nothing.
+#   Docs: https://docs.astral.sh/ruff/rules/deprecated-unittest-alias/
+select = ["F401", "I", "UP005"]
 
 [tool.ruff.lint.per-file-ignores]
 # __init__.py files re-export symbols for the public API, so unused-import
@@ -300,6 +306,8 @@ select = ["F401", "I"]
 known-first-party = ["gigl", "tests", "snapchat", "scripts"]
 
 [tool.ty.environment]
+# The floor of the supported range. The `type_check` Make target covers the ceiling with
+# a second `ty check --python-version 3.13` pass.
 python-version = "3.11"
 
 [tool.ty.src]

--- a/scripts/bootstrap_resource_config.py
+++ b/scripts/bootstrap_resource_config.py
@@ -6,12 +6,12 @@ import pathlib
 import subprocess
 import tempfile
 from dataclasses import dataclass
-from distutils.util import strtobool
 from typing import Optional
 
 import yaml
 
 from gigl.common import GcsUri, HttpUri, LocalUri, UriFactory
+from gigl.common.utils.parse import str_to_bool
 from gigl.src.common.utils.file_loader import FileLoader
 
 GIGL_ROOT_DIR = pathlib.Path(__file__).resolve().parent.parent
@@ -335,7 +335,7 @@ if __name__ == "__main__":
     print(f"Updated YAML file saved at '{destination_file_path}'")
 
     # Update the user's shell configuration
-    if args.force_shell_config_update and strtobool(args.force_shell_config_update):
+    if args.force_shell_config_update and str_to_bool(args.force_shell_config_update):
         should_update_shell_config = "y"
         print("Forcing shell updated due to --force_shell_config_update flag.")
     else:

--- a/tests/integration/common/dataflow_test.py
+++ b/tests/integration/common/dataflow_test.py
@@ -50,7 +50,7 @@ class DataflowUtilsTest(TestCase):
 
         # Ensure the pipeline options were propogated through
         parsed_options = options.get_all_options()
-        self.assertEquals(parsed_options["num_workers"], NUM_WORKERS)
-        self.assertEquals(parsed_options["max_num_workers"], MAX_NUM_WORKERS)
-        self.assertEquals(parsed_options["machine_type"], MACHINE_TYPE)
-        self.assertEquals(parsed_options["disk_size_gb"], DISK_SIZE_GB)
+        self.assertEqual(parsed_options["num_workers"], NUM_WORKERS)
+        self.assertEqual(parsed_options["max_num_workers"], MAX_NUM_WORKERS)
+        self.assertEqual(parsed_options["machine_type"], MACHINE_TYPE)
+        self.assertEqual(parsed_options["disk_size_gb"], DISK_SIZE_GB)

--- a/tests/integration/common/gcs_test.py
+++ b/tests/integration/common/gcs_test.py
@@ -21,7 +21,7 @@ class GcsUtilsTest(TestCase):
         gcs_utils.delete_files_in_bucket_dir(self._scratch_gcs_path)
 
     def test_join_path(self):
-        self.assertEquals(
+        self.assertEqual(
             GcsUri.join("gs://bucket_name", "path", "file.txt"),
             GcsUri("gs://bucket_name/path/file.txt"),
         )

--- a/tests/integration/pipeline/data_preprocessor/data_preprocessor_pipeline_test.py
+++ b/tests/integration/pipeline/data_preprocessor/data_preprocessor_pipeline_test.py
@@ -168,21 +168,21 @@ class DataPreprocessorPipelineTest(TestCase):
             gbml_config_pb_wrapper.graph_metadata_pb_wrapper.condensed_edge_type_to_edge_type_map
         )
 
-        self.assertEquals(
+        self.assertEqual(
             len(condensed_node_type_to_node_type_map),
             len(mocked_dataset_info.node_types),
         )
-        self.assertEquals(
+        self.assertEqual(
             len(condensed_edge_type_to_edge_type_map),
             len(mocked_dataset_info.edge_types),
         )
 
-        self.assertEquals(
+        self.assertEqual(
             condensed_node_type_to_node_type_map[DEFAULT_CONDENSED_NODE_TYPE],
             mocked_dataset_info.default_node_type,
         )
 
-        self.assertEquals(
+        self.assertEqual(
             condensed_edge_type_to_edge_type_map[DEFAULT_CONDENSED_EDGE_TYPE].relation,
             mocked_dataset_info.default_edge_type.relation,
         )

--- a/tests/integration/pipeline/inferencer/inferencer_test.py
+++ b/tests/integration/pipeline/inferencer/inferencer_test.py
@@ -199,7 +199,7 @@ class InferencerTest(TestCase):
                 node_type_to_inferencer_output_info_map[node_type].embeddings_path
             )
             if should_assert_embeddings:
-                self.assertEquals(
+                self.assertEqual(
                     self.__bq_utils.count_number_of_rows_in_bq_table(
                         bq_table=node_type_to_inferencer_output_info_map[
                             node_type
@@ -210,7 +210,7 @@ class InferencerTest(TestCase):
                     f"Found unexpected number of rows for node type {node_type} in embedding table.",
                 )
             if should_assert_predictions:
-                self.assertEquals(
+                self.assertEqual(
                     self.__bq_utils.count_number_of_rows_in_bq_table(
                         bq_table=node_type_to_inferencer_output_info_map[
                             node_type

--- a/tests/integration/pipeline/split_generator/split_generator_pipeline_test.py
+++ b/tests/integration/pipeline/split_generator/split_generator_pipeline_test.py
@@ -643,7 +643,7 @@ class SplitGeneratorPipelineTest(TestCase):
             == supervised_node_classification.NodeClassificationSettingType.INDUCTIVE
         ):
             # All edge sets across train/val/test splits must be disjoint.
-            self.assertEquals(
+            self.assertEqual(
                 train_graph.num_edges + val_graph.num_edges + test_graph.num_edges,
                 composed_graph.num_edges,
             )

--- a/tests/integration/pipeline/subgraph_sampler/subgraph_sampler_test.py
+++ b/tests/integration/pipeline/subgraph_sampler/subgraph_sampler_test.py
@@ -1337,7 +1337,7 @@ class SubgraphSamplerTest(TestCase):
                 supervision_node_type
             ]
         )
-        self.assertEquals(
+        self.assertEqual(
             total_rooted_node_neighborhood_samples,
             expected_nodes_of_supervision_node_type,
             f"Found {total_rooted_node_neighborhood_samples} rooted samples from SGS output, but found {expected_nodes_of_supervision_node_type} nodes from Data Preprocessor output",

--- a/tests/unit/common/collections/itertools_test.py
+++ b/tests/unit/common/collections/itertools_test.py
@@ -7,4 +7,4 @@ class ItertoolsTest(TestCase):
         input_list = [1, 2, 3, 4, 5]
         output = batch(list_of_items=input_list, chunk_size=2)
         expected_output = [[1, 2], [3, 4], [5]]
-        self.assertEquals(output, expected_output)
+        self.assertEqual(output, expected_output)

--- a/tests/unit/common/utils/parse_test.py
+++ b/tests/unit/common/utils/parse_test.py
@@ -1,0 +1,50 @@
+import importlib
+
+from gigl.common.utils.parse import str_to_bool
+from tests.test_assets.test_case import TestCase
+
+_TRUE_SPELLINGS = ("y", "yes", "t", "true", "on", "1")
+_FALSE_SPELLINGS = ("n", "no", "f", "false", "off", "0")
+# `" true"` belongs here because `str_to_bool` does not strip surrounding whitespace.
+_INVALID_VALUES = ("", " true", "2", "none")
+
+
+def _casings(spelling: str) -> tuple[str, ...]:
+    """All the casings `str_to_bool` must accept for one spelling."""
+    return (spelling.lower(), spelling.upper(), spelling.capitalize())
+
+
+class ParseUtilsTest(TestCase):
+    def test_accepted_spellings(self) -> None:
+        for spelling in _TRUE_SPELLINGS:
+            for value in _casings(spelling):
+                with self.subTest(value=value):
+                    self.assertIs(str_to_bool(value), True)
+        for spelling in _FALSE_SPELLINGS:
+            for value in _casings(spelling):
+                with self.subTest(value=value):
+                    self.assertIs(str_to_bool(value), False)
+
+    def test_rejects_unrecognized_values(self) -> None:
+        for value in _INVALID_VALUES:
+            with self.subTest(value=value):
+                self.assertRaises(ValueError, str_to_bool, value)
+
+    def test_matches_distutils_strtobool(self) -> None:
+        # The import is dynamic because a static `from distutils.util import ...` fails the
+        # 3.13 pass of `make type_check`. The reference is whichever `distutils` is
+        # importable: CPython's on 3.11 without `setuptools`, otherwise the copy
+        # `setuptools` injects through `distutils-precedence.pth`, which is what GiGL's dev
+        # and build environments resolve on every Python version.
+        try:
+            strtobool = importlib.import_module("distutils.util").strtobool
+        except ImportError:
+            self.skipTest("distutils is not importable in this environment")
+
+        for spelling in _TRUE_SPELLINGS + _FALSE_SPELLINGS:
+            for value in _casings(spelling):
+                with self.subTest(value=value):
+                    self.assertEqual(str_to_bool(value), bool(strtobool(value)))
+        for value in _INVALID_VALUES:
+            with self.subTest(value=value):
+                self.assertRaises(ValueError, strtobool, value)

--- a/tests/unit/common/utils/retry_test.py
+++ b/tests/unit/common/utils/retry_test.py
@@ -37,7 +37,7 @@ class RetryUtilsTest(TestCase):
             return True
 
         self.assertTrue(should_succeed_after_3_tries())
-        self.assertEquals(exec_counter, 3)
+        self.assertEqual(exec_counter, 3)
 
     def test_retry_with_function_deadlines(self):
         exec_counter = 0
@@ -53,7 +53,7 @@ class RetryUtilsTest(TestCase):
 
         start = time()
         self.assertTrue(should_timeout_first_try_and_then_succeed())
-        self.assertEquals(exec_counter, 2)
+        self.assertEqual(exec_counter, 2)
         total_time_s = time() - start
         self.assertLessEqual(
             total_time_s, 10

--- a/tests/unit/scripts/post_install_test.py
+++ b/tests/unit/scripts/post_install_test.py
@@ -1,0 +1,67 @@
+"""Exit-code contract for `post_install.py` run as a script.
+
+This is the path `requirements/install_py_deps.sh` takes, so every Docker base image
+build treats this exit code as the verdict on GLT: a zero exit publishes the image, and
+a failed `install_glt.sh` that reports success ships an environment with no working GLT.
+These tests run the real script as a subprocess against a stub `install_glt.sh` and
+assert the process exit code, which is the only signal a build observes. The
+`gigl-post-install` console script reaches `main()` by a different route and is not
+covered here.
+"""
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+import gigl.scripts.post_install
+from tests.test_assets.test_case import TestCase
+
+# `post_install.py` resolves `install_glt.sh` as `Path(__file__).parent / "install_glt.sh"`,
+# so a copy of the real script in a temp dir runs whichever stub sits beside it.
+_POST_INSTALL_PATH: Path = Path(gigl.scripts.post_install.__file__)
+
+
+class PostInstallTest(TestCase):
+    def _run_post_install(
+        self, install_glt_exit_code: Optional[int]
+    ) -> "subprocess.CompletedProcess[str]":
+        """Runs the real post-install script beside a stub `install_glt.sh`.
+
+        Args:
+            install_glt_exit_code (Optional[int]): Status the stub exits with, or None to
+                leave the directory without an `install_glt.sh` at all.
+
+        Returns:
+            subprocess.CompletedProcess[str]: The finished process, for its `returncode`.
+        """
+        with tempfile.TemporaryDirectory() as script_dir:
+            script_path = Path(script_dir) / _POST_INSTALL_PATH.name
+            shutil.copyfile(_POST_INSTALL_PATH, script_path)
+            if install_glt_exit_code is not None:
+                # A two-line stub keeps the test hermetic: no network, no package install,
+                # no real GLT build.
+                (Path(script_dir) / "install_glt.sh").write_text(
+                    f"#!/usr/bin/env bash\nexit {install_glt_exit_code}\n"
+                )
+            return subprocess.run(
+                [sys.executable, str(script_path)],
+                capture_output=True,
+                text=True,
+            )
+
+    def test_exits_zero_when_install_glt_succeeds(self) -> None:
+        completed = self._run_post_install(install_glt_exit_code=0)
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+
+    def test_propagates_install_glt_exit_code(self) -> None:
+        # 7 is neither success nor the 1 the missing-script path uses, so matching it proves
+        # the child's own status reached the caller.
+        completed = self._run_post_install(install_glt_exit_code=7)
+        self.assertEqual(completed.returncode, 7, completed.stdout)
+
+    def test_exits_one_when_install_glt_is_missing(self) -> None:
+        completed = self._run_post_install(install_glt_exit_code=None)
+        self.assertEqual(completed.returncode, 1, completed.stdout)

--- a/tests/unit/src/common/graph_builder/pyg_graph_builder_test.py
+++ b/tests/unit/src/common/graph_builder/pyg_graph_builder_test.py
@@ -62,7 +62,7 @@ class PygGraphBuilderTest(TestCase):
                 ),
             }
         )
-        self.assertEquals(graph_data_from_builder, expected_graph_data)
+        self.assertEqual(graph_data_from_builder, expected_graph_data)
 
     def test_can_create_with_with_no_edge_and_node_features(self):
         pyg_graph_builder = PygGraphBuilder()
@@ -116,7 +116,7 @@ class PygGraphBuilderTest(TestCase):
         # This is a restriction of PyG, that is it expectes node features of atleast size 1
         expected_graph_data["1"].x = torch.ones(2, 1)
         expected_graph_data["2"].x = torch.ones(1, 1)
-        self.assertEquals(graph_data_from_builder, expected_graph_data)
+        self.assertEqual(graph_data_from_builder, expected_graph_data)
 
     def test_can_create_with_preexisting_data_objects_filtering_existing_nodes_and_edges(
         self,
@@ -158,7 +158,7 @@ class PygGraphBuilderTest(TestCase):
             }
         )
 
-        self.assertEquals(graph_data_from_builder, graph_data_1)
+        self.assertEqual(graph_data_from_builder, graph_data_1)
 
         # Ensure works when there are no edge features either
         graph_data_1["1", "1", "1"].edge_attr = None
@@ -168,7 +168,7 @@ class PygGraphBuilderTest(TestCase):
         pyg_graph_builder.add_graph_data(graph_data_1)
         pyg_graph_builder.add_graph_data(graph_data_2)
         graph_data_without_edges_from_builder = pyg_graph_builder.build()
-        self.assertEquals(graph_data_without_edges_from_builder, graph_data_1)
+        self.assertEqual(graph_data_without_edges_from_builder, graph_data_1)
 
     def test_add_subgraph_mapped_graph_data(self):
         pyg_graph_builder = PygGraphBuilder()
@@ -260,7 +260,7 @@ class PygGraphBuilderTest(TestCase):
 
         # Our expected graph does not have this since it is constructed outside the builder
         graph_data_from_builder.global_node_to_subgraph_node_mapping = FrozenDict({})
-        self.assertEquals(graph_data_from_builder, expected_graph_data)
+        self.assertEqual(graph_data_from_builder, expected_graph_data)
 
     def test_feature_enforcement_policies(self):
         pyg_graph_builder = PygGraphBuilder()

--- a/tests/unit/src/common/graph_builder/pyg_graph_data_test.py
+++ b/tests/unit/src/common/graph_builder/pyg_graph_data_test.py
@@ -25,7 +25,7 @@ class PygGraphDataTest(TestCase):
         data2["1", "1", "1"].edge_index = torch.LongTensor([[0], [1]])
         data2["1", "1", "2"].edge_index = torch.LongTensor([[0, 1], [0, 0]])
 
-        self.assertEquals(data, data2)
+        self.assertEqual(data, data2)
 
         data = PygGraphData()
         data["1"].x = torch.tensor([[1, 1], [2, 2]])
@@ -39,7 +39,7 @@ class PygGraphDataTest(TestCase):
         data2["1"].x = torch.tensor([[1, 1], [2, 2]])
         data2["2"].x = torch.tensor([[3, 3]])
 
-        self.assertNotEquals(data, data2)
+        self.assertNotEqual(data, data2)
 
         data = PygGraphData()
         data["1"].x = torch.tensor([[1, 1], [2, 2]])
@@ -49,7 +49,7 @@ class PygGraphDataTest(TestCase):
         data2["1"].x = torch.tensor([[1, 1], [2, 2]])
         data2["2"].x = torch.tensor([[3, 3]])
 
-        self.assertEquals(data, data2)
+        self.assertEqual(data, data2)
 
         data = PygGraphData()
         data["1"].x = torch.tensor([[1, 1], [2, 2]])
@@ -59,4 +59,4 @@ class PygGraphDataTest(TestCase):
         data2["1"].x = torch.tensor([[1, 2], [2, 2]])
         data2["2"].x = torch.tensor([[3, 3]])
 
-        self.assertNotEquals(data, data2)
+        self.assertNotEqual(data, data2)

--- a/tests/unit/src/training/lib/data_loaders/tf_records_iterable_dataset_test.py
+++ b/tests/unit/src/training/lib/data_loaders/tf_records_iterable_dataset_test.py
@@ -87,6 +87,6 @@ class TfRecordsIterableDatasetTest(TestCase):
         loopy_dataset_entries = [
             next(loopy_dataset_iter) for _ in range(num_records + 5)
         ]
-        self.assertEquals(
+        self.assertEqual(
             loopy_dataset_entries[0], loopy_dataset_entries[0 + num_records]
         )


### PR DESCRIPTION
…ilures fatal

Python 3.12 removed `distutils` and the deprecated `unittest` aliases, and GiGL uses both. The `distutils` imports work today only because `setuptools` is installed transitively and ships a compatibility shim; a library must not depend on that.

- Add `gigl.common.utils.parse.str_to_bool` and use it in place of `distutils.util.strtobool` at all 15 call sites. Accepted and rejected spellings match `strtobool`. Every call site already coerced the result with `bool()` or used it as a condition, so the `int` to `bool` return change is not observable.
- Rename the 26 `assertEquals` / `assertNotEquals` uses to `assertEqual` / `assertNotEqual`, and select ruff `UP005` so they cannot return.
- Make a failed `install_glt.sh` fatal. `main()` returned the child's status but the `__main__` block discarded it, so `requirements/install_py_deps.sh` saw exit 0 under `set -e` and every base image build continued after a failed GLT install. Measured against a stub that exits 7: the old script exits 0, the new one exits 7. A successful install still exits 0.
- Run `ty` twice in `make type_check`, at the 3.11 floor and at 3.13. `ty` resolves the standard library against one version per invocation, so the floor pass accepts modules 3.13 removed and only the ceiling pass rejects them.

**Scope of work done**

<!-- Description of PR goes here -->

<!-- Relevant screenshots go here (optional) -->

Where is the documentation for this feature?: N/A

Did you add automated tests or write a test plan?

***Updated Changelog.md?*** NO

***Ready for code review?:*** NO
